### PR TITLE
Make the eth registrar interface inherit from IERC721

### DIFF
--- a/contracts/ethregistrar/BaseRegistrar.sol
+++ b/contracts/ethregistrar/BaseRegistrar.sol
@@ -4,7 +4,7 @@ import "../registry/ENS.sol";
 import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 
-abstract contract BaseRegistrar is Ownable {
+abstract contract BaseRegistrar is Ownable, IERC721 {
     uint constant public GRACE_PERIOD = 90 days;
 
     event ControllerAdded(address indexed controller);

--- a/contracts/ethregistrar/BaseRegistrarImplementation.sol
+++ b/contracts/ethregistrar/BaseRegistrarImplementation.sol
@@ -57,7 +57,7 @@ contract BaseRegistrarImplementation is ERC721, BaseRegistrar  {
      * @param tokenId uint256 ID of the token to query the owner of
      * @return address currently marked as the owner of the given token ID
      */
-    function ownerOf(uint256 tokenId) public view override returns (address) {
+    function ownerOf(uint256 tokenId) public view override(IERC721, ERC721) returns (address) {
         require(expiries[tokenId] > block.timestamp);
         return super.ownerOf(tokenId);
     }
@@ -146,7 +146,7 @@ contract BaseRegistrarImplementation is ERC721, BaseRegistrar  {
         ens.setSubnodeOwner(baseNode, bytes32(id), owner);
     }
 
-    function supportsInterface(bytes4 interfaceID) public override view returns (bool) {
+    function supportsInterface(bytes4 interfaceID) public override(ERC721, IERC165) view returns (bool) {
         return interfaceID == INTERFACE_META_ID ||
                interfaceID == ERC721_ID ||
                interfaceID == RECLAIM_ID;


### PR DESCRIPTION
enhancement for cross sell smart contract allows lfor polygon to be used for swap transaction which allows cross universe with def/blockchain/ens this providing leverage and allows transaction without gas providing a link within the entire space growing the network cutting cost provide deflationary prospects to hedge the inflationary market through swap and blockfi cross sell dev........ i know because i invented the code that you all know that has allowed everyone to have a position no need to attack enhancement will only slow the process that eth and etherscan.io should be first and is 1st to tap in to the break through it is legit and more fun for devs than ever I joseph parente claims to be the author @geniusj204@yahoo.com @shibastax @Arachnid #shibastax [staxdigitalmarketing/autonomassolutions.facebook.com](url) @Shibainu_stax_official @Dogekilla