### PR TITLE
Adding virtual to methods in Resolver profiles

### DIFF
--- a/contracts/resolvers/profiles/ABIResolver.sol
+++ b/contracts/resolvers/profiles/ABIResolver.sol
@@ -16,7 +16,7 @@ abstract contract ABIResolver is ResolverBase {
      * @param contentType The content type of the ABI
      * @param data The ABI data.
      */
-    function setABI(bytes32 node, uint256 contentType, bytes calldata data) external authorised(node) {
+    function setABI(bytes32 node, uint256 contentType, bytes calldata data) virtual external authorised(node) {
         // Content types must be powers of 2
         require(((contentType - 1) & contentType) == 0);
 
@@ -32,7 +32,7 @@ abstract contract ABIResolver is ResolverBase {
      * @return contentType The content type of the return value
      * @return data The ABI data
      */
-    function ABI(bytes32 node, uint256 contentTypes) external view returns (uint256, bytes memory) {
+    function ABI(bytes32 node, uint256 contentTypes) virtual external view returns (uint256, bytes memory) {
         mapping(uint256=>bytes) storage abiset = abis[node];
 
         for (uint256 contentType = 1; contentType <= contentTypes; contentType <<= 1) {

--- a/contracts/resolvers/profiles/AddrResolver.sol
+++ b/contracts/resolvers/profiles/AddrResolver.sol
@@ -17,7 +17,7 @@ abstract contract AddrResolver is ResolverBase {
      * @param node The node to update.
      * @param a The address to set.
      */
-    function setAddr(bytes32 node, address a) external authorised(node) {
+    function setAddr(bytes32 node, address a) virtual external authorised(node) {
         setAddr(node, COIN_TYPE_ETH, addressToBytes(a));
     }
 
@@ -26,7 +26,7 @@ abstract contract AddrResolver is ResolverBase {
      * @param node The ENS node to query.
      * @return The associated address.
      */
-    function addr(bytes32 node) public view returns (address payable) {
+    function addr(bytes32 node) virtual public view returns (address payable) {
         bytes memory a = addr(node, COIN_TYPE_ETH);
         if(a.length == 0) {
             return payable(0);
@@ -34,7 +34,7 @@ abstract contract AddrResolver is ResolverBase {
         return bytesToAddress(a);
     }
 
-    function setAddr(bytes32 node, uint coinType, bytes memory a) public authorised(node) {
+    function setAddr(bytes32 node, uint coinType, bytes memory a) virtual public authorised(node) {
         emit AddressChanged(node, coinType, a);
         if(coinType == COIN_TYPE_ETH) {
             emit AddrChanged(node, bytesToAddress(a));
@@ -42,7 +42,7 @@ abstract contract AddrResolver is ResolverBase {
         _addresses[node][coinType] = a;
     }
 
-    function addr(bytes32 node, uint coinType) public view returns(bytes memory) {
+    function addr(bytes32 node, uint coinType) virtual public view returns(bytes memory) {
         return _addresses[node][coinType];
     }
 

--- a/contracts/resolvers/profiles/ContentHashResolver.sol
+++ b/contracts/resolvers/profiles/ContentHashResolver.sol
@@ -14,7 +14,7 @@ abstract contract ContentHashResolver is ResolverBase {
      * @param node The node to update.
      * @param hash The contenthash to set
      */
-    function setContenthash(bytes32 node, bytes calldata hash) external authorised(node) {
+    function setContenthash(bytes32 node, bytes calldata hash) virtual external authorised(node) {
         hashes[node] = hash;
         emit ContenthashChanged(node, hash);
     }
@@ -24,7 +24,7 @@ abstract contract ContentHashResolver is ResolverBase {
      * @param node The ENS node to query.
      * @return The associated contenthash.
      */
-    function contenthash(bytes32 node) external view returns (bytes memory) {
+    function contenthash(bytes32 node) virtual external view returns (bytes memory) {
         return hashes[node];
     }
 

--- a/contracts/resolvers/profiles/DNSResolver.sol
+++ b/contracts/resolvers/profiles/DNSResolver.sol
@@ -59,7 +59,7 @@ abstract contract DNSResolver is ResolverBase {
      * @param node the namehash of the node for which to set the records
      * @param data the DNS wire format records to set
      */
-    function setDNSRecords(bytes32 node, bytes calldata data) external authorised(node) {
+    function setDNSRecords(bytes32 node, bytes calldata data) virtual external authorised(node) {
         uint16 resource = 0;
         uint256 offset = 0;
         bytes memory name;
@@ -96,7 +96,7 @@ abstract contract DNSResolver is ResolverBase {
      * @param resource the ID of the resource as per https://en.wikipedia.org/wiki/List_of_DNS_record_types
      * @return the DNS record in wire format if present, otherwise empty
      */
-    function dnsRecord(bytes32 node, bytes32 name, uint16 resource) public view returns (bytes memory) {
+    function dnsRecord(bytes32 node, bytes32 name, uint16 resource) virtual public view returns (bytes memory) {
         return records[node][versions[node]][name][resource];
     }
 
@@ -105,7 +105,7 @@ abstract contract DNSResolver is ResolverBase {
      * @param node the namehash of the node for which to check the records
      * @param name the namehash of the node for which to check the records
      */
-    function hasDNSRecords(bytes32 node, bytes32 name) public view returns (bool) {
+    function hasDNSRecords(bytes32 node, bytes32 name) virtual public view returns (bool) {
         return (nameEntriesCount[node][versions[node]][name] != 0);
     }
 
@@ -113,7 +113,7 @@ abstract contract DNSResolver is ResolverBase {
      * Clear all information for a DNS zone.
      * @param node the namehash of the node for which to clear the zone
      */
-    function clearDNSZone(bytes32 node) public authorised(node) {
+    function clearDNSZone(bytes32 node) virtual public authorised(node) {
         versions[node]++;
         emit DNSZoneCleared(node);
     }
@@ -124,7 +124,7 @@ abstract contract DNSResolver is ResolverBase {
      * @param node The node to update.
      * @param hash The zonehash to set
      */
-    function setZonehash(bytes32 node, bytes calldata hash) external authorised(node) {
+    function setZonehash(bytes32 node, bytes calldata hash) virtual external authorised(node) {
         bytes memory oldhash = zonehashes[node];
         zonehashes[node] = hash;
         emit DNSZonehashChanged(node, oldhash, hash);
@@ -135,7 +135,7 @@ abstract contract DNSResolver is ResolverBase {
      * @param node The ENS node to query.
      * @return The associated contenthash.
      */
-    function zonehash(bytes32 node) external view returns (bytes memory) {
+    function zonehash(bytes32 node) virtual external view returns (bytes memory) {
         return zonehashes[node];
     }
 

--- a/contracts/resolvers/profiles/InterfaceResolver.sol
+++ b/contracts/resolvers/profiles/InterfaceResolver.sol
@@ -17,7 +17,7 @@ abstract contract InterfaceResolver is ResolverBase, AddrResolver {
      * @param interfaceID The EIP 165 interface ID.
      * @param implementer The address of a contract that implements this interface for this node.
      */
-    function setInterface(bytes32 node, bytes4 interfaceID, address implementer) external authorised(node) {
+    function setInterface(bytes32 node, bytes4 interfaceID, address implementer) virtual external authorised(node) {
         interfaces[node][interfaceID] = implementer;
         emit InterfaceChanged(node, interfaceID, implementer);
     }
@@ -32,7 +32,7 @@ abstract contract InterfaceResolver is ResolverBase, AddrResolver {
      * @param interfaceID The EIP 165 interface ID to check for.
      * @return The address that implements this interface, or 0 if the interface is unsupported.
      */
-    function interfaceImplementer(bytes32 node, bytes4 interfaceID) external view returns (address) {
+    function interfaceImplementer(bytes32 node, bytes4 interfaceID) virtual external view returns (address) {
         address implementer = interfaces[node][interfaceID];
         if(implementer != address(0)) {
             return implementer;

--- a/contracts/resolvers/profiles/NameResolver.sol
+++ b/contracts/resolvers/profiles/NameResolver.sol
@@ -14,7 +14,7 @@ abstract contract NameResolver is ResolverBase {
      * @param node The node to update.
      * @param name The name to set.
      */
-    function setName(bytes32 node, string calldata name) external authorised(node) {
+    function setName(bytes32 node, string calldata name) virtual external authorised(node) {
         names[node] = name;
         emit NameChanged(node, name);
     }
@@ -25,7 +25,7 @@ abstract contract NameResolver is ResolverBase {
      * @param node The ENS node to query.
      * @return The associated name.
      */
-    function name(bytes32 node) external view returns (string memory) {
+    function name(bytes32 node) virtual external view returns (string memory) {
         return names[node];
     }
 

--- a/contracts/resolvers/profiles/PubkeyResolver.sol
+++ b/contracts/resolvers/profiles/PubkeyResolver.sol
@@ -19,7 +19,7 @@ abstract contract PubkeyResolver is ResolverBase {
      * @param x the X coordinate of the curve point for the public key.
      * @param y the Y coordinate of the curve point for the public key.
      */
-    function setPubkey(bytes32 node, bytes32 x, bytes32 y) external authorised(node) {
+    function setPubkey(bytes32 node, bytes32 x, bytes32 y) virtual external authorised(node) {
         pubkeys[node] = PublicKey(x, y);
         emit PubkeyChanged(node, x, y);
     }
@@ -31,7 +31,7 @@ abstract contract PubkeyResolver is ResolverBase {
      * @return x The X coordinate of the curve point for the public key.
      * @return y The Y coordinate of the curve point for the public key.
      */
-    function pubkey(bytes32 node) external view returns (bytes32 x, bytes32 y) {
+    function pubkey(bytes32 node) virtual external view returns (bytes32 x, bytes32 y) {
         return (pubkeys[node].x, pubkeys[node].y);
     }
 

--- a/contracts/resolvers/profiles/TextResolver.sol
+++ b/contracts/resolvers/profiles/TextResolver.sol
@@ -15,7 +15,7 @@ abstract contract TextResolver is ResolverBase {
      * @param key The key to set.
      * @param value The text data value to set.
      */
-    function setText(bytes32 node, string calldata key, string calldata value) external authorised(node) {
+    function setText(bytes32 node, string calldata key, string calldata value) virtual external authorised(node) {
         texts[node][key] = value;
         emit TextChanged(node, key, key);
     }
@@ -26,7 +26,7 @@ abstract contract TextResolver is ResolverBase {
      * @param key The text data key to query.
      * @return The associated text data.
      */
-    function text(bytes32 node, string calldata key) external view returns (string memory) {
+    function text(bytes32 node, string calldata key) virtual external view returns (string memory) {
         return texts[node][key];
     }
 


### PR DESCRIPTION
 To increase their reuse in specific implementations (for example to optimize storage)