### PR TITLE
Refactoring of SetSubnodeOwner

### DIFF
--- a/contracts/wrapper/ERC1155Fuse.sol
+++ b/contracts/wrapper/ERC1155Fuse.sol
@@ -275,12 +275,12 @@ abstract contract ERC1155Fuse is ERC165, IERC1155, IERC1155MetadataURI {
         bytes32 node,
         address owner,
         uint32 fuses,
-        uint64 expiry
+        uint64 expiry,
+        address oldOwner,
+        uint32 oldFuses,
+        uint64 oldExpiry
     ) internal virtual {
         uint256 tokenId = uint256(node);
-        (address oldOwner, uint32 oldFuses, uint64 oldExpiry) = getData(
-            uint256(node)
-        );
 
         uint32 parentControlledFuses = (uint32(type(uint16).max) << 16) &
             oldFuses;

--- a/contracts/wrapper/ERC1155Fuse.sol
+++ b/contracts/wrapper/ERC1155Fuse.sol
@@ -271,12 +271,11 @@ abstract contract ERC1155Fuse is ERC165, IERC1155, IERC1155MetadataURI {
         );
     }
 
-    function _mintWithData(
+    function _mintWithDataForUnwrappedNames(
         bytes32 node,
         address owner,
         uint32 fuses,
         uint64 expiry,
-        address oldOwner,
         uint32 oldFuses,
         uint64 oldExpiry
     ) internal virtual {
@@ -285,7 +284,6 @@ abstract contract ERC1155Fuse is ERC165, IERC1155, IERC1155MetadataURI {
             fuses = fuses | ((uint32(type(uint16).max) << 16) & oldFuses);
         }
 
-        require(oldOwner == address(0), "ERC1155: mint of existing token");
         require(owner != address(0), "ERC1155: mint to the zero address");
         require(
             owner != address(this),

--- a/contracts/wrapper/ERC1155Fuse.sol
+++ b/contracts/wrapper/ERC1155Fuse.sol
@@ -280,17 +280,13 @@ abstract contract ERC1155Fuse is ERC165, IERC1155, IERC1155MetadataURI {
         uint32 oldFuses,
         uint64 oldExpiry
     ) internal virtual {
-        uint256 tokenId = uint256(node);
-
-        uint32 parentControlledFuses = (uint32(type(uint16).max) << 16) &
-            oldFuses;
 
         if (oldExpiry > expiry) {
             expiry = oldExpiry;
         }
 
         if (oldExpiry >= block.timestamp) {
-            fuses = fuses | parentControlledFuses;
+            fuses = fuses | ((uint32(type(uint16).max) << 16) & oldFuses);
         }
 
         require(oldOwner == address(0), "ERC1155: mint of existing token");
@@ -300,13 +296,13 @@ abstract contract ERC1155Fuse is ERC165, IERC1155, IERC1155MetadataURI {
             "ERC1155: newOwner cannot be the NameWrapper contract"
         );
 
-        _setData(tokenId, owner, fuses, expiry);
-        emit TransferSingle(msg.sender, address(0x0), owner, tokenId, 1);
+        _setData(uint256(node), owner, fuses, expiry);
+        emit TransferSingle(msg.sender, address(0x0), owner, uint256(node), 1);
         _doSafeTransferAcceptanceCheck(
             msg.sender,
             address(0),
             owner,
-            tokenId,
+            uint256(node),
             1,
             ""
         );

--- a/contracts/wrapper/ERC1155Fuse.sol
+++ b/contracts/wrapper/ERC1155Fuse.sol
@@ -281,10 +281,6 @@ abstract contract ERC1155Fuse is ERC165, IERC1155, IERC1155MetadataURI {
         uint64 oldExpiry
     ) internal virtual {
 
-        if (oldExpiry > expiry) {
-            expiry = oldExpiry;
-        }
-
         if (oldExpiry >= block.timestamp) {
             fuses = fuses | ((uint32(type(uint16).max) << 16) & oldFuses);
         }

--- a/contracts/wrapper/INameWrapper.sol
+++ b/contracts/wrapper/INameWrapper.sol
@@ -109,7 +109,7 @@ interface INameWrapper is IERC1155 {
 
     function setSubnodeOwner(
         bytes32 node,
-        string calldata label,
+        string memory label,
         address newOwner,
         uint32 fuses,
         uint64 expiry

--- a/contracts/wrapper/NameWrapper.sol
+++ b/contracts/wrapper/NameWrapper.sol
@@ -592,11 +592,6 @@ contract NameWrapper is
             } else {
                 // If the name was wrapped, then just update the data.   
 
-                // If the name is not already set then set it.
-                if (names[node].length == 0) {
-                    names[node] = bytes(label);
-                }
-
                 // Set the fuses.
                 _setFuses(node, nodeOwner, fuses, expiry);
 

--- a/contracts/wrapper/NameWrapper.sol
+++ b/contracts/wrapper/NameWrapper.sol
@@ -524,23 +524,23 @@ contract NameWrapper is
         bytes32 labelhash = keccak256(bytes(label));
         node = _makeNode(parentNode, labelhash);
 
-        // Make sure that IS_DOT_ETH is not part of the fuses. 
-        _checkFusesAreSettable(node, fuses);
-
         // Get the node data and parentNode data.
         // Notice: in order to save stack space we call the parent owner baseOwner.
         // We will use baseOwner for another purpose later. 
         (address nodeOwner, uint32 nodeFuses, uint64 oldExpiry) = getData(uint256(node));
         (address baseOwner, uint32 parentFuses, uint64 parentExpiry) = getData(uint256(parentNode));
 
+        // Set the expiry between the old expiry and the parentExpiry.
+        expiry = _normaliseExpiry(expiry, oldExpiry, parentExpiry);
+
+        // Make sure that IS_DOT_ETH is not part of the fuses. 
+        _checkFusesAreSettable(node, fuses);
+
         // If parent controlled fuses in the node are being set, make sure CANNOT_UNWRAP
         // is burned in the fuses of the parent node. 
         if (fuses & PARENT_CONTROLLED_FUSES != 0 && parentFuses & CANNOT_UNWRAP == 0) {
             revert OperationProhibited(node);
         }
-
-        // Set the expiry between the old expiry and the parentExpiry.
-        expiry = _normaliseExpiry(expiry, oldExpiry, parentExpiry);
 
         // Make sure the caller is the parent owner or approved, and the parent name is not expired. 
         if ((baseOwner != msg.sender && !isApprovedForAll(baseOwner, msg.sender)) || 

--- a/contracts/wrapper/NameWrapper.sol
+++ b/contracts/wrapper/NameWrapper.sol
@@ -581,13 +581,6 @@ contract NameWrapper is
                 _updateName(parentNode, node, label, owner, fuses, expiry);
             }
         }
-
-        // NTS: I don't think this function is necessary since only owner controled fuses 
-        // are allowed to be set. 
-        // If parent controlled fuses in the node are being set, make sure 
-        // CANNOT_UNWRAP is burned in the fuses of the parent node. 
-        //_checkParentFuses(node, fuses, parentFuses);
-
     }
 
     /**

--- a/contracts/wrapper/NameWrapper.sol
+++ b/contracts/wrapper/NameWrapper.sol
@@ -543,7 +543,7 @@ contract NameWrapper is
             revert Unauthorised(parentNode, msg.sender);
         }
 
-        canCallSetSubnodeOwnerFunc(node, nodeFuses, parentNode, parentFuses);
+        canCallSetSubnodeOwnerFunc(node, nodeFuses, parentFuses);
 
         bytes memory _name = _saveLabel(parentNode, node, label);
 
@@ -724,7 +724,7 @@ contract NameWrapper is
         _;
     }
 
-    function canCallSetSubnodeOwnerFunc(bytes32 node, uint32 nodeFuses, bytes32 parentNode, uint32 parentFuses) private view {
+    function canCallSetSubnodeOwnerFunc(bytes32 node, uint32 nodeFuses, uint32 parentFuses) private view {
         address owner = ens.owner(node);
 
         if (owner == address(0)) {

--- a/contracts/wrapper/NameWrapper.sol
+++ b/contracts/wrapper/NameWrapper.sol
@@ -201,6 +201,13 @@ contract NameWrapper is
         _;
     }
 
+    function onlyTokenOwnerFunc(bytes32 node) private view{
+        if (!canModifyName(node, msg.sender)) {
+            revert Unauthorised(node, msg.sender);
+        }
+
+    }
+
     /**
      * @notice Checks if owner or approved by owner
      * @param node namehash of the name to check
@@ -517,14 +524,15 @@ contract NameWrapper is
         uint64 expiry
     )
         public
-        onlyTokenOwner(parentNode)
         returns (bytes32 node)
     {
-
-        canCallSetSubnodeOwnerFunc(parentNode, keccak256(bytes(label)));
-
         bytes32 labelhash = keccak256(bytes(label));
         node = _makeNode(parentNode, labelhash);
+
+        onlyTokenOwnerFunc(parentNode);
+
+        canCallSetSubnodeOwnerFunc(parentNode, labelhash);
+
         _checkFusesAreSettable(node, fuses);
         bytes memory name = _saveLabel(parentNode, node, label);
         expiry = _checkParentFusesAndExpiry(parentNode, node, fuses, expiry);

--- a/contracts/wrapper/NameWrapper.sol
+++ b/contracts/wrapper/NameWrapper.sol
@@ -585,7 +585,7 @@ contract NameWrapper is
             label = string(_saveLabel(parentNode, node, label));
 
             // If the name is not wrapped, then register the name and wrap it. 
-            if (ownerOf(uint256(node)) == address(0)) {
+            if (nodeOwner == address(0)) {
                 ens.setSubnodeOwner(parentNode, labelhash, address(this));
                 _mintWithData(node, owner, fuses, expiry, nodeOwner, nodeFuses, oldExpiry);
                 emit NameWrapped(node, bytes(label), owner, fuses, expiry);
@@ -858,7 +858,6 @@ contract NameWrapper is
         }
         return abi.encodePacked(uint8(bytes(label).length), label, name);
     }
-
 
     function _mint(
         bytes32 node,

--- a/contracts/wrapper/NameWrapper.sol
+++ b/contracts/wrapper/NameWrapper.sol
@@ -532,7 +532,8 @@ contract NameWrapper is
         // Make sure that only owner controlled fuses are being set. 
         _checkFusesAreSettable(node, fuses);
 
-        (, , uint64 oldExpiry) = getData(uint256(node));
+        // Get the node data and parentNode data.
+        (, uint32 nodeFuses, uint64 oldExpiry) = getData(uint256(node));
         (address parentOwner, uint32 parentFuses, uint64 parentExpiry) = getData(uint256(parentNode));
 
         // Make sure the caller is the parent owner or approved, and the parent name is not expired. 

--- a/contracts/wrapper/NameWrapper.sol
+++ b/contracts/wrapper/NameWrapper.sol
@@ -511,7 +511,7 @@ contract NameWrapper is
 
     function setSubnodeOwner(
         bytes32 parentNode,
-        string calldata label,
+        string memory label,
         address owner,
         uint32 fuses,
         uint64 expiry
@@ -578,9 +578,11 @@ contract NameWrapper is
 
             // If the name is not wrapped, then register the name and wrap it. 
             if (ownerOf(uint256(node)) == address(0)) {
-                bytes memory _name = _saveLabel(parentNode, node, label);
+                //Notice: In order to limit the stack heigh we are temporaily using label as "name"
+                //label = string(_addLabel(label, names[parentNode]));
+                label = string(_saveLabel(parentNode, node, label));
                 ens.setSubnodeOwner(parentNode, labelhash, address(this));
-                _wrap(node, _name, owner, fuses, expiry);
+                _wrap(node, bytes(label), owner, fuses, expiry);
             } else {
 
                 // If the name was wrapped, then just update the data.   

--- a/contracts/wrapper/NameWrapper.sol
+++ b/contracts/wrapper/NameWrapper.sol
@@ -545,8 +545,6 @@ contract NameWrapper is
 
         canCallSetSubnodeOwnerFunc(node, nodeFuses, parentFuses);
 
-        bytes memory _name = _saveLabel(parentNode, node, label);
-
         // NTS: I don't think this function is necessary since only owner controled fuses 
         // are allowed to be set. 
         // If parent controlled fuses in the node are being set, make sure 
@@ -557,6 +555,7 @@ contract NameWrapper is
 
 
         if (ownerOf(uint256(node)) == address(0)) {
+            bytes memory _name = _saveLabel(parentNode, node, label);
             ens.setSubnodeOwner(parentNode, labelhash, address(this));
             _wrap(node, _name, owner, fuses, expiry);
         } else {

--- a/contracts/wrapper/NameWrapper.sol
+++ b/contracts/wrapper/NameWrapper.sol
@@ -534,12 +534,18 @@ contract NameWrapper is
         canCallSetSubnodeOwnerFunc(parentNode, labelhash);
 
         _checkFusesAreSettable(node, fuses);
-        bytes memory name = _saveLabel(parentNode, node, label);
-        expiry = _checkParentFusesAndExpiry(parentNode, node, fuses, expiry);
+        bytes memory _name = _saveLabel(parentNode, node, label);
+        
+        (, , uint64 oldExpiry) = getData(uint256(node));
+        (, uint32 parentFuses, uint64 maxExpiry) = getData(uint256(parentNode));
+
+        _checkParentFuses(node, fuses, parentFuses);
+        expiry = _normaliseExpiry(expiry, oldExpiry, maxExpiry);
+
 
         if (ownerOf(uint256(node)) == address(0)) {
             ens.setSubnodeOwner(parentNode, labelhash, address(this));
-            _wrap(node, name, owner, fuses, expiry);
+            _wrap(node, _name, owner, fuses, expiry);
         } else {
             _updateName(parentNode, node, label, owner, fuses, expiry);
         }

--- a/contracts/wrapper/NameWrapper.sol
+++ b/contracts/wrapper/NameWrapper.sol
@@ -570,12 +570,6 @@ contract NameWrapper is
             // PARENT_CANNOT_CONTROL and CANNOT_UNWRAP have been burned. 
             _canFusesBeBurned(node, fuses);
 
-            // If the token was previously wrapped burn it before wrapping again.  
-            if (nodeOwner != address(0)) {
-                // burn and unwrap old token of old owner
-                _burn(uint256(node));
-                emit NameUnwrapped(node, address(0));
-            }
             super._mint(node, owner, fuses, expiry);
             emit NameWrapped(node, _name, owner, fuses, expiry);
 

--- a/contracts/wrapper/NameWrapper.sol
+++ b/contracts/wrapper/NameWrapper.sol
@@ -570,7 +570,7 @@ contract NameWrapper is
             // PARENT_CANNOT_CONTROL and CANNOT_UNWRAP have been burned. 
             _canFusesBeBurned(node, fuses);
 
-            super._mint(node, owner, fuses, expiry);
+            super._mintWithData(node, owner, fuses, expiry, nodeOwner, nodeFuses, oldExpiry);
             emit NameWrapped(node, _name, owner, fuses, expiry);
 
         } else {
@@ -587,7 +587,7 @@ contract NameWrapper is
             // If the name is not wrapped, then register the name and wrap it. 
             if (ownerOf(uint256(node)) == address(0)) {
                 ens.setSubnodeOwner(parentNode, labelhash, address(this));
-                _mint(node, owner, fuses, expiry);
+                _mintWithData(node, owner, fuses, expiry, nodeOwner, nodeFuses, oldExpiry);
                 emit NameWrapped(node, bytes(label), owner, fuses, expiry);
             } else {
                 // If the name was wrapped, then just update the data.   

--- a/contracts/wrapper/NameWrapper.sol
+++ b/contracts/wrapper/NameWrapper.sol
@@ -529,6 +529,9 @@ contract NameWrapper is
         bytes32 labelhash = keccak256(bytes(label));
         node = _makeNode(parentNode, labelhash);
 
+        // Make sure that only owner controlled fuses are being set. 
+        _checkFusesAreSettable(node, fuses);
+
         (, , uint64 oldExpiry) = getData(uint256(node));
         (address parentOwner, uint32 parentFuses, uint64 parentExpiry) = getData(uint256(parentNode));
 
@@ -541,7 +544,6 @@ contract NameWrapper is
 
         canCallSetSubnodeOwnerFunc(parentNode, labelhash);
 
-        _checkFusesAreSettable(node, fuses);
         bytes memory _name = _saveLabel(parentNode, node, label);
 
         _checkParentFuses(node, fuses, parentFuses);

--- a/contracts/wrapper/NameWrapper.sol
+++ b/contracts/wrapper/NameWrapper.sol
@@ -530,9 +530,12 @@ contract NameWrapper is
         node = _makeNode(parentNode, labelhash);
 
         (, , uint64 oldExpiry) = getData(uint256(node));
-        (, uint32 parentFuses, uint64 maxExpiry) = getData(uint256(parentNode));
+        (address parentOwner, uint32 parentFuses, uint64 parentExpiry) = getData(uint256(parentNode));
 
-        if (!canModifyName(parentNode, msg.sender)) {
+        // Make sure the caller is the parent owner or approved, and the parent name is not expired. 
+        if ((parentOwner != msg.sender && !isApprovedForAll(parentOwner, msg.sender)) || 
+            (parentFuses & IS_DOT_ETH != 0 && parentExpiry - GRACE_PERIOD < block.timestamp)
+            ) {
             revert Unauthorised(parentNode, msg.sender);
         }
 
@@ -542,7 +545,7 @@ contract NameWrapper is
         bytes memory _name = _saveLabel(parentNode, node, label);
 
         _checkParentFuses(node, fuses, parentFuses);
-        expiry = _normaliseExpiry(expiry, oldExpiry, maxExpiry);
+        expiry = _normaliseExpiry(expiry, oldExpiry, parentExpiry);
 
 
         if (ownerOf(uint256(node)) == address(0)) {

--- a/contracts/wrapper/NameWrapper.sol
+++ b/contracts/wrapper/NameWrapper.sol
@@ -536,6 +536,9 @@ contract NameWrapper is
         (, uint32 nodeFuses, uint64 oldExpiry) = getData(uint256(node));
         (address parentOwner, uint32 parentFuses, uint64 parentExpiry) = getData(uint256(parentNode));
 
+        // Set the expiry between the old expiry and the parentExpiry.
+        expiry = _normaliseExpiry(expiry, oldExpiry, parentExpiry);
+
         // Make sure the caller is the parent owner or approved, and the parent name is not expired. 
         if ((parentOwner != msg.sender && !isApprovedForAll(parentOwner, msg.sender)) || 
             (parentFuses & IS_DOT_ETH != 0 && parentExpiry - GRACE_PERIOD < block.timestamp)
@@ -543,7 +546,22 @@ contract NameWrapper is
             revert Unauthorised(parentNode, msg.sender);
         }
 
-        canCallSetSubnodeOwnerFunc(node, nodeFuses, parentFuses);
+        //canCallSetSubnodeOwnerFunc(node, nodeFuses, parentFuses);
+
+        //This is a hack!!!!!!
+        // We are no longer using the parent owner 
+        // so we can set it to the registry owner to save a new stack row. 
+        parentOwner = ens.owner(node);
+
+        if (parentOwner == address(0)) {
+            if (parentFuses & CANNOT_CREATE_SUBDOMAIN != 0) {
+                revert OperationProhibited(node);
+            }
+        } else {
+            if (nodeFuses & PARENT_CANNOT_CONTROL != 0) {
+                revert OperationProhibited(node);
+            }
+        }
 
         // NTS: I don't think this function is necessary since only owner controled fuses 
         // are allowed to be set. 
@@ -551,7 +569,6 @@ contract NameWrapper is
         // CANNOT_UNWRAP is burned in the fuses of the parent node. 
         //_checkParentFuses(node, fuses, parentFuses);
 
-        expiry = _normaliseExpiry(expiry, oldExpiry, parentExpiry);
 
 
         if (ownerOf(uint256(node)) == address(0)) {

--- a/contracts/wrapper/NameWrapper.sol
+++ b/contracts/wrapper/NameWrapper.sol
@@ -547,7 +547,12 @@ contract NameWrapper is
 
         bytes memory _name = _saveLabel(parentNode, node, label);
 
-        _checkParentFuses(node, fuses, parentFuses);
+        // NTS: I don't think this function is necessary since only owner controled fuses 
+        // are allowed to be set. 
+        // If parent controlled fuses in the node are being set, make sure 
+        // CANNOT_UNWRAP is burned in the fuses of the parent node. 
+        //_checkParentFuses(node, fuses, parentFuses);
+
         expiry = _normaliseExpiry(expiry, oldExpiry, parentExpiry);
 
 

--- a/contracts/wrapper/NameWrapper.sol
+++ b/contracts/wrapper/NameWrapper.sol
@@ -201,13 +201,6 @@ contract NameWrapper is
         _;
     }
 
-    function onlyTokenOwnerFunc(bytes32 node) private view{
-        if (!canModifyName(node, msg.sender)) {
-            revert Unauthorised(node, msg.sender);
-        }
-
-    }
-
     /**
      * @notice Checks if owner or approved by owner
      * @param node namehash of the name to check
@@ -748,21 +741,6 @@ contract NameWrapper is
         }
 
         _;
-    }
-
-    function canCallSetSubnodeOwnerFunc(bytes32 node, uint32 nodeFuses, uint32 parentFuses) private view {
-        address owner = ens.owner(node);
-
-        if (owner == address(0)) {
-            if (parentFuses & CANNOT_CREATE_SUBDOMAIN != 0) {
-                revert OperationProhibited(node);
-            }
-        } else {
-            if (nodeFuses & PARENT_CANNOT_CONTROL != 0) {
-                revert OperationProhibited(node);
-            }
-        }
-
     }
 
     /**

--- a/contracts/wrapper/NameWrapper.sol
+++ b/contracts/wrapper/NameWrapper.sol
@@ -562,15 +562,15 @@ contract NameWrapper is
                 revert OperationProhibited(node);
             }
 
-            // If we pass all the checks, register the subname and wrap it. 
-            bytes memory _name = _saveLabel(parentNode, node, label);
-            ens.setSubnodeOwner(parentNode, labelhash, address(this));
-
             // If a owner controlled fuse are being burned, check to make sure 
             // PARENT_CANNOT_CONTROL and CANNOT_UNWRAP have been burned. 
             _canFusesBeBurned(node, fuses);
 
-            super._mintWithData(node, owner, fuses, expiry, nodeOwner, nodeFuses, oldExpiry);
+            // If we pass all the checks, register the subname and wrap it. 
+            bytes memory _name = _saveLabel(parentNode, node, label);
+            ens.setSubnodeOwner(parentNode, labelhash, address(this));
+
+            _mintWithData(node, owner, fuses, expiry, nodeOwner, nodeFuses, oldExpiry);
             emit NameWrapped(node, _name, owner, fuses, expiry);
 
         } else {

--- a/contracts/wrapper/NameWrapper.sol
+++ b/contracts/wrapper/NameWrapper.sol
@@ -543,7 +543,7 @@ contract NameWrapper is
             revert Unauthorised(parentNode, msg.sender);
         }
 
-        canCallSetSubnodeOwnerFunc(parentNode, labelhash);
+        canCallSetSubnodeOwnerFunc(node, parentNode);
 
         bytes memory _name = _saveLabel(parentNode, node, label);
 
@@ -724,8 +724,7 @@ contract NameWrapper is
         _;
     }
 
-    function canCallSetSubnodeOwnerFunc(bytes32 parentNode, bytes32 labelhash) private view {
-        bytes32 node = _makeNode(parentNode, labelhash);
+    function canCallSetSubnodeOwnerFunc(bytes32 node, bytes32 parentNode) private view {
         address owner = ens.owner(node);
 
         if (owner == address(0)) {

--- a/contracts/wrapper/NameWrapper.sol
+++ b/contracts/wrapper/NameWrapper.sol
@@ -529,15 +529,15 @@ contract NameWrapper is
         bytes32 labelhash = keccak256(bytes(label));
         node = _makeNode(parentNode, labelhash);
 
+        (, , uint64 oldExpiry) = getData(uint256(node));
+        (, uint32 parentFuses, uint64 maxExpiry) = getData(uint256(parentNode));
+
         onlyTokenOwnerFunc(parentNode);
 
         canCallSetSubnodeOwnerFunc(parentNode, labelhash);
 
         _checkFusesAreSettable(node, fuses);
         bytes memory _name = _saveLabel(parentNode, node, label);
-        
-        (, , uint64 oldExpiry) = getData(uint256(node));
-        (, uint32 parentFuses, uint64 maxExpiry) = getData(uint256(parentNode));
 
         _checkParentFuses(node, fuses, parentFuses);
         expiry = _normaliseExpiry(expiry, oldExpiry, maxExpiry);

--- a/contracts/wrapper/NameWrapper.sol
+++ b/contracts/wrapper/NameWrapper.sol
@@ -533,14 +533,16 @@ contract NameWrapper is
         _checkFusesAreSettable(node, fuses);
 
         // Get the node data and parentNode data.
+        // Note: in order to save stack space we call the parent owner baseOwner
+        // We will use baseOwner for another purpose later. 
         (, uint32 nodeFuses, uint64 oldExpiry) = getData(uint256(node));
-        (address parentOwner, uint32 parentFuses, uint64 parentExpiry) = getData(uint256(parentNode));
+        (address baseOwner, uint32 parentFuses, uint64 parentExpiry) = getData(uint256(parentNode));
 
         // Set the expiry between the old expiry and the parentExpiry.
         expiry = _normaliseExpiry(expiry, oldExpiry, parentExpiry);
 
         // Make sure the caller is the parent owner or approved, and the parent name is not expired. 
-        if ((parentOwner != msg.sender && !isApprovedForAll(parentOwner, msg.sender)) || 
+        if ((baseOwner != msg.sender && !isApprovedForAll(baseOwner, msg.sender)) || 
             (parentFuses & IS_DOT_ETH != 0 && parentExpiry - GRACE_PERIOD < block.timestamp)
             ) {
             revert Unauthorised(parentNode, msg.sender);
@@ -548,18 +550,35 @@ contract NameWrapper is
 
         //canCallSetSubnodeOwnerFunc(node, nodeFuses, parentFuses);
 
-        //This is a hack!!!!!!
         // We are no longer using the parent owner 
-        // so we can set it to the registry owner to save a new stack row. 
-        parentOwner = ens.owner(node);
+        // so we now can set it to the registry owner to save stack space. 
+        baseOwner = ens.owner(node);
 
-        if (parentOwner == address(0)) {
+        // If the name does not exist in the registery, check to see
+        // if it can be created. If it does exist, then check to see
+        // if it has been wrapped.   
+        if (baseOwner == address(0)) {
+            
             if (parentFuses & CANNOT_CREATE_SUBDOMAIN != 0) {
                 revert OperationProhibited(node);
             }
+
+            bytes memory _name = _saveLabel(parentNode, node, label);
+            ens.setSubnodeOwner(parentNode, labelhash, address(this));
+            _wrap(node, _name, owner, fuses, expiry);
+
         } else {
+
             if (nodeFuses & PARENT_CANNOT_CONTROL != 0) {
                 revert OperationProhibited(node);
+            }
+            
+            if (ownerOf(uint256(node)) == address(0)) {
+                bytes memory _name = _saveLabel(parentNode, node, label);
+                ens.setSubnodeOwner(parentNode, labelhash, address(this));
+                _wrap(node, _name, owner, fuses, expiry);
+            } else {
+                _updateName(parentNode, node, label, owner, fuses, expiry);
             }
         }
 
@@ -569,15 +588,6 @@ contract NameWrapper is
         // CANNOT_UNWRAP is burned in the fuses of the parent node. 
         //_checkParentFuses(node, fuses, parentFuses);
 
-
-
-        if (ownerOf(uint256(node)) == address(0)) {
-            bytes memory _name = _saveLabel(parentNode, node, label);
-            ens.setSubnodeOwner(parentNode, labelhash, address(this));
-            _wrap(node, _name, owner, fuses, expiry);
-        } else {
-            _updateName(parentNode, node, label, owner, fuses, expiry);
-        }
     }
 
     /**

--- a/contracts/wrapper/NameWrapper.sol
+++ b/contracts/wrapper/NameWrapper.sol
@@ -587,7 +587,8 @@ contract NameWrapper is
             // If the name is not wrapped, then register the name and wrap it. 
             if (ownerOf(uint256(node)) == address(0)) {
                 ens.setSubnodeOwner(parentNode, labelhash, address(this));
-                _wrap(node, bytes(label), owner, fuses, expiry);
+                _mint(node, owner, fuses, expiry);
+                emit NameWrapped(node, bytes(label), owner, fuses, expiry);
             } else {
                 // If the name was wrapped, then just update the data.   
 

--- a/contracts/wrapper/NameWrapper.sol
+++ b/contracts/wrapper/NameWrapper.sol
@@ -524,7 +524,7 @@ contract NameWrapper is
         bytes32 labelhash = keccak256(bytes(label));
         node = _makeNode(parentNode, labelhash);
 
-        // Make sure that only owner controlled fuses are being set. 
+        // Make sure that IS_DOT_ETH is not part of the fuses. 
         _checkFusesAreSettable(node, fuses);
 
         // Get the node data and parentNode data.
@@ -532,6 +532,12 @@ contract NameWrapper is
         // We will use baseOwner for another purpose later. 
         (, uint32 nodeFuses, uint64 oldExpiry) = getData(uint256(node));
         (address baseOwner, uint32 parentFuses, uint64 parentExpiry) = getData(uint256(parentNode));
+
+        // If parent controlled fuses in the node are being set, make sure 
+        // CANNOT_UNWRAP is burned in the fuses of the parent node. 
+        if (fuses & PARENT_CONTROLLED_FUSES != 0 && parentFuses & CANNOT_UNWRAP == 0) {
+            revert OperationProhibited(node);
+        }
 
         // Set the expiry between the old expiry and the parentExpiry.
         expiry = _normaliseExpiry(expiry, oldExpiry, parentExpiry);

--- a/contracts/wrapper/NameWrapper.sol
+++ b/contracts/wrapper/NameWrapper.sol
@@ -937,12 +937,10 @@ contract NameWrapper is
         uint32 fuses,
         uint32 parentFuses
     ) internal pure {
-        bool isBurningParentControlledFuses = fuses & PARENT_CONTROLLED_FUSES !=
-            0;
 
-        bool parentHasNotBurnedCU = parentFuses & CANNOT_UNWRAP == 0;
-
-        if (isBurningParentControlledFuses && parentHasNotBurnedCU) {
+        // If parent controlled fuses in the node are being set, make sure 
+        // CANNOT_UNWRAP is burned in the fuses of the parent node. 
+        if (fuses & PARENT_CONTROLLED_FUSES != 0 && parentFuses & CANNOT_UNWRAP == 0) {
             revert OperationProhibited(node);
         }
     }

--- a/contracts/wrapper/NameWrapper.sol
+++ b/contracts/wrapper/NameWrapper.sol
@@ -543,7 +543,7 @@ contract NameWrapper is
             revert Unauthorised(parentNode, msg.sender);
         }
 
-        canCallSetSubnodeOwnerFunc(node, parentNode);
+        canCallSetSubnodeOwnerFunc(node, parentNode, parentFuses);
 
         bytes memory _name = _saveLabel(parentNode, node, label);
 
@@ -724,12 +724,11 @@ contract NameWrapper is
         _;
     }
 
-    function canCallSetSubnodeOwnerFunc(bytes32 node, bytes32 parentNode) private view {
+    function canCallSetSubnodeOwnerFunc(bytes32 node, bytes32 parentNode, uint32 parentFuses) private view {
         address owner = ens.owner(node);
 
         if (owner == address(0)) {
-            (, uint32 fuses, ) = getData(uint256(parentNode));
-            if (fuses & CANNOT_CREATE_SUBDOMAIN != 0) {
+            if (parentFuses & CANNOT_CREATE_SUBDOMAIN != 0) {
                 revert OperationProhibited(node);
             }
         } else {

--- a/contracts/wrapper/NameWrapper.sol
+++ b/contracts/wrapper/NameWrapper.sol
@@ -570,7 +570,7 @@ contract NameWrapper is
             bytes memory _name = _saveLabel(parentNode, node, label);
             ens.setSubnodeOwner(parentNode, labelhash, address(this));
 
-            _mintWithData(node, owner, fuses, expiry, nodeOwner, nodeFuses, oldExpiry);
+            _mintWithDataForUnwrappedNames(node, owner, fuses, expiry, nodeFuses, oldExpiry);
             emit NameWrapped(node, _name, owner, fuses, expiry);
 
         } else {
@@ -587,7 +587,7 @@ contract NameWrapper is
             // If the name is not wrapped, then register the name and wrap it. 
             if (nodeOwner == address(0)) {
                 ens.setSubnodeOwner(parentNode, labelhash, address(this));
-                _mintWithData(node, owner, fuses, expiry, nodeOwner, nodeFuses, oldExpiry);
+                _mintWithDataForUnwrappedNames(node, owner, fuses, expiry, nodeFuses, oldExpiry);
                 emit NameWrapped(node, bytes(label), owner, fuses, expiry);
             } else {
                 // If the name was wrapped, then just update the data.   

--- a/contracts/wrapper/NameWrapper.sol
+++ b/contracts/wrapper/NameWrapper.sol
@@ -526,6 +526,8 @@ contract NameWrapper is
         public
         returns (bytes32 node)
     {
+
+        // Make the labelhash and node.
         bytes32 labelhash = keccak256(bytes(label));
         node = _makeNode(parentNode, labelhash);
 
@@ -533,7 +535,7 @@ contract NameWrapper is
         _checkFusesAreSettable(node, fuses);
 
         // Get the node data and parentNode data.
-        // Note: in order to save stack space we call the parent owner baseOwner
+        // Notice: in order to save stack space we call the parent owner baseOwner.
         // We will use baseOwner for another purpose later. 
         (, uint32 nodeFuses, uint64 oldExpiry) = getData(uint256(node));
         (address baseOwner, uint32 parentFuses, uint64 parentExpiry) = getData(uint256(parentNode));
@@ -548,9 +550,7 @@ contract NameWrapper is
             revert Unauthorised(parentNode, msg.sender);
         }
 
-        //canCallSetSubnodeOwnerFunc(node, nodeFuses, parentFuses);
-
-        // We are no longer using the parent owner 
+        // We are no longer using the parent owner (baseOwner)
         // so we now can set it to the registry owner to save stack space. 
         baseOwner = ens.owner(node);
 
@@ -558,26 +558,33 @@ contract NameWrapper is
         // if it can be created. If it does exist, then check to see
         // if it has been wrapped.   
         if (baseOwner == address(0)) {
-            
+
+            // Check to make sure CANNOT_CREATE_SUBDOMAIN is not set.
             if (parentFuses & CANNOT_CREATE_SUBDOMAIN != 0) {
                 revert OperationProhibited(node);
             }
 
+            // If we pass all the checks, register the subname and wrap it. 
             bytes memory _name = _saveLabel(parentNode, node, label);
             ens.setSubnodeOwner(parentNode, labelhash, address(this));
             _wrap(node, _name, owner, fuses, expiry);
 
         } else {
 
+            // If the name does exist in the registry check to make sure that 
+            // PARENT_CANNOT_CONTROL has not been burned.  
             if (nodeFuses & PARENT_CANNOT_CONTROL != 0) {
                 revert OperationProhibited(node);
             }
-            
+
+            // If the name is not wrapped, then register the name and wrap it. 
             if (ownerOf(uint256(node)) == address(0)) {
                 bytes memory _name = _saveLabel(parentNode, node, label);
                 ens.setSubnodeOwner(parentNode, labelhash, address(this));
                 _wrap(node, _name, owner, fuses, expiry);
             } else {
+
+                // If the name was wrapped, then just update the data.   
                 _updateName(parentNode, node, label, owner, fuses, expiry);
             }
         }

--- a/contracts/wrapper/NameWrapper.sol
+++ b/contracts/wrapper/NameWrapper.sol
@@ -530,7 +530,7 @@ contract NameWrapper is
         // Get the node data and parentNode data.
         // Notice: in order to save stack space we call the parent owner baseOwner.
         // We will use baseOwner for another purpose later. 
-        (, uint32 nodeFuses, uint64 oldExpiry) = getData(uint256(node));
+        (address nodeOwner, uint32 nodeFuses, uint64 oldExpiry) = getData(uint256(node));
         (address baseOwner, uint32 parentFuses, uint64 parentExpiry) = getData(uint256(parentNode));
 
         // If parent controlled fuses in the node are being set, make sure 
@@ -576,17 +576,31 @@ contract NameWrapper is
                 revert OperationProhibited(node);
             }
 
+            //Notice: In order to limit the stack heigh we are temporaily using label as "name"
+            label = string(_saveLabel(parentNode, node, label));
+
             // If the name is not wrapped, then register the name and wrap it. 
             if (ownerOf(uint256(node)) == address(0)) {
-                //Notice: In order to limit the stack heigh we are temporaily using label as "name"
-                //label = string(_addLabel(label, names[parentNode]));
-                label = string(_saveLabel(parentNode, node, label));
                 ens.setSubnodeOwner(parentNode, labelhash, address(this));
                 _wrap(node, bytes(label), owner, fuses, expiry);
             } else {
-
                 // If the name was wrapped, then just update the data.   
-                _updateName(parentNode, node, label, owner, fuses, expiry);
+
+                // If the name is not already set then set it.
+                if (names[node].length == 0) {
+                    names[node] = bytes(label);
+                }
+
+                // Set the fuses.
+                _setFuses(node, nodeOwner, fuses, expiry);
+
+                //If the owner is set to the 0 address then unwrap the name
+                // and if not then transfer the name to the new owner.
+                if (owner == address(0)) {
+                    _unwrap(node, address(0));
+                } else {
+                    _transfer(nodeOwner, owner, uint256(node), 1, "");
+                }
             }
         }
     }

--- a/contracts/wrapper/NameWrapper.sol
+++ b/contracts/wrapper/NameWrapper.sol
@@ -543,7 +543,7 @@ contract NameWrapper is
             revert Unauthorised(parentNode, msg.sender);
         }
 
-        canCallSetSubnodeOwnerFunc(node, parentNode, parentFuses);
+        canCallSetSubnodeOwnerFunc(node, nodeFuses, parentNode, parentFuses);
 
         bytes memory _name = _saveLabel(parentNode, node, label);
 
@@ -724,7 +724,7 @@ contract NameWrapper is
         _;
     }
 
-    function canCallSetSubnodeOwnerFunc(bytes32 node, bytes32 parentNode, uint32 parentFuses) private view {
+    function canCallSetSubnodeOwnerFunc(bytes32 node, uint32 nodeFuses, bytes32 parentNode, uint32 parentFuses) private view {
         address owner = ens.owner(node);
 
         if (owner == address(0)) {
@@ -732,8 +732,7 @@ contract NameWrapper is
                 revert OperationProhibited(node);
             }
         } else {
-            (, uint32 subnodeFuses, ) = getData(uint256(node));
-            if (subnodeFuses & PARENT_CANNOT_CONTROL != 0) {
+            if (nodeFuses & PARENT_CANNOT_CONTROL != 0) {
                 revert OperationProhibited(node);
             }
         }

--- a/contracts/wrapper/NameWrapper.sol
+++ b/contracts/wrapper/NameWrapper.sol
@@ -532,7 +532,9 @@ contract NameWrapper is
         (, , uint64 oldExpiry) = getData(uint256(node));
         (, uint32 parentFuses, uint64 maxExpiry) = getData(uint256(parentNode));
 
-        onlyTokenOwnerFunc(parentNode);
+        if (!canModifyName(parentNode, msg.sender)) {
+            revert Unauthorised(parentNode, msg.sender);
+        }
 
         canCallSetSubnodeOwnerFunc(parentNode, labelhash);
 

--- a/test/wrapper/NameWrapper.js
+++ b/test/wrapper/NameWrapper.js
@@ -3343,6 +3343,52 @@ describe('Name Wrapper', () => {
       ).to.be.revertedWith(`OperationProhibited("${subWrappedTokenId}")`)
     })
 
+    it('Unwrapping a previously wrapped unexpired name retains parent controlled fuses', async () => {
+      const label = 'test'
+      const labelHash = labelhash(label)
+      const wrappedTokenId = namehash(label + '.eth')
+      const subLabel = 'sub'
+      const subLabelHash = labelhash(subLabel)
+      const subWrappedTokenId = namehash(`${subLabel}.${label}.eth`)
+      await registerSetupAndWrapName(label, account, CANNOT_UNWRAP)
+      // Confirm that the name is wrapped
+
+      const parentExpiry = await BaseRegistrar.nameExpires(labelHash)
+      expect(await NameWrapper.ownerOf(wrappedTokenId)).to.equal(account)
+      // NameWrapper.setSubnodeOwner to account2
+      await NameWrapper.setSubnodeOwner(
+        wrappedTokenId,
+        subLabel,
+        account2,
+        IS_DOT_ETH*2,
+        MAX_EXPIRY,
+      )
+      // Confirm fuses are set
+      const [, fusesBefore] = await NameWrapper.getData(subWrappedTokenId)
+      expect(fusesBefore).to.equal(IS_DOT_ETH*2)
+
+      await NameWrapper.setSubnodeOwner(
+        wrappedTokenId,
+        subLabel,
+        EMPTY_ADDRESS,
+        0,
+        0,
+      )
+      const [owner] = await NameWrapper.getData(subWrappedTokenId)
+      expect(owner).to.equal(EMPTY_ADDRESS)
+
+      await NameWrapper.setSubnodeOwner(
+        wrappedTokenId,
+        subLabel,
+        account2,
+        0,
+        0,
+      )
+      let[newOwner, newFuses] = await NameWrapper.getData(subWrappedTokenId)
+      expect(newOwner).to.equal(account2)
+      expect(newFuses).to.equal(IS_DOT_ETH*2)
+    })
+
     it('Rewrapping a name that had PCC burned, but has now expired is possible and resets fuses', async () => {
       const label = 'test'
       const labelHash = labelhash(label)


### PR DESCRIPTION
This is a complete rewrite of the setSubnodeOwner function. The gas use is reduced by omitting redundant calls and other optimizations. 

min          max            average
60391  ·     131996  ·      123610
54530  ·     125378  ·      117276
(-5,861)     (-6,618)       (-6334)