### PR TITLE
Tiny gas optimization in StablePriceOracle.sol

### DIFF
--- a/contracts/ethregistrar/StablePriceOracle.sol
+++ b/contracts/ethregistrar/StablePriceOracle.sol
@@ -44,16 +44,16 @@ contract StablePriceOracle is IPriceOracle {
         uint256 len = name.strlen();
         uint256 basePrice;
 
-        if (len == 1) {
-            basePrice = price1Letter * duration;
-        } else if (len == 2) {
-            basePrice = price2Letter * duration;
-        } else if (len == 3) {
-            basePrice = price3Letter * duration;
+        if (len >= 5) {
+            basePrice = price5Letter * duration;
         } else if (len == 4) {
             basePrice = price4Letter * duration;
+        } else if (len == 3) {
+            basePrice = price3Letter * duration;
+        } else if (len == 2) {
+            basePrice = price2Letter * duration;
         } else {
-            basePrice = price5Letter * duration;
+            basePrice = price1Letter * duration;
         }
 
         return


### PR DESCRIPTION
As there'll always be more domains with >=5 chars, 
changing oracle price logic to check >=5 chars first will save tiny (~59) gas during registration and renewal per domain.

Domains with <5 chars are already paying extra for registration so few gWei shouldn't matter to them.