### PR TITLE
Add GitHub workflow

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,0 +1,25 @@
+name: build-test
+
+on:
+  pull_request:
+    paths-ignore:
+      - '**.md'
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - '**.md'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Node 14.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: 14
+          cache: 'npm'
+      - run: npm install
+      - run: npm run lint
+      - run: npm test

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # ENS
 
+[![build-test](https://github.com/ensdomains/ens-contracts/actions/workflows/build-test.yml/badge.svg?branch=master)](https://github.com/ensdomains/ens-contracts/actions/workflows/build-test.yml)
 [![Build Status](https://travis-ci.org/ensdomains/ens-contracts.svg?branch=master)](https://travis-ci.org/ensdomains/ens-contracts)
 
 For documentation of the ENS system, see [docs.ens.domains](https://docs.ens.domains/).


### PR DESCRIPTION
It does exactly the same job as [.travis.yml](https://github.com/ensdomains/ens-contracts/blob/8a2423829a28852297ee208357d148987e8dce0f/.travis.yml) but as a GitHub workflow.

The build history in Travis stopped working about an year ago. [[1]](https://app.travis-ci.com/github/ensdomains/ens-contracts/builds). Fixing Travis would require admin rights in the organization and migrating to GitHub Workflows has advantage of being native (to GitHub) and also free.