### PR TITLE
Refactor of SetSubnodeOwner including rebase of PR #159

### DIFF
--- a/contracts/wrapper/INameWrapper.sol
+++ b/contracts/wrapper/INameWrapper.sol
@@ -109,7 +109,7 @@ interface INameWrapper is IERC1155 {
 
     function setSubnodeOwner(
         bytes32 node,
-        string calldata label,
+        string memory label,
         address newOwner,
         uint32 fuses,
         uint64 expiry

--- a/contracts/wrapper/NameWrapper.sol
+++ b/contracts/wrapper/NameWrapper.sol
@@ -540,15 +540,15 @@ contract NameWrapper is
         bytes32 labelhash = keccak256(bytes(label));
         node = _makeNode(parentNode, labelhash);
 
+        (, , uint64 oldExpiry) = getData(uint256(node));
+        (, uint32 parentFuses, uint64 maxExpiry) = getData(uint256(parentNode));
+
         onlyTokenOwnerFunc(parentNode);
 
         canCallSetSubnodeOwnerFunc(parentNode, labelhash);
 
         _checkFusesAreSettable(node, fuses);
         bytes memory _name = _saveLabel(parentNode, node, label);
-        
-        (, , uint64 oldExpiry) = getData(uint256(node));
-        (, uint32 parentFuses, uint64 maxExpiry) = getData(uint256(parentNode));
 
         _checkParentFuses(node, fuses, parentFuses);
         expiry = _normaliseExpiry(expiry, oldExpiry, maxExpiry);

--- a/contracts/wrapper/NameWrapper.sol
+++ b/contracts/wrapper/NameWrapper.sol
@@ -554,7 +554,7 @@ contract NameWrapper is
             revert Unauthorised(parentNode, msg.sender);
         }
 
-        canCallSetSubnodeOwnerFunc(node, nodeFuses, parentNode, parentFuses);
+        canCallSetSubnodeOwnerFunc(node, nodeFuses, parentFuses);
 
         bytes memory _name = _saveLabel(parentNode, node, label);
 
@@ -735,7 +735,7 @@ contract NameWrapper is
         _;
     }
 
