### PR TITLE
Some edits to NameWrapper.sol and NameWrapper.js

### DIFF
--- a/contracts/wrapper/NameWrapper.sol
+++ b/contracts/wrapper/NameWrapper.sol
@@ -469,13 +469,14 @@ contract NameWrapper is
     ) public {
         bytes32 node = _makeNode(parentNode, labelhash);
         _checkFusesAreSettable(node, fuses);
+
         (address owner, uint32 oldFuses, uint64 oldExpiry) = getData(uint256(node));
+
         // max expiry is set to the expiry of the parent
-        (, uint32 parentFuses, uint64 maxExpiry) = getData(
-            uint256(parentNode)
-        );
+        (, uint32 parentFuses, uint64 maxExpiry) = getData(uint256(parentNode));
+
         if (parentNode == ROOT_NODE) {
-            if (!canModifyName(node, msg.sender)) {
+            if (!canModifyName(node, msg.sender)) {   
                 revert Unauthorised(node, msg.sender);
             }
         } else {
@@ -488,13 +489,14 @@ contract NameWrapper is
 
         expiry = _normaliseExpiry(expiry, oldExpiry, maxExpiry);
 
-        // if PARENT_CANNOT_CONTROL has been burned and fuses have changed
+        // disallow burning any new fuses if the parent cannot control fuse has been burned
         if (
             oldFuses & PARENT_CANNOT_CONTROL != 0 &&
             oldFuses | fuses != oldFuses
         ) {
             revert OperationProhibited(node);
         }
+
         fuses |= oldFuses;
         _setFuses(node, owner, fuses, expiry);
     }
@@ -668,7 +670,7 @@ contract NameWrapper is
 
     /**
      * @notice Check whether a name can call setSubnodeOwner/setSubnodeRecord
-     * @dev Checks both CANNOT_CREATE_SUBDOMAIN and PARENT_CANNOT_CONTROL and whether not they have been burnt
+     * @dev Checks both CANNOT_CREATE_SUBDOMAIN and PARENT_CANNOT_CONTROL and whether not they have been burned
      *      and checks whether the owner of the subdomain is 0x0 for creating or already exists for
      *      replacing a subdomain. If either conditions are true, then it is possible to call
      *      setSubnodeOwner

--- a/contracts/wrapper/NameWrapper.sol
+++ b/contracts/wrapper/NameWrapper.sol
@@ -484,7 +484,7 @@ contract NameWrapper is
             }
         }
 
-        _checkParentFuses(node, fuses, parentFuses);
+        _checkParentCannotUnwrap(node, fuses, parentFuses);
 
         expiry = _normaliseExpiry(expiry, oldExpiry, maxExpiry);
 
@@ -524,8 +524,8 @@ contract NameWrapper is
         bytes32 labelhash = keccak256(bytes(label));
         node = _makeNode(parentNode, labelhash);
         _checkFusesAreSettable(node, fuses);
-        bytes memory name = _saveLabel(parentNode, node, label);
-        expiry = _checkParentFusesAndExpiry(parentNode, node, fuses, expiry);
+        bytes memory name = _saveName(parentNode, node, label);
+        expiry = _checkParentCannotUnwrapAndExpiry(parentNode, node, fuses, expiry);
 
         if (ownerOf(uint256(node)) == address(0)) {
             ens.setSubnodeOwner(parentNode, labelhash, address(this));
@@ -564,8 +564,8 @@ contract NameWrapper is
         bytes32 labelhash = keccak256(bytes(label));
         node = _makeNode(parentNode, labelhash);
         _checkFusesAreSettable(node, fuses);
-        _saveLabel(parentNode, node, label);
-        expiry = _checkParentFusesAndExpiry(parentNode, node, fuses, expiry);
+        _saveName(parentNode, node, label);
+        expiry = _checkParentCannotUnwrapAndExpiry(parentNode, node, fuses, expiry);
         if (ownerOf(uint256(node)) == address(0)) {
             ens.setSubnodeRecord(
                 parentNode,
@@ -828,7 +828,7 @@ contract NameWrapper is
         _wrap(node, name, owner, fuses, expiry);
     }
 
-    function _saveLabel(
+    function _saveName(
         bytes32 parentNode,
         bytes32 node,
         string memory label
@@ -877,7 +877,7 @@ contract NameWrapper is
     }
 
     // wrapper function for stack limit
-    function _checkParentFusesAndExpiry(
+    function _checkParentCannotUnwrapAndExpiry(
         bytes32 parentNode,
         bytes32 node,
         uint32 fuses,
@@ -887,11 +887,11 @@ contract NameWrapper is
         (, uint32 parentFuses, uint64 maxExpiry) = getData(
             uint256(parentNode)
         );
-        _checkParentFuses(node, fuses, parentFuses);
+        _checkParentCannotUnwrap(node, fuses, parentFuses);
         return _normaliseExpiry(expiry, oldExpiry, maxExpiry);
     }
 
-    function _checkParentFuses(
+    function _checkParentCannotUnwrap(
         bytes32 node,
         uint32 fuses,
         uint32 parentFuses
@@ -984,7 +984,7 @@ contract NameWrapper is
     }
 
     function _canFusesBeBurned(bytes32 node, uint32 fuses) internal pure {
-        // If a non-parent controlled fuse is being burned, check PCC and CU are burnt
+        // If user settable fuses are being burned, check to make sure PCC and CU are burnt
         if (
             fuses & ~PARENT_CONTROLLED_FUSES != 0 &&
             fuses & (PARENT_CANNOT_CONTROL | CANNOT_UNWRAP) !=

--- a/contracts/wrapper/NameWrapper.sol
+++ b/contracts/wrapper/NameWrapper.sol
@@ -574,7 +574,7 @@ contract NameWrapper is
                 resolver,
                 ttl
             );
-            _storeNameAndWrap(parentNode, node, label, owner, fuses, expiry);
+            _getNameAndWrap(parentNode, node, label, owner, fuses, expiry);
         } else {
             ens.setSubnodeRecord(
                 parentNode,
@@ -815,7 +815,8 @@ contract NameWrapper is
         emit NameWrapped(node, name, wrappedOwner, fuses, expiry);
     }
 
-    function _storeNameAndWrap(
+    // wrapper function for stack limit
+    function _getNameAndWrap(
         bytes32 parentNode,
         bytes32 node,
         string memory label,

--- a/contracts/wrapper/NameWrapper.sol
+++ b/contracts/wrapper/NameWrapper.sol
@@ -896,14 +896,12 @@ contract NameWrapper is
         uint32 fuses,
         uint32 parentFuses
     ) internal pure {
-        bool isBurningParentControlledFuses = fuses & PARENT_CONTROLLED_FUSES !=
-            0;
-
-        bool parentHasNotBurnedCU = parentFuses & CANNOT_UNWRAP == 0;
-
-        if (isBurningParentControlledFuses && parentHasNotBurnedCU) {
+        
+        //To burn parent controlled fuses in the node, the parent must have burned the cannot unwrap fuse.  
+        if (fuses & PARENT_CONTROLLED_FUSES != 0 && parentFuses & CANNOT_UNWRAP == 0) {
             revert OperationProhibited(node);
         }
+
     }
 
     function _normaliseExpiry(

--- a/test/wrapper/NameWrapper.js
+++ b/test/wrapper/NameWrapper.js
@@ -2574,13 +2574,6 @@ describe('Name Wrapper', () => {
       await EnsRegistry.setApprovalForAll(NameWrapper.address, true)
       await NameWrapper.wrap(encodeName('anothertld'), account, ZERO_ADDRESS)
 
-      let [, fuses, expiry] = await NameWrapper.getData(
-        namehash('sub.fuses.eth'),
-      )
-
-      expect(fuses).to.equal(0)
-      expect(expiry).to.equal(0)
-
       const block = await ethers.provider.getBlock(
         await ethers.provider.getBlockNumber(),
       )


### PR DESCRIPTION
- Name is only used for an event, not stored, so I think we should change the name. 
- Remove sub.fuses.eth from a test. It is out of place. 
