### PR TITLE
add exponential premium price oracle to deploy scripts

### DIFF
--- a/deploy/ethregistrar/01_deploy_exponential_premium_price_oracle.ts
+++ b/deploy/ethregistrar/01_deploy_exponential_premium_price_oracle.ts
@@ -1,7 +1,7 @@
 import { DeployFunction } from 'hardhat-deploy/types'
 import { HardhatRuntimeEnvironment } from 'hardhat/types'
 
-const func: DeployFunction = async function(hre: HardhatRuntimeEnvironment) {
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { getNamedAccounts, deployments, network } = hre
   const { deploy } = deployments
   const { deployer } = await getNamedAccounts()
@@ -12,19 +12,24 @@ const func: DeployFunction = async function(hre: HardhatRuntimeEnvironment) {
 
   const dummyOracle = await deploy('DummyOracle', {
     from: deployer,
-    args: ['100000000'],
+    args: ['160000000000'],
     log: true,
   })
 
-  await deploy('StablePriceOracle', {
+  await deploy('ExponentialPremiumPriceOracle', {
     from: deployer,
-    args: [dummyOracle.address, [0, 0, 4, 2, 1]],
+    args: [
+      dummyOracle.address,
+      [0, 0, '20294266869609', '5073566717402', '158548959919'],
+      '100000000000000000000000000',
+      21,
+    ],
     log: true,
   })
 }
 
 func.id = 'price-oracle'
-func.tags = ['ethregistrar', 'StablePriceOracle', 'DummyOracle']
+func.tags = ['ethregistrar', 'ExponentialPremiumPriceOracle', 'DummyOracle']
 func.dependencies = ['registry']
 
 export default func

--- a/deploy/ethregistrar/02_deploy_legacy_eth_registrar_controller.ts
+++ b/deploy/ethregistrar/02_deploy_legacy_eth_registrar_controller.ts
@@ -8,7 +8,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { deployer, owner } = await getNamedAccounts()
 
   const registrar = await ethers.getContract('BaseRegistrarImplementation')
-  const priceOracle = await ethers.getContract('StablePriceOracle')
+  const priceOracle = await ethers.getContract('ExponentialPremiumPriceOracle')
   const reverseRegistrar = await ethers.getContract('ReverseRegistrar')
 
   await deploy('LegacyETHRegistrarController', {
@@ -47,7 +47,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     resetMemory: false,
   })
 
-  return true;
+  return true
 }
 
 func.id = 'legacy-controller'

--- a/deploy/ethregistrar/03_deploy_eth_registrar_controller.ts
+++ b/deploy/ethregistrar/03_deploy_eth_registrar_controller.ts
@@ -8,7 +8,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { deployer } = await getNamedAccounts()
 
   const registrar = await ethers.getContract('BaseRegistrarImplementation')
-  const priceOracle = await ethers.getContract('StablePriceOracle')
+  const priceOracle = await ethers.getContract('ExponentialPremiumPriceOracle')
   const reverseRegistrar = await ethers.getContract('ReverseRegistrar')
   const nameWrapper = await ethers.getContract('NameWrapper')
 
@@ -55,6 +55,12 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 }
 
 func.tags = ['ethregistrar', 'ETHRegistrarController']
-func.dependencies = ['ENSRegistry', 'BaseRegistrarImplementation', 'StablePriceOracle', 'ReverseRegistrar', 'NameWrapper']
+func.dependencies = [
+  'ENSRegistry',
+  'BaseRegistrarImplementation',
+  'ExponentialPremiumPriceOracle',
+  'ReverseRegistrar',
+  'NameWrapper',
+]
 
 export default func


### PR DESCRIPTION
- previously if not on mainnet, StablePriceOracle was deployed
- this change uses ExponentialPremiumPriceOracle instead
- also updates the DummyOracle's constructor value to more accurately represent ETH/USD