### PR TITLE
Align data locations between interface and implementation.

### DIFF
--- a/contracts/dnssec-oracle/DNSSEC.sol
+++ b/contracts/dnssec-oracle/DNSSEC.sol
@@ -15,9 +15,9 @@ abstract contract DNSSEC {
     event NSEC3DigestUpdated(uint8 id, address addr);
     event RRSetUpdated(bytes name, bytes rrset);
 
-    function submitRRSets(RRSetWithSignature[] memory input, bytes calldata proof) public virtual returns (bytes memory);
-    function submitRRSet(RRSetWithSignature calldata input, bytes calldata proof) public virtual returns (bytes memory);
-    function deleteRRSet(uint16 deleteType, bytes calldata deleteName, RRSetWithSignature calldata nsec, bytes calldata proof) public virtual;
+    function submitRRSets(RRSetWithSignature[] memory input, bytes memory proof) public virtual returns (bytes memory);
+    function submitRRSet(RRSetWithSignature memory input, bytes memory proof) public virtual returns (bytes memory);
+    function deleteRRSet(uint16 deleteType, bytes memory deleteName, RRSetWithSignature memory nsec, bytes memory proof) public virtual;
     function deleteRRSetNSEC3(uint16 deleteType, bytes memory deleteName, RRSetWithSignature memory closestEncloser, RRSetWithSignature memory nextClosest, bytes memory dnskey) public virtual;
     function rrdata(uint16 dnstype, bytes calldata name) external virtual view returns (uint32, uint32, bytes20);
 }

--- a/contracts/dnssec-oracle/DNSSECImpl.sol
+++ b/contracts/dnssec-oracle/DNSSECImpl.sol
@@ -105,11 +105,10 @@ contract DNSSECImpl is DNSSEC, Owned {
     /**
      * @dev Submits multiple RRSets
      * @param input A list of RRSets and signatures forming a chain of trust from an existing known-good record.
-     * @param _proof The DNSKEY or DS to validate the first signature against.
+     * @param proof The DNSKEY or DS to validate the first signature against.
      * @return The last RRSET submitted.
      */
-    function submitRRSets(RRSetWithSignature[] memory input, bytes calldata _proof) public override returns (bytes memory) {
-        bytes memory proof = _proof;
+    function submitRRSets(RRSetWithSignature[] memory input, bytes memory proof) public override returns (bytes memory) {
         for(uint i = 0; i < input.length; i++) {
             proof = _submitRRSet(input[i], proof);
         }


### PR DESCRIPTION
We are currently fixing a bug in the Solidity compiler where it did not properly enforce that the data location is unchanged during inheritance. This pull request fixes your contracts to be compliant with the stricter rules.

Your contracts can only be really affected by the bug when you have a contract that inherits from DNSSEC but not from DNSSECImpl, calls one of DNSSEC's functions internally and is part of an inheritance hierarchy that does include DNSSECImpl in the end, leading to virtual function lookup ending with the wrong data location of the passed arguments.

Here is a simplified example:

```solidity
abstract contract I {
        function f(uint[] calldata x)  virtual internal;
}
contract C is I {
        uint public data;
        // The override checker in the compiler does not complain
        // here - this is the bug in the compiler.
        function f(uint[] memory x)  override internal {
                data = x[0];
        }
}
abstract contract D is I {
        function g(uint[] calldata x)  external {
                // Since D only "knows" `I`, the signature of `f` uses calldata,
                // while the virtual lookup ends up with `C.f`, which uses memory.
                // This results in the calldata pointer `x` being passed and interpreted
                // as a memory pointer.
                f(x);
        }
}
contract X is C, D { }
```