### PR TITLE
Remove import statements from IABIResolver.sol

### DIFF
--- a/contracts/resolvers/profiles/IABIResolver.sol
+++ b/contracts/resolvers/profiles/IABIResolver.sol
@@ -1,9 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.4;
 
-import "./IABIResolver.sol";
-import "../ResolverBase.sol";
-
 interface IABIResolver {
     event ABIChanged(bytes32 indexed node, uint256 indexed contentType);
     /**


### PR DESCRIPTION
The `IABIResolver` interface does not require any external solidity files.  These import statements can be removed.