-    function canCallSetSubnodeOwnerFunc(bytes32 node, uint32 nodeFuses, bytes32 parentNode, uint32 parentFuses) private view {
+    function canCallSetSubnodeOwnerFunc(bytes32 node, uint32 nodeFuses, uint32 parentFuses) private view {
         address owner = ens.owner(node);
 
         if (owner == address(0)) {

--- a/contracts/wrapper/NameWrapper.sol
+++ b/contracts/wrapper/NameWrapper.sol
@@ -522,7 +522,7 @@ contract NameWrapper is
 
     function setSubnodeOwner(
         bytes32 parentNode,
-        string calldata label,
+        string memory label,
         address owner,
         uint32 fuses,
         uint64 expiry
@@ -589,9 +589,11 @@ contract NameWrapper is
 
             // If the name is not wrapped, then register the name and wrap it. 
             if (!isWrapped(node)) {
-                bytes memory _name = _saveLabel(parentNode, node, label);
+                //Notice: In order to limit the stack heigh we are temporaily using label as "name"
+                //label = string(_addLabel(label, names[parentNode]));
+                label = string(_saveLabel(parentNode, node, label));
                 ens.setSubnodeOwner(parentNode, labelhash, address(this));
-                _wrap(node, _name, owner, fuses, expiry);
+                _wrap(node, bytes(label), owner, fuses, expiry);
             } else {
 
                 // If the name was wrapped, then just update the data.   

--- a/contracts/wrapper/NameWrapper.sol
+++ b/contracts/wrapper/NameWrapper.sol
@@ -598,7 +598,8 @@ contract NameWrapper is
             // If the name is not wrapped, then register the name and wrap it. 
             if (!isWrapped(node)) {
                 ens.setSubnodeOwner(parentNode, labelhash, address(this));
-                _wrap(node, bytes(label), owner, fuses, expiry);
+                _mint(node, owner, fuses, expiry);
+                emit NameWrapped(node, bytes(label), owner, fuses, expiry);
             } else {
                 // If the name was wrapped, then just update the data.   
 

--- a/contracts/wrapper/NameWrapper.sol
+++ b/contracts/wrapper/NameWrapper.sol
@@ -592,13 +592,6 @@ contract NameWrapper is
                 _updateName(parentNode, node, label, owner, fuses, expiry);
             }
         }
-
-        // NTS: I don't think this function is necessary since only owner controled fuses 
-        // are allowed to be set. 
-        // If parent controlled fuses in the node are being set, make sure 
-        // CANNOT_UNWRAP is burned in the fuses of the parent node. 
-        //_checkParentFuses(node, fuses, parentFuses);
-
     }
 
     /**

--- a/contracts/wrapper/NameWrapper.sol
+++ b/contracts/wrapper/NameWrapper.sol
@@ -543,7 +543,9 @@ contract NameWrapper is
         (, , uint64 oldExpiry) = getData(uint256(node));
         (, uint32 parentFuses, uint64 maxExpiry) = getData(uint256(parentNode));
 
-        onlyTokenOwnerFunc(parentNode);
+        if (!canModifyName(parentNode, msg.sender)) {
+            revert Unauthorised(parentNode, msg.sender);
+        }
 
         canCallSetSubnodeOwnerFunc(parentNode, labelhash);
 

--- a/contracts/wrapper/NameWrapper.sol
+++ b/contracts/wrapper/NameWrapper.sol
@@ -573,13 +573,13 @@ contract NameWrapper is
                 revert OperationProhibited(node);
             }
 
-            // If we pass all the checks, register the subname and wrap it. 
-            bytes memory _name = _saveLabel(parentNode, node, label);
-            ens.setSubnodeOwner(parentNode, labelhash, address(this));
-
             // If a owner controlled fuse are being burned, check to make sure 
             // PARENT_CANNOT_CONTROL and CANNOT_UNWRAP have been burned. 
             _canFusesBeBurned(node, fuses);
+
+            // If we pass all the checks, register the subname and wrap it. 
+            bytes memory _name = _saveLabel(parentNode, node, label);
+            ens.setSubnodeOwner(parentNode, labelhash, address(this));
 
             super._mint(node, owner, fuses, expiry);
             emit NameWrapped(node, _name, owner, fuses, expiry);

--- a/contracts/wrapper/NameWrapper.sol
+++ b/contracts/wrapper/NameWrapper.sol
@@ -535,23 +535,23 @@ contract NameWrapper is
         bytes32 labelhash = keccak256(bytes(label));
         node = _makeNode(parentNode, labelhash);
 
-        // Make sure that IS_DOT_ETH is not part of the fuses. 
-        _checkFusesAreSettable(node, fuses);
-
         // Get the node data and parentNode data.
         // Notice: in order to save stack space we call the parent owner baseOwner.
         // We will use baseOwner for another purpose later. 
         (address nodeOwner, uint32 nodeFuses, uint64 oldExpiry) = getData(uint256(node));
         (address baseOwner, uint32 parentFuses, uint64 parentExpiry) = getData(uint256(parentNode));
 
+        // Set the expiry between the old expiry and the parentExpiry.
+        expiry = _normaliseExpiry(expiry, oldExpiry, parentExpiry);
+
+        // Make sure that IS_DOT_ETH is not part of the fuses. 
+        _checkFusesAreSettable(node, fuses);
+
         // If parent controlled fuses in the node are being set, make sure CANNOT_UNWRAP
         // is burned in the fuses of the parent node. 
         if (fuses & PARENT_CONTROLLED_FUSES != 0 && parentFuses & CANNOT_UNWRAP == 0) {
             revert OperationProhibited(node);
         }
-
-        // Set the expiry between the old expiry and the parentExpiry.
-        expiry = _normaliseExpiry(expiry, oldExpiry, parentExpiry);
 
         // Make sure the caller is the parent owner or approved, and the parent name is not expired. 
         if ((baseOwner != msg.sender && !isApprovedForAll(baseOwner, msg.sender)) || 

--- a/contracts/wrapper/NameWrapper.sol
+++ b/contracts/wrapper/NameWrapper.sol
@@ -529,9 +529,11 @@ contract NameWrapper is
     )
         public
         onlyTokenOwner(parentNode)
-        canCallSetSubnodeOwner(parentNode, keccak256(bytes(label)))
         returns (bytes32 node)
     {
+
+        canCallSetSubnodeOwnerFunc(parentNode, keccak256(bytes(label)));
+
         bytes32 labelhash = keccak256(bytes(label));
         node = _makeNode(parentNode, labelhash);
         _checkFusesAreSettable(node, fuses);
@@ -704,6 +706,24 @@ contract NameWrapper is
         }
 
         _;
+    }
+
+    function canCallSetSubnodeOwnerFunc(bytes32 parentNode, bytes32 labelhash) private view {
+        bytes32 node = _makeNode(parentNode, labelhash);
+        address owner = ens.owner(node);
+
+        if (owner == address(0)) {
+            (, uint32 fuses, ) = getData(uint256(parentNode));
+            if (fuses & CANNOT_CREATE_SUBDOMAIN != 0) {
+                revert OperationProhibited(node);
+            }
+        } else {
+            (, uint32 subnodeFuses, ) = getData(uint256(node));
+            if (subnodeFuses & PARENT_CANNOT_CONTROL != 0) {
+                revert OperationProhibited(node);
+            }
+        }
+
     }
 
     /**

--- a/contracts/wrapper/NameWrapper.sol
+++ b/contracts/wrapper/NameWrapper.sol
@@ -554,7 +554,7 @@ contract NameWrapper is
             revert Unauthorised(parentNode, msg.sender);
         }
 
-        canCallSetSubnodeOwnerFunc(node, parentNode, parentFuses);
+        canCallSetSubnodeOwnerFunc(node, nodeFuses, parentNode, parentFuses);
 
         bytes memory _name = _saveLabel(parentNode, node, label);
 
@@ -735,7 +735,7 @@ contract NameWrapper is
         _;
     }
 
-    function canCallSetSubnodeOwnerFunc(bytes32 node, bytes32 parentNode, uint32 parentFuses) private view {
+    function canCallSetSubnodeOwnerFunc(bytes32 node, uint32 nodeFuses, bytes32 parentNode, uint32 parentFuses) private view {
         address owner = ens.owner(node);
 
         if (owner == address(0)) {
@@ -743,8 +743,7 @@ contract NameWrapper is
                 revert OperationProhibited(node);
             }
         } else {
-            (, uint32 subnodeFuses, ) = getData(uint256(node));
-            if (subnodeFuses & PARENT_CANNOT_CONTROL != 0) {
+            if (nodeFuses & PARENT_CANNOT_CONTROL != 0) {
                 revert OperationProhibited(node);
             }
         }

--- a/contracts/wrapper/NameWrapper.sol
+++ b/contracts/wrapper/NameWrapper.sol
@@ -956,12 +956,10 @@ contract NameWrapper is
         uint32 fuses,
         uint32 parentFuses
     ) internal pure {
-        bool isBurningParentControlledFuses = fuses & PARENT_CONTROLLED_FUSES !=
-            0;
 
-        bool parentHasNotBurnedCU = parentFuses & CANNOT_UNWRAP == 0;
-
-        if (isBurningParentControlledFuses && parentHasNotBurnedCU) {
+        // If parent controlled fuses in the node are being set, make sure 
+        // CANNOT_UNWRAP is burned in the fuses of the parent node. 
+        if (fuses & PARENT_CONTROLLED_FUSES != 0 && parentFuses & CANNOT_UNWRAP == 0) {
             revert OperationProhibited(node);
         }
     }

--- a/contracts/wrapper/NameWrapper.sol
+++ b/contracts/wrapper/NameWrapper.sol
@@ -204,6 +204,13 @@ contract NameWrapper is
         _;
     }
 
+    function onlyTokenOwnerFunc(bytes32 node) private view{
+        if (!canModifyName(node, msg.sender)) {
+            revert Unauthorised(node, msg.sender);
+        }
+
+    }
+
     /**
      * @notice Checks if owner or approved by owner
      * @param node namehash of the name to check
@@ -528,14 +535,15 @@ contract NameWrapper is
         uint64 expiry
     )
         public
-        onlyTokenOwner(parentNode)
         returns (bytes32 node)
     {
-
-        canCallSetSubnodeOwnerFunc(parentNode, keccak256(bytes(label)));
-
         bytes32 labelhash = keccak256(bytes(label));
         node = _makeNode(parentNode, labelhash);
+
+        onlyTokenOwnerFunc(parentNode);
+
+        canCallSetSubnodeOwnerFunc(parentNode, labelhash);
+
         _checkFusesAreSettable(node, fuses);
         bytes memory name = _saveLabel(parentNode, node, label);
         expiry = _checkParentFusesAndExpiry(parentNode, node, fuses, expiry);

--- a/contracts/wrapper/NameWrapper.sol
+++ b/contracts/wrapper/NameWrapper.sol
@@ -535,7 +535,7 @@ contract NameWrapper is
         bytes32 labelhash = keccak256(bytes(label));
         node = _makeNode(parentNode, labelhash);
 
-        // Make sure that only owner controlled fuses are being set. 
+        // Make sure that IS_DOT_ETH is not part of the fuses. 
         _checkFusesAreSettable(node, fuses);
 
         // Get the node data and parentNode data.
@@ -543,6 +543,12 @@ contract NameWrapper is
         // We will use baseOwner for another purpose later. 
         (, uint32 nodeFuses, uint64 oldExpiry) = getData(uint256(node));
         (address baseOwner, uint32 parentFuses, uint64 parentExpiry) = getData(uint256(parentNode));
+
+        // If parent controlled fuses in the node are being set, make sure 
+        // CANNOT_UNWRAP is burned in the fuses of the parent node. 
+        if (fuses & PARENT_CONTROLLED_FUSES != 0 && parentFuses & CANNOT_UNWRAP == 0) {
+            revert OperationProhibited(node);
+        }
 
         // Set the expiry between the old expiry and the parentExpiry.
         expiry = _normaliseExpiry(expiry, oldExpiry, parentExpiry);

--- a/contracts/wrapper/NameWrapper.sol
+++ b/contracts/wrapper/NameWrapper.sol
@@ -581,12 +581,6 @@ contract NameWrapper is
             // PARENT_CANNOT_CONTROL and CANNOT_UNWRAP have been burned. 
             _canFusesBeBurned(node, fuses);
 
-            // If the token was previously wrapped burn it before wrapping again.  
-            if (nodeOwner != address(0)) {
-                // burn and unwrap old token of old owner
-                _burn(uint256(node));
-                emit NameUnwrapped(node, address(0));
-            }
             super._mint(node, owner, fuses, expiry);
             emit NameWrapped(node, _name, owner, fuses, expiry);
 

--- a/contracts/wrapper/NameWrapper.sol
+++ b/contracts/wrapper/NameWrapper.sol
@@ -544,8 +544,8 @@ contract NameWrapper is
         (address nodeOwner, uint32 nodeFuses, uint64 oldExpiry) = getData(uint256(node));
         (address baseOwner, uint32 parentFuses, uint64 parentExpiry) = getData(uint256(parentNode));
 
-        // If parent controlled fuses in the node are being set, make sure 
-        // CANNOT_UNWRAP is burned in the fuses of the parent node. 
+        // If parent controlled fuses in the node are being set, make sure CANNOT_UNWRAP
+        // is burned in the fuses of the parent node. 
         if (fuses & PARENT_CONTROLLED_FUSES != 0 && parentFuses & CANNOT_UNWRAP == 0) {
             revert OperationProhibited(node);
         }
@@ -560,13 +560,12 @@ contract NameWrapper is
             revert Unauthorised(parentNode, msg.sender);
         }
 
-        // We are no longer using the parent owner (baseOwner)
-        // so we now can set it to the registry owner to save stack space. 
+        // We are no longer using the parent owner "baseOwner" so we now
+        // can set it to the registry owner to save stack space. 
         baseOwner = ens.owner(node);
 
-        // If the name does not exist in the registery, check to see
-        // if it can be created. If it does exist, then check to see
-        // if it has been wrapped.   
+        // If the name does not exist in the registery, check to see if it can be 
+        // created. If it does exist, then check to see if it has been wrapped.   
         if (baseOwner == address(0)) {
 
             // Check to make sure CANNOT_CREATE_SUBDOMAIN is not set.
@@ -577,7 +576,19 @@ contract NameWrapper is
             // If we pass all the checks, register the subname and wrap it. 
             bytes memory _name = _saveLabel(parentNode, node, label);
             ens.setSubnodeOwner(parentNode, labelhash, address(this));
-            _wrap(node, _name, owner, fuses, expiry);
+
+            // If a owner controlled fuse are being burned, check to make sure 
+            // PARENT_CANNOT_CONTROL and CANNOT_UNWRAP have been burned. 
+            _canFusesBeBurned(node, fuses);
+
+            // If the token was previously wrapped burn it before wrapping again.  
+            if (nodeOwner != address(0)) {
+                // burn and unwrap old token of old owner
+                _burn(uint256(node));
+                emit NameUnwrapped(node, address(0));
+            }
+            super._mint(node, owner, fuses, expiry);
+            emit NameWrapped(node, _name, owner, fuses, expiry);
 
         } else {
 
@@ -587,7 +598,7 @@ contract NameWrapper is
                 revert OperationProhibited(node);
             }
 
-            //Notice: In order to limit the stack heigh we are temporaily using label as "name"
+            //Notice: In order to limit the stack height we are temporaily using label as "name".
             label = string(_saveLabel(parentNode, node, label));
 
             // If the name is not wrapped, then register the name and wrap it. 
@@ -605,7 +616,7 @@ contract NameWrapper is
                 // Set the fuses.
                 _setFuses(node, nodeOwner, fuses, expiry);
 
-                //If the owner is set to the 0 address then unwrap the name
+                // If the owner is set to the 0 address then unwrap the name
                 // and if not then transfer the name to the new owner.
                 if (owner == address(0)) {
                     _unwrap(node, address(0));
@@ -878,6 +889,7 @@ contract NameWrapper is
         }
         return abi.encodePacked(uint8(bytes(label).length), label, name);
     }
+
 
     function _mint(
         bytes32 node,

--- a/contracts/wrapper/NameWrapper.sol
+++ b/contracts/wrapper/NameWrapper.sol
@@ -22,6 +22,7 @@ error LabelTooLong(string label);
 error IncorrectTargetOwner(address owner);
 error CannotUpgrade();
 error OperationProhibited(bytes32 node);
+error NameIsNotWrapped();
 
 contract NameWrapper is
     Ownable,
@@ -129,7 +130,9 @@ contract NameWrapper is
 
         bytes32 labelhash = _getEthLabelhash(bytes32(id), fuses);
         if (labelhash != bytes32(0)) {
-            expiry = uint64(registrar.nameExpires(uint256(labelhash))) + GRACE_PERIOD;
+            expiry =
+                uint64(registrar.nameExpires(uint256(labelhash))) +
+                GRACE_PERIOD;
         }
 
         if (expiry < block.timestamp) {
@@ -215,7 +218,10 @@ contract NameWrapper is
         returns (bool)
     {
         (address owner, uint32 fuses, uint64 expiry) = getData(uint256(node));
-        return (owner == addr || isApprovedForAll(owner, addr)) && (fuses & IS_DOT_ETH == 0 || expiry - GRACE_PERIOD >= block.timestamp);
+        return
+            (owner == addr || isApprovedForAll(owner, addr)) &&
+            (fuses & IS_DOT_ETH == 0 ||
+                expiry - GRACE_PERIOD >= block.timestamp);
     }
 
     /**
@@ -285,10 +291,12 @@ contract NameWrapper is
      * @return expires The expiry date of the name on the .eth registrar, in seconds since the Unix epoch.
      */
 
-    function renew(
-        uint256 tokenId,
-        uint256 duration
-    ) external override onlyController returns (uint256 expires) {
+    function renew(uint256 tokenId, uint256 duration)
+        external
+        override
+        onlyController
+        returns (uint256 expires)
+    {
         return registrar.renew(tokenId, duration);
     }
 
@@ -469,11 +477,14 @@ contract NameWrapper is
     ) public {
         bytes32 node = _makeNode(parentNode, labelhash);
         _checkFusesAreSettable(node, fuses);
-        (address owner, uint32 oldFuses, uint64 oldExpiry) = getData(uint256(node));
-        // max expiry is set to the expiry of the parent
-        (, uint32 parentFuses, uint64 maxExpiry) = getData(
-            uint256(parentNode)
+        (address owner, uint32 oldFuses, uint64 oldExpiry) = getData(
+            uint256(node)
         );
+        if (owner == address(0) || ens.owner(node) != address(this)) {
+            revert NameIsNotWrapped();
+        }
+        // max expiry is set to the expiry of the parent
+        (, uint32 parentFuses, uint64 maxExpiry) = getData(uint256(parentNode));
         if (parentNode == ROOT_NODE) {
             if (!canModifyName(node, msg.sender)) {
                 revert Unauthorised(node, msg.sender);
@@ -527,7 +538,7 @@ contract NameWrapper is
         bytes memory name = _saveLabel(parentNode, node, label);
         expiry = _checkParentFusesAndExpiry(parentNode, node, fuses, expiry);
 
-        if (ownerOf(uint256(node)) == address(0)) {
+        if (!isWrapped(node)) {
             ens.setSubnodeOwner(parentNode, labelhash, address(this));
             _wrap(node, name, owner, fuses, expiry);
         } else {
@@ -566,7 +577,7 @@ contract NameWrapper is
         _checkFusesAreSettable(node, fuses);
         _saveLabel(parentNode, node, label);
         expiry = _checkParentFusesAndExpiry(parentNode, node, fuses, expiry);
-        if (ownerOf(uint256(node)) == address(0)) {
+        if (!isWrapped(node)) {
             ens.setSubnodeRecord(
                 parentNode,
                 labelhash,
@@ -712,6 +723,12 @@ contract NameWrapper is
         return fuses & fuseMask == fuseMask;
     }
 
+    function isWrapped(bytes32 node) public view returns (bool) {
+        return
+            ownerOf(uint256(node)) != address(0) &&
+            ens.owner(node) == address(this);
+    }
+
     function onERC721Received(
         address to,
         address,
@@ -747,20 +764,24 @@ contract NameWrapper is
 
     /***** Internal functions */
 
-    function _preTransferCheck(uint256 id, uint32 fuses, uint64 expiry) internal view override returns (bool) {
+    function _preTransferCheck(
+        uint256 id,
+        uint32 fuses,
+        uint64 expiry
+    ) internal view override returns (bool) {
         // For this check, treat .eth 2LDs as expiring at the start of the grace period.
-        if(fuses & IS_DOT_ETH == IS_DOT_ETH) {
+        if (fuses & IS_DOT_ETH == IS_DOT_ETH) {
             expiry -= GRACE_PERIOD;
         }
 
-        if(expiry < block.timestamp) {
+        if (expiry < block.timestamp) {
             // Transferable if the name was not emancipated
-            if(fuses & PARENT_CANNOT_CONTROL != 0) {
+            if (fuses & PARENT_CANNOT_CONTROL != 0) {
                 revert("ERC1155: insufficient balance for transfer");
             }
         } else {
             // Transferable if CANNOT_TRANSFER is unburned
-            if(fuses & CANNOT_TRANSFER != 0) {
+            if (fuses & CANNOT_TRANSFER != 0) {
                 revert OperationProhibited(bytes32(id));
             }
         }
@@ -883,9 +904,7 @@ contract NameWrapper is
         uint64 expiry
     ) internal view returns (uint64) {
         (, , uint64 oldExpiry) = getData(uint256(node));
-        (, uint32 parentFuses, uint64 maxExpiry) = getData(
-            uint256(parentNode)
-        );
+        (, uint32 parentFuses, uint64 maxExpiry) = getData(uint256(parentNode));
         _checkParentFuses(node, fuses, parentFuses);
         return _normaliseExpiry(expiry, oldExpiry, maxExpiry);
     }
@@ -935,7 +954,8 @@ contract NameWrapper is
         bytes memory name = _addLabel(label, "\x03eth\x00");
         names[node] = name;
 
-        uint64 expiry = uint64(registrar.nameExpires(uint256(labelhash))) + GRACE_PERIOD;
+        uint64 expiry = uint64(registrar.nameExpires(uint256(labelhash))) +
+            GRACE_PERIOD;
 
         _wrap(
             node,

--- a/contracts/wrapper/NameWrapper.sol
+++ b/contracts/wrapper/NameWrapper.sol
@@ -545,12 +545,18 @@ contract NameWrapper is
         canCallSetSubnodeOwnerFunc(parentNode, labelhash);
 
         _checkFusesAreSettable(node, fuses);
-        bytes memory name = _saveLabel(parentNode, node, label);
-        expiry = _checkParentFusesAndExpiry(parentNode, node, fuses, expiry);
+        bytes memory _name = _saveLabel(parentNode, node, label);
+        
+        (, , uint64 oldExpiry) = getData(uint256(node));
+        (, uint32 parentFuses, uint64 maxExpiry) = getData(uint256(parentNode));
+
+        _checkParentFuses(node, fuses, parentFuses);
+        expiry = _normaliseExpiry(expiry, oldExpiry, maxExpiry);
+
 
         if (!isWrapped(node)) {
             ens.setSubnodeOwner(parentNode, labelhash, address(this));
-            _wrap(node, name, owner, fuses, expiry);
+            _wrap(node, _name, owner, fuses, expiry);
         } else {
             _updateName(parentNode, node, label, owner, fuses, expiry);
         }

--- a/contracts/wrapper/NameWrapper.sol
+++ b/contracts/wrapper/NameWrapper.sol
@@ -556,8 +556,6 @@ contract NameWrapper is
 
         canCallSetSubnodeOwnerFunc(node, nodeFuses, parentFuses);
 
-        bytes memory _name = _saveLabel(parentNode, node, label);
-
         // NTS: I don't think this function is necessary since only owner controled fuses 
         // are allowed to be set. 
         // If parent controlled fuses in the node are being set, make sure 
@@ -568,6 +566,7 @@ contract NameWrapper is
 
 
         if (!isWrapped(node)) {
+            bytes memory _name = _saveLabel(parentNode, node, label);
             ens.setSubnodeOwner(parentNode, labelhash, address(this));
             _wrap(node, _name, owner, fuses, expiry);
         } else {

--- a/contracts/wrapper/NameWrapper.sol
+++ b/contracts/wrapper/NameWrapper.sol
@@ -554,7 +554,7 @@ contract NameWrapper is
             revert Unauthorised(parentNode, msg.sender);
         }
 
-        canCallSetSubnodeOwnerFunc(node, parentNode);
+        canCallSetSubnodeOwnerFunc(node, parentNode, parentFuses);
 
         bytes memory _name = _saveLabel(parentNode, node, label);
 
@@ -735,12 +735,11 @@ contract NameWrapper is
         _;
     }
 
-    function canCallSetSubnodeOwnerFunc(bytes32 node, bytes32 parentNode) private view {
+    function canCallSetSubnodeOwnerFunc(bytes32 node, bytes32 parentNode, uint32 parentFuses) private view {
         address owner = ens.owner(node);
 
         if (owner == address(0)) {
-            (, uint32 fuses, ) = getData(uint256(parentNode));
-            if (fuses & CANNOT_CREATE_SUBDOMAIN != 0) {
+            if (parentFuses & CANNOT_CREATE_SUBDOMAIN != 0) {
                 revert OperationProhibited(node);
             }
         } else {

--- a/contracts/wrapper/NameWrapper.sol
+++ b/contracts/wrapper/NameWrapper.sol
@@ -540,6 +540,9 @@ contract NameWrapper is
         bytes32 labelhash = keccak256(bytes(label));
         node = _makeNode(parentNode, labelhash);
 
+        // Make sure that only owner controlled fuses are being set. 
+        _checkFusesAreSettable(node, fuses);
+
         (, , uint64 oldExpiry) = getData(uint256(node));
         (address parentOwner, uint32 parentFuses, uint64 parentExpiry) = getData(uint256(parentNode));
 
@@ -552,7 +555,6 @@ contract NameWrapper is
 
         canCallSetSubnodeOwnerFunc(parentNode, labelhash);
 
-        _checkFusesAreSettable(node, fuses);
         bytes memory _name = _saveLabel(parentNode, node, label);
 
         _checkParentFuses(node, fuses, parentFuses);

--- a/contracts/wrapper/NameWrapper.sol
+++ b/contracts/wrapper/NameWrapper.sol
@@ -543,7 +543,8 @@ contract NameWrapper is
         // Make sure that only owner controlled fuses are being set. 
         _checkFusesAreSettable(node, fuses);
 
-        (, , uint64 oldExpiry) = getData(uint256(node));
+        // Get the node data and parentNode data.
+        (, uint32 nodeFuses, uint64 oldExpiry) = getData(uint256(node));
         (address parentOwner, uint32 parentFuses, uint64 parentExpiry) = getData(uint256(parentNode));
 
         // Make sure the caller is the parent owner or approved, and the parent name is not expired. 

--- a/contracts/wrapper/NameWrapper.sol
+++ b/contracts/wrapper/NameWrapper.sol
@@ -603,11 +603,6 @@ contract NameWrapper is
             } else {
                 // If the name was wrapped, then just update the data.   
 
-                // If the name is not already set then set it.
-                if (names[node].length == 0) {
-                    names[node] = bytes(label);
-                }
-
                 // Set the fuses.
                 _setFuses(node, nodeOwner, fuses, expiry);
 

--- a/contracts/wrapper/NameWrapper.sol
+++ b/contracts/wrapper/NameWrapper.sol
@@ -558,7 +558,12 @@ contract NameWrapper is
 
         bytes memory _name = _saveLabel(parentNode, node, label);
 
-        _checkParentFuses(node, fuses, parentFuses);
+        // NTS: I don't think this function is necessary since only owner controled fuses 
+        // are allowed to be set. 
+        // If parent controlled fuses in the node are being set, make sure 
+        // CANNOT_UNWRAP is burned in the fuses of the parent node. 
+        //_checkParentFuses(node, fuses, parentFuses);
+
         expiry = _normaliseExpiry(expiry, oldExpiry, parentExpiry);
 
 

--- a/contracts/wrapper/NameWrapper.sol
+++ b/contracts/wrapper/NameWrapper.sol
@@ -204,13 +204,6 @@ contract NameWrapper is
         _;
     }
 
-    function onlyTokenOwnerFunc(bytes32 node) private view{
-        if (!canModifyName(node, msg.sender)) {
-            revert Unauthorised(node, msg.sender);
-        }
-
-    }
-
     /**
      * @notice Checks if owner or approved by owner
      * @param node namehash of the name to check
@@ -759,21 +752,6 @@ contract NameWrapper is
         }
 
         _;
-    }
-
-    function canCallSetSubnodeOwnerFunc(bytes32 node, uint32 nodeFuses, uint32 parentFuses) private view {
-        address owner = ens.owner(node);
-
-        if (owner == address(0)) {
-            if (parentFuses & CANNOT_CREATE_SUBDOMAIN != 0) {
-                revert OperationProhibited(node);
-            }
-        } else {
-            if (nodeFuses & PARENT_CANNOT_CONTROL != 0) {
-                revert OperationProhibited(node);
-            }
-        }
-
     }
 
     /**

--- a/contracts/wrapper/NameWrapper.sol
+++ b/contracts/wrapper/NameWrapper.sol
@@ -554,7 +554,7 @@ contract NameWrapper is
             revert Unauthorised(parentNode, msg.sender);
         }
 
-        canCallSetSubnodeOwnerFunc(parentNode, labelhash);
+        canCallSetSubnodeOwnerFunc(node, parentNode);
 
         bytes memory _name = _saveLabel(parentNode, node, label);
 
@@ -735,8 +735,7 @@ contract NameWrapper is
         _;
     }
 
-    function canCallSetSubnodeOwnerFunc(bytes32 parentNode, bytes32 labelhash) private view {
-        bytes32 node = _makeNode(parentNode, labelhash);
+    function canCallSetSubnodeOwnerFunc(bytes32 node, bytes32 parentNode) private view {
         address owner = ens.owner(node);
 
         if (owner == address(0)) {


### PR DESCRIPTION
This refactoring was done to limit the gas used and make the code more readable. Some of the methods used include:

- Removing duplicate calls to getData()
- Adding comments to all parts of the code 
- Reducing the number of calls to external functions

The overall gas used by setSubnodeOwner was reduced by:

Min - Max - Average
60391  ·     131996  ·      123610
55282  ·     124713  ·      116696
(-5,109)      (-7,283)       (-6,914)