### PR TITLE
Add token approvals to PublicResolver.sol

### DIFF
--- a/contracts/resolvers/PublicResolver.sol
+++ b/contracts/resolvers/PublicResolver.sol
@@ -139,7 +139,8 @@ contract PublicResolver is
         if (owner == address(nameWrapper)) {
             owner = nameWrapper.ownerOf(uint256(node));
         }
-        return owner == msg.sender || isApprovedForAll(owner, msg.sender);
+        return owner == msg.sender || isApprovedForAll(owner, msg.sender) || 
+            isApprovedFor(owner, node, msg.sender);
     }
 
     function supportsInterface(bytes4 interfaceID)

--- a/contracts/resolvers/PublicResolver.sol
+++ b/contracts/resolvers/PublicResolver.sol
@@ -44,6 +44,14 @@ contract PublicResolver is
      */
     mapping(address => mapping(address => bool)) private _operatorApprovals;
 
+    /**
+     * A mapping of delegates. A delegate that is authorised by an owner
+     * for a name may make changes to the name's resolver, but may not update
+     * the set of token approvals.
+     * (owner, name, delegate) => approved
+     */
+    mapping(address => mapping(bytes32 => mapping(address => bool))) private _tokenApprovals;
+
     // Logged when an operator is added or removed.
     event ApprovalForAll(
         address indexed owner,

--- a/contracts/resolvers/PublicResolver.sol
+++ b/contracts/resolvers/PublicResolver.sol
@@ -59,6 +59,14 @@ contract PublicResolver is
         bool approved
     );
 
+    // Logged when a delegate is approved or  an approval is revoked.
+    event Approved(
+        address owner,
+        bytes32 indexed node,
+        address indexed delegate,
+        bool indexed approved
+    );
+
     constructor(
         ENS _ens,
         INameWrapper wrapperAddress,

--- a/contracts/resolvers/PublicResolver.sol
+++ b/contracts/resolvers/PublicResolver.sol
@@ -117,6 +117,16 @@ contract PublicResolver is
         emit Approved(msg.sender, node, delegate, approved);
     }
 
+    /**
+     * @dev Check to see if the delegate has been approved by the owner for the node.
+     */
+    function isApprovedFor(address owner, bytes32 node, address delegate)
+        public
+        view
+        returns (bool)
+    {
+        return _tokenApprovals[owner][node][delegate];
+    }
 
     function isAuthorised(bytes32 node) internal view override returns (bool) {
         if (

--- a/contracts/resolvers/PublicResolver.sol
+++ b/contracts/resolvers/PublicResolver.sol
@@ -103,6 +103,21 @@ contract PublicResolver is
         return _operatorApprovals[account][operator];
     }
 
+
+    /**
+     * @dev Approve a delegate to be able to updated records on a node.
+     */
+    function approve(bytes32 node, address delegate, bool approved) external {
+        require(
+            msg.sender != delegate,
+            "Setting delegate status for self"
+        );
+
+        _tokenApprovals[msg.sender][node][delegate] = approved;
+        emit Approved(msg.sender, node, delegate, approved);
+    }
+
+
     function isAuthorised(bytes32 node) internal view override returns (bool) {
         if (
             msg.sender == trustedETHController ||


### PR DESCRIPTION
The current version of the Public Resolver only allows owners to approve other addresses to update all of their records on their behalf. However, this proposed change (referred to as "token approvals") would allow an owner to approve a delegate to make changes to the records of a specific name. This would be useful for companies that want to retain control over their subnames but still allow employees to make updates to individual subnames assigned to them. For example, an employee could update all of the records for a subname like "greg.technet.eth," but the company would retain ownership and be able to revoke the approved wallet address at any time.

Another potential use case for token approvals is if a parent name is wrapped in a contract. In this scenario, the contract could approve the previous owner of the name in the Public Resolver, allowing them to continue using the name and making updates through the ENS app.


