### PR TITLE
do preTransferCheck when owner != wrappedOwner on upgrade

### DIFF
--- a/contracts/wrapper/NameWrapper.sol
+++ b/contracts/wrapper/NameWrapper.sol
@@ -129,7 +129,9 @@ contract NameWrapper is
 
         bytes32 labelhash = _getEthLabelhash(bytes32(id), fuses);
         if (labelhash != bytes32(0)) {
-            expiry = uint64(registrar.nameExpires(uint256(labelhash))) + GRACE_PERIOD;
+            expiry =
+                uint64(registrar.nameExpires(uint256(labelhash))) +
+                GRACE_PERIOD;
         }
 
         if (expiry < block.timestamp) {
@@ -215,7 +217,10 @@ contract NameWrapper is
         returns (bool)
     {
         (address owner, uint32 fuses, uint64 expiry) = getData(uint256(node));
-        return (owner == addr || isApprovedForAll(owner, addr)) && (fuses & IS_DOT_ETH == 0 || expiry - GRACE_PERIOD >= block.timestamp);
+        return
+            (owner == addr || isApprovedForAll(owner, addr)) &&
+            (fuses & IS_DOT_ETH == 0 ||
+                expiry - GRACE_PERIOD >= block.timestamp);
     }
 
     /**
@@ -285,10 +290,12 @@ contract NameWrapper is
      * @return expires The expiry date of the name on the .eth registrar, in seconds since the Unix epoch.
      */
 
-    function renew(
-        uint256 tokenId,
-        uint256 duration
-    ) external override onlyController returns (uint256 expires) {
+    function renew(uint256 tokenId, uint256 duration)
+        external
+        override
+        onlyController
+        returns (uint256 expires)
+    {
         return registrar.renew(tokenId, duration);
     }
 
@@ -412,7 +419,13 @@ contract NameWrapper is
     ) public {
         bytes32 labelhash = keccak256(bytes(label));
         bytes32 node = _makeNode(ETH_NODE, labelhash);
-        (uint32 fuses, uint64 expiry) = _prepareUpgrade(node);
+        (address currentOwner, uint32 fuses, uint64 expiry) = _prepareUpgrade(
+            node
+        );
+
+        if (wrappedOwner != currentOwner) {
+            _preTransferCheck(uint256(node), fuses, expiry);
+        }
 
         upgradeContract.wrapETH2LD(
             label,
@@ -441,7 +454,14 @@ contract NameWrapper is
     ) public {
         bytes32 labelhash = keccak256(bytes(label));
         bytes32 node = _makeNode(parentNode, labelhash);
-        (uint32 fuses, uint64 expiry) = _prepareUpgrade(node);
+        (address currentOwner, uint32 fuses, uint64 expiry) = _prepareUpgrade(
+            node
+        );
+
+        if (wrappedOwner != currentOwner) {
+            _preTransferCheck(uint256(node), fuses, expiry);
+        }
+
         upgradeContract.setSubnodeRecord(
             parentNode,
             label,
@@ -469,11 +489,11 @@ contract NameWrapper is
     ) public {
         bytes32 node = _makeNode(parentNode, labelhash);
         _checkFusesAreSettable(node, fuses);
-        (address owner, uint32 oldFuses, uint64 oldExpiry) = getData(uint256(node));
-        // max expiry is set to the expiry of the parent
-        (, uint32 parentFuses, uint64 maxExpiry) = getData(
-            uint256(parentNode)
+        (address owner, uint32 oldFuses, uint64 oldExpiry) = getData(
+            uint256(node)
         );
+        // max expiry is set to the expiry of the parent
+        (, uint32 parentFuses, uint64 maxExpiry) = getData(uint256(parentNode));
         if (parentNode == ROOT_NODE) {
             if (!canModifyName(node, msg.sender)) {
                 revert Unauthorised(node, msg.sender);
@@ -747,20 +767,24 @@ contract NameWrapper is
 
     /***** Internal functions */
 
-    function _preTransferCheck(uint256 id, uint32 fuses, uint64 expiry) internal view override returns (bool) {
+    function _preTransferCheck(
+        uint256 id,
+        uint32 fuses,
+        uint64 expiry
+    ) internal view override returns (bool) {
         // For this check, treat .eth 2LDs as expiring at the start of the grace period.
-        if(fuses & IS_DOT_ETH == IS_DOT_ETH) {
+        if (fuses & IS_DOT_ETH == IS_DOT_ETH) {
             expiry -= GRACE_PERIOD;
         }
 
-        if(expiry < block.timestamp) {
+        if (expiry < block.timestamp) {
             // Transferable if the name was not emancipated
-            if(fuses & PARENT_CANNOT_CONTROL != 0) {
+            if (fuses & PARENT_CANNOT_CONTROL != 0) {
                 revert("ERC1155: insufficient balance for transfer");
             }
         } else {
             // Transferable if CANNOT_TRANSFER is unburned
-            if(fuses & CANNOT_TRANSFER != 0) {
+            if (fuses & CANNOT_TRANSFER != 0) {
                 revert OperationProhibited(bytes32(id));
             }
         }
@@ -839,7 +863,11 @@ contract NameWrapper is
 
     function _prepareUpgrade(bytes32 node)
         private
-        returns (uint32 fuses, uint64 expiry)
+        returns (
+            address owner,
+            uint32 fuses,
+            uint64 expiry
+        )
     {
         if (address(upgradeContract) == address(0)) {
             revert CannotUpgrade();
@@ -849,7 +877,7 @@ contract NameWrapper is
             revert Unauthorised(node, msg.sender);
         }
 
-        (, fuses, expiry) = getData(uint256(node));
+        (owner, fuses, expiry) = getData(uint256(node));
 
         _burn(uint256(node));
     }
@@ -883,9 +911,7 @@ contract NameWrapper is
         uint64 expiry
     ) internal view returns (uint64) {
         (, , uint64 oldExpiry) = getData(uint256(node));
-        (, uint32 parentFuses, uint64 maxExpiry) = getData(
-            uint256(parentNode)
-        );
+        (, uint32 parentFuses, uint64 maxExpiry) = getData(uint256(parentNode));
         _checkParentFuses(node, fuses, parentFuses);
         return _normaliseExpiry(expiry, oldExpiry, maxExpiry);
     }
@@ -935,7 +961,8 @@ contract NameWrapper is
         bytes memory name = _addLabel(label, "\x03eth\x00");
         names[node] = name;
 
-        uint64 expiry = uint64(registrar.nameExpires(uint256(labelhash))) + GRACE_PERIOD;
+        uint64 expiry = uint64(registrar.nameExpires(uint256(labelhash))) +
+            GRACE_PERIOD;
 
         _wrap(
             node,


### PR DESCRIPTION
Checks for `CANNOT_TRANSFER` fuse when upgrading if `owner != newOwner`

Fixes: https://github.com/code-423n4/2022-11-ens-findings/issues/6