### PR TITLE
Fix rendering of resolver list in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,14 +136,14 @@ Resolver implements a general-purpose ENS resolver that is suitable for most sta
 
 PublicResolver includes the following profiles that implements different EIPs.
 
-─ ABIResolver = EIP 205 - ABI support (`ABI()`).
-─ AddrResolver = EIP 137 - Contract address interface. EIP 2304 - Multicoin support (`addr()`).
-─ ContentHashResolver = EIP 1577 - Content hash support (`contenthash()`).
-─ InterfaceResolver = EIP 165 - Interface Detection (`supportsInterface()`).
-─ NameResolver = EIP 181 - Reverse resolution (`name()`).
-─ PubkeyResolver = EIP 619 - SECP256k1 public keys (`pubkey()`).
-─ TextResolver = EIP 634 - Text records (`text()`).
-─ DNSResolver = Experimental support is available for hosting DNS domains on the Ethereum blockchain via ENS. [The more detail](https://veox-ens.readthedocs.io/en/latest/dns.html) is on the old ENS doc.
+- ABIResolver = EIP 205 - ABI support (`ABI()`).
+- AddrResolver = EIP 137 - Contract address interface. EIP 2304 - Multicoin support (`addr()`).
+- ContentHashResolver = EIP 1577 - Content hash support (`contenthash()`).
+- InterfaceResolver = EIP 165 - Interface Detection (`supportsInterface()`).
+- NameResolver = EIP 181 - Reverse resolution (`name()`).
+- PubkeyResolver = EIP 619 - SECP256k1 public keys (`pubkey()`).
+- TextResolver = EIP 634 - Text records (`text()`).
+- DNSResolver = Experimental support is available for hosting DNS domains on the Ethereum blockchain via ENS. [The more detail](https://veox-ens.readthedocs.io/en/latest/dns.html) is on the old ENS doc.
 
 ## Developer guide
 


### PR DESCRIPTION
Markdown renderer doesn't consider em-dash as a list.