### PR TITLE
Controller for Reverse Registrar

### DIFF
--- a/contracts/registry/ReverseRegistrar.sol
+++ b/contracts/registry/ReverseRegistrar.sol
@@ -83,9 +83,10 @@ contract ReverseRegistrar is Ownable, Controllable {
      * resolver if necessary.
      * Only callable by controllers
      * @param name The name to set for this address.
+     * @param name The name to set for this address.
      * @return The ENS node hash of the reverse record.
      */
-    function setNameWithController(address addr, string memory name)
+    function setNameForAddr(address addr, string memory name)
         public
         onlyController
         returns (bytes32)
@@ -152,10 +153,11 @@ contract ReverseRegistrar is Ownable, Controllable {
         bytes32 label = sha3HexAddress(addr);
         bytes32 node = keccak256(abi.encodePacked(ADDR_REVERSE_NODE, label));
         address currentResolver = ens.resolver(node);
-        address newResolver = (resolver != address(0x0) &&
-            resolver != currentResolver)
-            ? resolver
-            : currentResolver;
+        address newResolver = currentResolver;
+
+        if (resolver != address(0x0) && resolver != currentResolver) {
+            newResolver = resolver;
+        }
 
         ens.setSubnodeRecord(ADDR_REVERSE_NODE, label, owner, newResolver, 0);
 

--- a/contracts/registry/ReverseRegistrar.sol
+++ b/contracts/registry/ReverseRegistrar.sol
@@ -42,7 +42,8 @@ contract ReverseRegistrar is Ownable, Controllable {
         require(
             addr == msg.sender ||
                 controllers[msg.sender] ||
-                ens.isApprovedForAll(addr, msg.sender),
+                ens.isApprovedForAll(addr, msg.sender) ||
+                ownsContract(addr),
             "Caller is not a controller or authorised by address or the address itself"
         );
         _;
@@ -181,13 +182,8 @@ contract ReverseRegistrar is Ownable, Controllable {
         }
     }
 
-    /**
-     * @dev Transfers ownership of the reverse ENS record associated with the
-     *      calling account.
-     * @param owner The address to set as the owner of the reverse record in ENS.
-     * @param resolver The address of the resolver to set; 0 to leave unchanged.
-     * @return The ENS node hash of the reverse record.
-     */
+    /* Internal functions */
+
     function _claimWithResolver(
         address addr,
         address owner,
@@ -205,5 +201,13 @@ contract ReverseRegistrar is Ownable, Controllable {
         emit ReverseClaimed(addr, node);
 
         return node;
+    }
+
+    function ownsContract(address addr) internal view returns (bool) {
+        try Ownable(addr).owner() returns (address owner) {
+            return owner == msg.sender;
+        } catch {
+            return false;
+        }
     }
 }

--- a/contracts/registry/ReverseRegistrar.sol
+++ b/contracts/registry/ReverseRegistrar.sol
@@ -82,18 +82,19 @@ contract ReverseRegistrar is Ownable, Controllable {
      * @param name The name to set for this address.
      * @return The ENS node hash of the reverse record.
      */
-    // function setName(string memory name)
-    //     public
-    //     onlyController
-    //     returns (bytes32)
-    // {
-    //     bytes32 node = claimWithResolver(
-    //         address(this),
-    //         address(defaultResolver)
-    //     );
-    //     defaultResolver.setName(node, name);
-    //     return node;
-    // }
+    function setNameWithController(address addr, string memory name)
+        public
+        onlyController
+        returns (bytes32)
+    {
+        bytes32 node = _claimWithResolver(
+            addr,
+            address(this),
+            address(defaultResolver)
+        );
+        defaultResolver.setName(node, name);
+        return node;
+    }
 
     /**
      * @dev Returns the node hash for a given account's reverse records.

--- a/contracts/registry/ReverseRegistrar.sol
+++ b/contracts/registry/ReverseRegistrar.sol
@@ -41,7 +41,7 @@ contract ReverseRegistrar is Ownable, Controllable {
             controllers[msg.sender] ||
                 addr == msg.sender ||
                 ens.isApprovedForAll(addr, msg.sender),
-            "Caller is not a controller or is authori"
+            "Caller is not a controller or authorised by address or the address itself"
         );
         _;
     }

--- a/contracts/registry/ReverseRegistrar.sol
+++ b/contracts/registry/ReverseRegistrar.sol
@@ -118,8 +118,6 @@ contract ReverseRegistrar is Ownable, Controllable {
      *         input address.
      */
     function sha3HexAddress(address addr) private pure returns (bytes32 ret) {
-        addr;
-        ret; // Stop warning us about unused variables
         assembly {
             for {
                 let i := 40

--- a/contracts/registry/ReverseRegistrar.sol
+++ b/contracts/registry/ReverseRegistrar.sol
@@ -8,6 +8,8 @@ abstract contract NameResolver {
     function setName(bytes32 node, string memory name) public virtual;
 }
 
+bytes32 constant lookup = 0x3031323334353637383961626364656600000000000000000000000000000000;
+
 contract ReverseRegistrar is Ownable, Controllable {
     // namehash('addr.reverse')
     bytes32 public constant ADDR_REVERSE_NODE =
@@ -119,10 +121,6 @@ contract ReverseRegistrar is Ownable, Controllable {
         addr;
         ret; // Stop warning us about unused variables
         assembly {
-            let
-                lookup
-            := 0x3031323334353637383961626364656600000000000000000000000000000000
-
             for {
                 let i := 40
             } gt(i, 0) {

--- a/contracts/registry/ReverseRegistrar.sol
+++ b/contracts/registry/ReverseRegistrar.sol
@@ -1,14 +1,17 @@
 pragma solidity >=0.8.4;
 
 import "./ENS.sol";
+import "../root/Ownable.sol";
+import "../root/Controllable.sol";
 
 abstract contract NameResolver {
     function setName(bytes32 node, string memory name) public virtual;
 }
 
-contract ReverseRegistrar {
+contract ReverseRegistrar is Ownable, Controllable {
     // namehash('addr.reverse')
-    bytes32 public constant ADDR_REVERSE_NODE = 0x91d1777781884d03a6757a803996e38de2a42967fb37eeaca72729271025a9e2;
+    bytes32 public constant ADDR_REVERSE_NODE =
+        0x91d1777781884d03a6757a803996e38de2a42967fb37eeaca72729271025a9e2;
 
     ENS public ens;
     NameResolver public defaultResolver;
@@ -23,7 +26,9 @@ contract ReverseRegistrar {
         defaultResolver = resolverAddr;
 
         // Assign ownership of the reverse record to our deployer
-        ReverseRegistrar oldRegistrar = ReverseRegistrar(ens.owner(ADDR_REVERSE_NODE));
+        ReverseRegistrar oldRegistrar = ReverseRegistrar(
+            ens.owner(ADDR_REVERSE_NODE)
+        );
         if (address(oldRegistrar) != address(0x0)) {
             oldRegistrar.claim(msg.sender);
         }
@@ -46,8 +51,107 @@ contract ReverseRegistrar {
      * @param resolver The address of the resolver to set; 0 to leave unchanged.
      * @return The ENS node hash of the reverse record.
      */
-    function claimWithResolver(address owner, address resolver) public returns (bytes32) {
-        bytes32 label = sha3HexAddress(msg.sender);
+    function claimWithResolver(address owner, address resolver)
+        public
+        returns (bytes32)
+    {
+        return _claimWithResolver(msg.sender, owner, resolver);
+    }
+
+    /**
+     * @dev Sets the `name()` record for the reverse ENS record associated with
+     * the calling account. First updates the resolver to the default reverse
+     * resolver if necessary.
+     * @param name The name to set for this address.
+     * @return The ENS node hash of the reverse record.
+     */
+    function setName(string memory name) public returns (bytes32) {
+        bytes32 node = claimWithResolver(
+            address(this),
+            address(defaultResolver)
+        );
+        defaultResolver.setName(node, name);
+        return node;
+    }
+
+    /**
+     * @dev Sets the `name()` record for the reverse ENS record associated with
+     * the account provided. First updates the resolver to the default reverse
+     * resolver if necessary.
+     * Only callable by controllers
+     * @param name The name to set for this address.
+     * @return The ENS node hash of the reverse record.
+     */
+    // function setName(string memory name)
+    //     public
+    //     onlyController
+    //     returns (bytes32)
+    // {
+    //     bytes32 node = claimWithResolver(
+    //         address(this),
+    //         address(defaultResolver)
+    //     );
+    //     defaultResolver.setName(node, name);
+    //     return node;
+    // }
+
+    /**
+     * @dev Returns the node hash for a given account's reverse records.
+     * @param addr The address to hash
+     * @return The ENS node hash.
+     */
+    function node(address addr) public pure returns (bytes32) {
+        return
+            keccak256(
+                abi.encodePacked(ADDR_REVERSE_NODE, sha3HexAddress(addr))
+            );
+    }
+
+    /**
+     * @dev An optimised function to compute the sha3 of the lower-case
+     *      hexadecimal representation of an Ethereum address.
+     * @param addr The address to hash
+     * @return ret The SHA3 hash of the lower-case hexadecimal encoding of the
+     *         input address.
+     */
+    function sha3HexAddress(address addr) private pure returns (bytes32 ret) {
+        addr;
+        ret; // Stop warning us about unused variables
+        assembly {
+            let
+                lookup
+            := 0x3031323334353637383961626364656600000000000000000000000000000000
+
+            for {
+                let i := 40
+            } gt(i, 0) {
+
+            } {
+                i := sub(i, 1)
+                mstore8(i, byte(and(addr, 0xf), lookup))
+                addr := div(addr, 0x10)
+                i := sub(i, 1)
+                mstore8(i, byte(and(addr, 0xf), lookup))
+                addr := div(addr, 0x10)
+            }
+
+            ret := keccak256(0, 40)
+        }
+    }
+
+    /**
+     * @dev Transfers ownership of the reverse ENS record associated with the
+     *      calling account.
+     * @param owner The address to set as the owner of the reverse record in ENS.
+     * @param resolver The address of the resolver to set; 0 to leave unchanged.
+     * @return The ENS node hash of the reverse record.
+     */
+    function _claimWithResolver(
+        address addr,
+        address owner,
+        address resolver
+    ) internal returns (bytes32) {
+        bytes32 label = sha3HexAddress(addr);
         bytes32 node = keccak256(abi.encodePacked(ADDR_REVERSE_NODE, label));
         address currentOwner = ens.owner(node);
 
@@ -67,53 +171,5 @@ contract ReverseRegistrar {
         }
 
         return node;
-    }
-
-    /**
-     * @dev Sets the `name()` record for the reverse ENS record associated with
-     * the calling account. First updates the resolver to the default reverse
-     * resolver if necessary.
-     * @param name The name to set for this address.
-     * @return The ENS node hash of the reverse record.
-     */
-    function setName(string memory name) public returns (bytes32) {
-        bytes32 node = claimWithResolver(address(this), address(defaultResolver));
-        defaultResolver.setName(node, name);
-        return node;
-    }
-
-    /**
-     * @dev Returns the node hash for a given account's reverse records.
-     * @param addr The address to hash
-     * @return The ENS node hash.
-     */
-    function node(address addr) public pure returns (bytes32) {
-        return keccak256(abi.encodePacked(ADDR_REVERSE_NODE, sha3HexAddress(addr)));
-    }
-
-    /**
-     * @dev An optimised function to compute the sha3 of the lower-case
-     *      hexadecimal representation of an Ethereum address.
-     * @param addr The address to hash
-     * @return ret The SHA3 hash of the lower-case hexadecimal encoding of the
-     *         input address.
-     */
-    function sha3HexAddress(address addr) private pure returns (bytes32 ret) {
-        addr;
-        ret; // Stop warning us about unused variables
-        assembly {
-            let lookup := 0x3031323334353637383961626364656600000000000000000000000000000000
-
-            for { let i := 40 } gt(i, 0) { } {
-                i := sub(i, 1)
-                mstore8(i, byte(and(addr, 0xf), lookup))
-                addr := div(addr, 0x10)
-                i := sub(i, 1)
-                mstore8(i, byte(and(addr, 0xf), lookup))
-                addr := div(addr, 0x10)
-            }
-
-            ret := keccak256(0, 40)
-        }
     }
 }

--- a/contracts/registry/ReverseRegistrar.sol
+++ b/contracts/registry/ReverseRegistrar.sol
@@ -125,22 +125,24 @@ contract ReverseRegistrar is Ownable, Controllable {
      * @dev Sets the `name()` record for the reverse ENS record associated with
      * the account provided. First updates the resolver to the default reverse
      * resolver if necessary.
-     * Only callable by controllers
+     * Only callable by controllers and authorised users
      * @param addr The reverse record to set
+     * @param owner The owner of the reverse node
      * @param name The name to set for this address.
      * @return The ENS node hash of the reverse record.
      */
-    function setNameForAddr(address addr, string memory name)
-        public
-        authorised(addr)
-        returns (bytes32)
-    {
+    function setNameForAddr(
+        address addr,
+        address owner,
+        string memory name
+    ) public authorised(addr) returns (bytes32) {
         bytes32 node = _claimWithResolver(
             addr,
             address(this),
             address(defaultResolver)
         );
         defaultResolver.setName(node, name);
+        ens.setSubnodeOwner(ADDR_REVERSE_NODE, sha3HexAddress(addr), owner);
         return node;
     }
 

--- a/contracts/registry/ReverseRegistrar.sol
+++ b/contracts/registry/ReverseRegistrar.sol
@@ -18,6 +18,8 @@ contract ReverseRegistrar is Ownable, Controllable {
     ENS public ens;
     NameResolver public defaultResolver;
 
+    event ReverseClaimed(address indexed addr, bytes32 indexed node);
+
     /**
      * @dev Constructor
      * @param ensAddr The address of the ENS registry.
@@ -38,8 +40,8 @@ contract ReverseRegistrar is Ownable, Controllable {
 
     modifier authorised(address addr) {
         require(
-            controllers[msg.sender] ||
-                addr == msg.sender ||
+            addr == msg.sender ||
+                controllers[msg.sender] ||
                 ens.isApprovedForAll(addr, msg.sender),
             "Caller is not a controller or authorised by address or the address itself"
         );
@@ -199,6 +201,8 @@ contract ReverseRegistrar is Ownable, Controllable {
         address newResolver = shouldUpdateResolver ? resolver : currentResolver;
 
         ens.setSubnodeRecord(ADDR_REVERSE_NODE, label, owner, newResolver, 0);
+
+        emit ReverseClaimed(addr, node);
 
         return node;
     }

--- a/contracts/registry/ReverseRegistrar.sol
+++ b/contracts/registry/ReverseRegistrar.sol
@@ -10,10 +10,10 @@ abstract contract NameResolver {
 
 bytes32 constant lookup = 0x3031323334353637383961626364656600000000000000000000000000000000;
 
+bytes32 constant ADDR_REVERSE_NODE = 0x91d1777781884d03a6757a803996e38de2a42967fb37eeaca72729271025a9e2;
+
 contract ReverseRegistrar is Ownable, Controllable {
     // namehash('addr.reverse')
-    bytes32 public constant ADDR_REVERSE_NODE =
-        0x91d1777781884d03a6757a803996e38de2a42967fb37eeaca72729271025a9e2;
 
     ENS public ens;
     NameResolver public defaultResolver;

--- a/contracts/registry/ReverseRegistrar.sol
+++ b/contracts/registry/ReverseRegistrar.sol
@@ -1,7 +1,7 @@
 pragma solidity >=0.8.4;
 
 import "./ENS.sol";
-import "../root/Ownable.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
 import "../root/Controllable.sol";
 
 abstract contract NameResolver {

--- a/contracts/registry/ReverseRegistrar.sol
+++ b/contracts/registry/ReverseRegistrar.sol
@@ -38,7 +38,9 @@ contract ReverseRegistrar is Ownable, Controllable {
 
     modifier authorised(address addr) {
         require(
-            controllers[msg.sender] || addr == msg.sender,
+            controllers[msg.sender] ||
+                addr == msg.sender ||
+                ens.isApprovedForAll(addr, msg.sender),
             "Caller is not a controller or is authori"
         );
         _;

--- a/contracts/root/Controllable.sol
+++ b/contracts/root/Controllable.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.8.4;
 
-import "./Ownable.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
 
 contract Controllable is Ownable {
     mapping(address => bool) public controllers;
@@ -8,7 +8,10 @@ contract Controllable is Ownable {
     event ControllerChanged(address indexed controller, bool enabled);
 
     modifier onlyController {
-        require(controllers[msg.sender], "Controllable: Caller is not a controller");
+        require(
+            controllers[msg.sender],
+            "Controllable: Caller is not a controller"
+        );
         _;
     }
 

--- a/contracts/root/Controllable.sol
+++ b/contracts/root/Controllable.sol
@@ -8,7 +8,7 @@ contract Controllable is Ownable {
     event ControllerChanged(address indexed controller, bool enabled);
 
     modifier onlyController {
-        require(controllers[msg.sender]);
+        require(controllers[msg.sender], "Controllable: Caller is not a controller");
         _;
     }
 

--- a/contracts/root/Controllable.sol
+++ b/contracts/root/Controllable.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.4;
 import "./Ownable.sol";
 
 contract Controllable is Ownable {
-    mapping(address=>bool) public controllers;
+    mapping(address => bool) public controllers;
 
     event ControllerChanged(address indexed controller, bool enabled);
 

--- a/contracts/root/Root.sol
+++ b/contracts/root/Root.sol
@@ -1,24 +1,28 @@
 pragma solidity ^0.8.4;
 
 import "../registry/ENS.sol";
-import "./Ownable.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
 import "./Controllable.sol";
 
 contract Root is Ownable, Controllable {
-    bytes32 constant private ROOT_NODE = bytes32(0);
+    bytes32 private constant ROOT_NODE = bytes32(0);
 
-    bytes4 constant private INTERFACE_META_ID = bytes4(keccak256("supportsInterface(bytes4)"));
+    bytes4 private constant INTERFACE_META_ID =
+        bytes4(keccak256("supportsInterface(bytes4)"));
 
     event TLDLocked(bytes32 indexed label);
 
     ENS public ens;
-    mapping(bytes32=>bool) public locked;
+    mapping(bytes32 => bool) public locked;
 
     constructor(ENS _ens) public {
         ens = _ens;
     }
 
-    function setSubnodeOwner(bytes32 label, address owner) external onlyController {
+    function setSubnodeOwner(bytes32 label, address owner)
+        external
+        onlyController
+    {
         require(!locked[label]);
         ens.setSubnodeOwner(ROOT_NODE, label, owner);
     }
@@ -32,7 +36,11 @@ contract Root is Ownable, Controllable {
         locked[label] = true;
     }
 
-    function supportsInterface(bytes4 interfaceID) external pure returns (bool) {
+    function supportsInterface(bytes4 interfaceID)
+        external
+        pure
+        returns (bool)
+    {
         return interfaceID == INTERFACE_META_ID;
     }
 }

--- a/test/registry/TestReverseRegistrar.js
+++ b/test/registry/TestReverseRegistrar.js
@@ -24,7 +24,6 @@ describe.only('ReverseRegistrar Tests', () => {
       nameWrapper = await NameWrapper.new()
       resolver = await PublicResolver.new(ens.address, nameWrapper.address)
       registrar = await ReverseRegistrar.new(ens.address, resolver.address)
-      await registrar.setController(accounts[0], true)
 
       await ens.setSubnodeOwner('0x0', sha3('reverse'), accounts[0], {
         from: accounts[0],
@@ -71,6 +70,7 @@ describe.only('ReverseRegistrar Tests', () => {
     })
 
     it('allows controller to set name records for other accounts', async () => {
+      await registrar.setController(accounts[0], true)
       await registrar.setNameForAddr(accounts[1], 'testname', {
         from: accounts[0],
         gas: 1000000,
@@ -79,13 +79,22 @@ describe.only('ReverseRegistrar Tests', () => {
       assert.equal(await resolver.name(node2), 'testname')
     })
 
-    it('forbids non-controller from calling setNameWithController', async () => {
+    it('forbids non-controller from calling setNameWithController if addresss is different', async () => {
       await exceptions.expectFailure(
         registrar.setNameForAddr(accounts[1], 'testname', {
-          from: accounts[1],
+          from: accounts[0],
           gas: 1000000,
         })
       )
+    })
+
+    it('allows name to be set for an address if the sender is the address even if not controller', async () => {
+      await registrar.setNameForAddr(accounts[0], 'testname', {
+        from: accounts[0],
+        gas: 1000000,
+      })
+      assert.equal(await ens.resolver(node), resolver.address)
+      assert.equal(await resolver.name(node), 'testname')
     })
 
     // @todo this test does not work.

--- a/test/registry/TestReverseRegistrar.js
+++ b/test/registry/TestReverseRegistrar.js
@@ -71,7 +71,7 @@ describe.only('ReverseRegistrar Tests', () => {
     })
 
     it('allows controller to set name records for other accounts', async () => {
-      await registrar.setNameWithController(accounts[1], 'testname', {
+      await registrar.setNameForAddr(accounts[1], 'testname', {
         from: accounts[0],
         gas: 1000000,
       })
@@ -81,7 +81,7 @@ describe.only('ReverseRegistrar Tests', () => {
 
     it('forbids non-controller from calling setNameWithController', async () => {
       await exceptions.expectFailure(
-        registrar.setNameWithController(accounts[1], 'testname', {
+        registrar.setNameForAddr(accounts[1], 'testname', {
           from: accounts[1],
           gas: 1000000,
         })

--- a/test/registry/TestReverseRegistrar.js
+++ b/test/registry/TestReverseRegistrar.js
@@ -1,28 +1,30 @@
 const namehash = require('eth-ens-namehash')
 const sha3 = require('web3-utils').sha3
-const PublicResolver = artifacts.require('./resolvers/PublicResolver.sol');
-const ReverseRegistrar = artifacts.require('./registry/ReverseRegistrar.sol');
-const ENS = artifacts.require('./registry/ENSRegistry.sol');
-const NameWrapper = artifacts.require('DummyNameWrapper.sol');
-const { exceptions } = require("../test-utils")
+const PublicResolver = artifacts.require('./resolvers/PublicResolver.sol')
+const ReverseRegistrar = artifacts.require('./registry/ReverseRegistrar.sol')
+const ENS = artifacts.require('./registry/ENSRegistry.sol')
+const NameWrapper = artifacts.require('DummyNameWrapper.sol')
+const { exceptions } = require('../test-utils')
 
-describe('ReverseRegistrar Tests', () => {
+describe.only('ReverseRegistrar Tests', () => {
+  contract('ReverseRegistar', function(accounts) {
+    let node, node2, node3
 
-contract('ReverseRegistar', function (accounts) {
-
-    let node, node2, node3;
-    
-    let registrar, resolver, ens, nameWrapper;
+    let registrar, resolver, ens, nameWrapper
 
     beforeEach(async () => {
-        node = namehash.hash(accounts[0].slice(2).toLowerCase() + ".addr.reverse");
-        node2 = namehash.hash(accounts[1].slice(2).toLowerCase() + '.addr.reverse');
-        node3 = namehash.hash(accounts[2].slice(2).toLowerCase() + '.addr.reverse');
-        ens = await ENS.new();
-        nameWrapper = await NameWrapper.new();
-        resolver = await PublicResolver.new(ens.address, nameWrapper.address);
-        registrar = await ReverseRegistrar.new(ens.address, resolver.address);
-        await registrar.setController(accounts[0], true)
+      node = namehash.hash(accounts[0].slice(2).toLowerCase() + '.addr.reverse')
+      node2 = namehash.hash(
+        accounts[1].slice(2).toLowerCase() + '.addr.reverse'
+      )
+      node3 = namehash.hash(
+        accounts[2].slice(2).toLowerCase() + '.addr.reverse'
+      )
+      ens = await ENS.new()
+      nameWrapper = await NameWrapper.new()
+      resolver = await PublicResolver.new(ens.address, nameWrapper.address)
+      registrar = await ReverseRegistrar.new(ens.address, resolver.address)
+      await registrar.setController(accounts[0], true)
 
       await ens.setSubnodeOwner('0x0', sha3('reverse'), accounts[0], {
         from: accounts[0],
@@ -69,13 +71,21 @@ contract('ReverseRegistar', function (accounts) {
     })
 
     it('allows controller to set name records for other accounts', async () => {
-      await registrar.setNameWithController(accounts[1], 'testname', { from: accounts[0], gas: 1000000 })
+      await registrar.setNameWithController(accounts[1], 'testname', {
+        from: accounts[0],
+        gas: 1000000,
+      })
       assert.equal(await ens.resolver(node2), resolver.address)
       assert.equal(await resolver.name(node2), 'testname')
     })
 
     it('forbids non-controller from calling setNameWithController', async () => {
-      await exceptions.expectFailure(registrar.setNameWithController(accounts[1], 'testname', { from: accounts[1], gas: 1000000 }));
+      await exceptions.expectFailure(
+        registrar.setNameWithController(accounts[1], 'testname', {
+          from: accounts[1],
+          gas: 1000000,
+        })
+      )
     })
 
     // @todo this test does not work.
@@ -98,5 +108,4 @@ contract('ReverseRegistar', function (accounts) {
     //        assert.fail('updating name did not fail');
     //    });
   })
-
 })

--- a/test/registry/TestReverseRegistrar.js
+++ b/test/registry/TestReverseRegistrar.js
@@ -1,54 +1,65 @@
+const PublicResolver = artifacts.require('./resolvers/PublicResolver.sol')
+const ReverseRegistrar = artifacts.require('./registry/ReverseRegistrar.sol')
+const ENS = artifacts.require('./registry/ENSRegistry.sol')
 
-const PublicResolver = artifacts.require('./resolvers/PublicResolver.sol');
-const ReverseRegistrar = artifacts.require('./registry/ReverseRegistrar.sol');
-const ENS = artifacts.require('./registry/ENSRegistry.sol');
+const namehash = require('eth-ens-namehash')
+const sha3 = require('web3-utils').sha3
 
-const namehash = require('eth-ens-namehash');
-const sha3 = require('web3-utils').sha3;
+describe.only('ReverseRegistrar Tests', () => {
 
-contract('ReverseRegistar', function (accounts) {
-
-    let node;
-    let registrar, resolver, ens;
+  contract('ReverseRegistar', function(accounts) {
+    let node
+    let registrar, resolver, ens
 
     beforeEach(async () => {
-        node = namehash.hash(accounts[0].slice(2).toLowerCase() + ".addr.reverse");
-        ens = await ENS.new();
-        resolver = await PublicResolver.new(ens.address);
-        registrar = await ReverseRegistrar.new(ens.address, resolver.address);
+      node = namehash.hash(accounts[0].slice(2).toLowerCase() + '.addr.reverse')
+      ens = await ENS.new()
+      resolver = await PublicResolver.new(ens.address)
+      registrar = await ReverseRegistrar.new(ens.address, resolver.address)
 
-        await ens.setSubnodeOwner('0x0', sha3('reverse'), accounts[0], {from: accounts[0]});
-        await ens.setSubnodeOwner(namehash.hash('reverse'), sha3('addr'), registrar.address, {from: accounts[0]});
-    });
+      await ens.setSubnodeOwner('0x0', sha3('reverse'), accounts[0], {
+        from: accounts[0],
+      })
+      await ens.setSubnodeOwner(
+        namehash.hash('reverse'),
+        sha3('addr'),
+        registrar.address,
+        { from: accounts[0] }
+      )
+    })
 
     it('should calculate node hash correctly', async () => {
-        assert.equal(await registrar.node.call(accounts[0]), node);
-    });
+      assert.equal(await registrar.node.call(accounts[0]), node)
+    })
 
     it('allows an account to claim its address', async () => {
-        await registrar.claim(accounts[1], {from: accounts[0]});
-        assert.equal(await ens.owner(node), accounts[1]);
-    });
+      await registrar.claim(accounts[1], { from: accounts[0] })
+      assert.equal(await ens.owner(node), accounts[1])
+    })
 
-    it('allows an account to specify resolver', async () =>  {
-        await registrar.claimWithResolver(accounts[1], accounts[2], {from: accounts[0]});
-        assert.equal(await ens.owner(node), accounts[1]);
-        assert.equal(await ens.resolver(node), accounts[2]);
-    });
+    it('allows an account to specify resolver', async () => {
+      await registrar.claimWithResolver(accounts[1], accounts[2], {
+        from: accounts[0],
+      })
+      assert.equal(await ens.owner(node), accounts[1])
+      assert.equal(await ens.resolver(node), accounts[2])
+    })
 
     it('does not overwrite resolver if not specified', async () => {
-        await registrar.claimWithResolver(accounts[1], accounts[2], {from: accounts[0]});
-        await registrar.claim(accounts[3], {from: accounts[0]});
+      await registrar.claimWithResolver(accounts[1], accounts[2], {
+        from: accounts[0],
+      })
+      await registrar.claim(accounts[3], { from: accounts[0] })
 
-        assert.equal(await ens.owner(node), accounts[3]);
-        assert.equal(await ens.resolver(node), accounts[2]);
-    });
+      assert.equal(await ens.owner(node), accounts[3])
+      assert.equal(await ens.resolver(node), accounts[2])
+    })
 
     it('sets name records', async () => {
-        await registrar.setName('testname', {from: accounts[0], gas: 1000000});
-        assert.equal(await ens.resolver(node), resolver.address);
-        assert.equal(await resolver.name(node), 'testname');
-    });
+      await registrar.setName('testname', { from: accounts[0], gas: 1000000 })
+      assert.equal(await ens.resolver(node), resolver.address)
+      assert.equal(await resolver.name(node), 'testname')
+    })
 
     // @todo this test does not work.
     // it('allows the owner to update the name', async () => {
@@ -57,16 +68,18 @@ contract('ReverseRegistar', function (accounts) {
     //     assert.equal(await resolver.name(node), 'testname');
     // });
 
-// @todo does not work because we shifted to a dummy resolver
-//    it('does not allow non-owners to update the name', async () => {
-//        await registrar.claimWithResolver(accounts[1], resolver, {from: accounts[0]});
-//
-//        try {
-//            await resolver.setName(node, 'testname', {from: accounts[0]})
-//        } catch (error) {
-//            return utils.ensureException(error);
-//        }
-//
-//        assert.fail('updating name did not fail');
-//    });
-});
+    // @todo does not work because we shifted to a dummy resolver
+    //    it('does not allow non-owners to update the name', async () => {
+    //        await registrar.claimWithResolver(accounts[1], resolver, {from: accounts[0]});
+    //
+    //        try {
+    //            await resolver.setName(node, 'testname', {from: accounts[0]})
+    //        } catch (error) {
+    //            return utils.ensureException(error);
+    //        }
+    //
+    //        assert.fail('updating name did not fail');
+    //    });
+  })
+
+})


### PR DESCRIPTION
Adds Controller pattern to Reverse Registrar and adds a method to allow controllers to set any name to any reverse account node.

This PR will allow the permanent registrar controller (once added as a controller) to setName on behalf of a user
so then we can create a new register method on the permanent registrar controller that can call `setNameForAddr` and setup on the reverse record on behalf of a user. This will allow it to be all set in one tx on a new `register` function

30/6/21 addition:

Added functions as per @Arachnid's request to mirror the original functions so they can all be called with a custom address. Renamed them to `forAddr`.

`forAddr` functions can now be called by the address themselves, controller, or an authorised party on the ENS registry. The reason for adding approvals as it also allows flexibility for contracts to set reverse records on behalf of their users if they have already authorised their contract on the registry. It would also allow them to switch the reverse record if the user created a new subdomain with them in one tx.

Added new tests for all additional functions.