### PR TITLE
Wrapper check expiry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ gasreport-*
 *.DS_Store
 node_modules
 build
+forge-cache
+out

--- a/contracts/wrapper/NameWrapper.sol
+++ b/contracts/wrapper/NameWrapper.sol
@@ -871,22 +871,6 @@ contract NameWrapper is
         return name;
     }
 
-    // function _saveLabelAndWrap(
-    //     bytes32 parentNode,
-    //     bytes32 node,
-    //     string memory label,
-    //     address owner,
-    //     uint32 fuses,
-    //     uint64 expiry
-    // ) internal {
-    //     bytes memory name = _saveLabel(
-    //         parentNode,
-    //         node,
-    //         label
-    //     );
-    //     _wrap(node, names[node], owner, fuses, expiry);
-    // }
-
     function _isDotEth(bytes memory name)
         internal
         pure

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -130,11 +130,13 @@ const config: HardhatUserConfig = {
     hardhat: {
       saveDeployments: false,
       tags: ['test', 'legacy', 'use_root'],
+      allowUnlimitedContractSize: true,
     },
     localhost: {
       url: 'http://127.0.0.1:8545',
       saveDeployments: false,
       tags: ['test', 'legacy', 'use_root'],
+      allowUnlimitedContractSize: true,
     },
     ropsten: {
       url: `https://ropsten.infura.io/v3/${process.env.INFURA_ID}`,

--- a/test/wrapper/NameWrapper.js
+++ b/test/wrapper/NameWrapper.js
@@ -4489,7 +4489,7 @@ describe('Name Wrapper', () => {
         PARENT_CANNOT_CONTROL | CANNOT_UNWRAP | CANNOT_SET_RESOLVER,
       )
       expect(expiry).to.equal(expectedExpiry)
-    })    
+    })
   })
 
   describe('Controllable', () => {


### PR DESCRIPTION
Fixes bug that allows wrapped .eth names to be transferred after expiry.

Todo:

- [ ] Fix tests
- [ ] Check gas comparison with using fuses instead
- [ ] Reduce contract size so it is still deployable
- [ ] Add tests for expired .eth names
- [ ] Add tests for preimage