### PR TITLE
Replace abstract NameResolver contract with import in ReverseRegistrar.sol

### DIFF
--- a/contracts/reverseRegistrar/ReverseRegistrar.sol
+++ b/contracts/reverseRegistrar/ReverseRegistrar.sol
@@ -4,10 +4,7 @@ import "../registry/ENS.sol";
 import "./IReverseRegistrar.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "../root/Controllable.sol";
-
-abstract contract NameResolver {
-    function setName(bytes32 node, string memory name) public virtual;
-}
+import "../resolvers/profiles/NameResolver.sol";
 
 bytes32 constant lookup = 0x3031323334353637383961626364656600000000000000000000000000000000;
 


### PR DESCRIPTION
This pull replaces the abstract contract named NameResolver in the file ReverseRegistrat.sol with an import of the NameResolver from it's respective .sol file.
I've come across hardhat compiler issues when using the ens-contracts npm package in my own projects due to two NameResolver contracts existing.