### PR TITLE
Store eth expiry

### DIFF
--- a/contracts/wrapper/NameWrapper.sol
+++ b/contracts/wrapper/NameWrapper.sol
@@ -1068,16 +1068,4 @@ contract NameWrapper is
             revert OperationProhibited(node);
         }
     }
-
-    function _getEthLabelhash(bytes32 node, uint32 fuses)
-        internal
-        view
-        returns (bytes32 labelhash)
-    {
-        if (fuses & IS_DOT_ETH == IS_DOT_ETH) {
-            bytes memory name = names[node];
-            (labelhash, ) = name.readLabel(0);
-        }
-        return labelhash;
-    }
 }

--- a/contracts/wrapper/NameWrapper.sol
+++ b/contracts/wrapper/NameWrapper.sol
@@ -23,6 +23,7 @@ error IncorrectTargetOwner(address owner);
 error CannotUpgrade();
 error OperationProhibited(bytes32 node);
 error NameIsNotWrapped();
+error NameIsStillExpired();
 
 contract NameWrapper is
     Ownable,
@@ -128,27 +129,7 @@ contract NameWrapper is
     {
         (owner, fuses, expiry) = super.getData(id);
 
-        // bytes32 labelHash = _getEthLabelhash(bytes32(id), fuses);
-        // if (labelHash != bytes32(0)) {
-        //     uint64 registrarExpiry = uint64(
-        //         registrar.nameExpires(uint256(labelHash))
-        //     );
-        //     expiry = registrarExpiry + GRACE_PERIOD;
-        //     // if owner in registrar is not the wrapper, zero out the owner
-        //     if (
-        //         registrarExpiry > block.timestamp &&
-        //         registrar.ownerOf(uint256(labelHash)) != address(this)
-        //     ) {
-        //         owner = address(0);
-        //     }
-        // }
-
-        if (expiry < block.timestamp) {
-            if (fuses & PARENT_CANNOT_CONTROL == PARENT_CANNOT_CONTROL) {
-                owner = address(0);
-            }
-            fuses = 0;
-        }
+        (owner, fuses) = _clearOwnerAndFuses(owner, fuses, expiry);
     }
 
     /* Metadata service */
@@ -310,12 +291,16 @@ contract NameWrapper is
         uint256 registrarExpiry = registrar.renew(tokenId, duration);
 
         // revert if name is not wrapped
-        if (
-            ens.owner(node) != address(this) ||
-            registrar.ownerOf(tokenId) != address(this) ||
-            ownerOf(uint256(node)) == address(0)
-        ) {
-            revert NameIsNotWrapped();
+        try registrar.ownerOf(tokenId) returns (address registrarOwner) {
+            if (
+                registrarOwner != address(this) ||
+                ens.owner(node) != address(this) ||
+                ownerOf(uint256(node)) == address(0)
+            ) {
+                revert NameIsNotWrapped();
+            }
+        } catch {
+            revert NameIsStillExpired();
         }
 
         // set expiry in Wrapper
@@ -830,6 +815,21 @@ contract NameWrapper is
                 revert OperationProhibited(bytes32(id));
             }
         }
+    }
+
+    function _clearOwnerAndFuses(
+        address owner,
+        uint32 fuses,
+        uint64 expiry
+    ) internal view override returns (address, uint32) {
+        if (expiry < block.timestamp) {
+            if (fuses & PARENT_CANNOT_CONTROL == PARENT_CANNOT_CONTROL) {
+                owner = address(0);
+            }
+            fuses = 0;
+        }
+
+        return (owner, fuses);
     }
 
     function _makeNode(bytes32 node, bytes32 labelhash)

--- a/contracts/wrapper/NameWrapper.sol
+++ b/contracts/wrapper/NameWrapper.sol
@@ -290,17 +290,17 @@ contract NameWrapper is
 
         uint256 registrarExpiry = registrar.renew(tokenId, duration);
 
-        // revert if name is not wrapped
+        // Do not set anything in wrapper if name is not wrapped
         try registrar.ownerOf(tokenId) returns (address registrarOwner) {
             if (
                 registrarOwner != address(this) ||
                 ens.owner(node) != address(this) ||
                 ownerOf(uint256(node)) == address(0)
             ) {
-                revert NameIsNotWrapped();
+                return registrarExpiry;
             }
         } catch {
-            revert NameIsStillExpired();
+            return registrarExpiry;
         }
 
         // set expiry in Wrapper

--- a/contracts/wrapper/NameWrapper.sol
+++ b/contracts/wrapper/NameWrapper.sol
@@ -307,6 +307,8 @@ contract NameWrapper is
     {
         bytes32 node = _makeNode(ETH_NODE, bytes32(tokenId));
 
+        uint256 registrarExpiry = registrar.renew(tokenId, duration);
+
         // revert if name is not wrapped
         if (
             ens.owner(node) != address(this) ||
@@ -316,7 +318,6 @@ contract NameWrapper is
             revert NameIsNotWrapped();
         }
 
-        uint256 registrarExpiry = registrar.renew(tokenId, duration);
         // set expiry in Wrapper
         uint64 expiry = uint64(registrarExpiry) + GRACE_PERIOD;
 
@@ -860,7 +861,7 @@ contract NameWrapper is
         uint64 expiry
     ) internal override {
         _canFusesBeBurned(node, fuses);
-        address oldOwner = ownerOf(uint256(node));
+        (address oldOwner, , ) = super.getData(uint256(node));
         if (oldOwner != address(0)) {
             // burn and unwrap old token of old owner
             _burn(uint256(node));

--- a/test/wrapper/NameWrapper.js
+++ b/test/wrapper/NameWrapper.js
@@ -5033,7 +5033,7 @@ describe('Name Wrapper', () => {
       expect(owner).to.equal(account)
     })
 
-    it('Renewing name less than required to unexpire it still has original owner/fuses', async () => {
+    it('cannot renew a name to an expired state', async () => {
       await NameWrapper.registerAndWrapETH2LD(
         label,
         account,
@@ -5052,21 +5052,9 @@ describe('Name Wrapper', () => {
       expect(expiryBefore).to.be.at.most(block1.timestamp + GRACE_PERIOD)
 
       //renew for less than the grace period
-      await NameWrapper.renew(labelHash, 1 * DAY)
-
-      const [ownerAfter, fusesAfter, expiryAfter] = await NameWrapper.getData(
-        wrappedTokenId,
+      await expect(NameWrapper.renew(labelHash, 1 * DAY)).to.be.revertedWith(
+        `NameIsStillExpired()`,
       )
-      expect(ownerAfter).to.equal(account)
-      // fuses remain the same
-      expect(fusesAfter).to.equal(
-        CANNOT_UNWRAP |
-          CANNOT_SET_RESOLVER |
-          IS_DOT_ETH |
-          PARENT_CANNOT_CONTROL,
-      )
-      // still expired
-      expect(expiryAfter).to.be.at.most(block1.timestamp + GRACE_PERIOD)
     })
   })
 

--- a/test/wrapper/NameWrapper.js
+++ b/test/wrapper/NameWrapper.js
@@ -5566,7 +5566,7 @@ describe('Name Wrapper', () => {
       await BaseRegistrar.addController(NameWrapper.address)
       await NameWrapper.setController(account, true)
     })
-    it('Attack happens within the deprecation period where both .eth registrar controllers are active - Hack 1', async () => {
+    it('Trying to burn child fuses when re-registering a name on the old controller reverts', async () => {
       await NameWrapper.registerAndWrapETH2LD(
         label1,
         hacker,

--- a/test/wrapper/NameWrapper.js
+++ b/test/wrapper/NameWrapper.js
@@ -788,18 +788,10 @@ describe('Name Wrapper', () => {
         EMPTY_ADDRESS,
       )
 
-      // Check the 4 events
-      // UnwrapETH2LD of the original owner
-      // TransferSingle burn of the original token
+      // Check for the Wrap and TransferSingle events
       // WrapETH2LD to the new owner with fuses
       // TransferSingle to mint the new token
 
-      await expect(tx)
-        .to.emit(NameWrapper, 'NameUnwrapped')
-        .withArgs(namehash('wrapped2.eth'), EMPTY_ADDRESS)
-      await expect(tx)
-        .to.emit(NameWrapper, 'TransferSingle')
-        .withArgs(account2, account, EMPTY_ADDRESS, nameHash, 1)
       await expect(tx)
         .to.emit(NameWrapper, 'NameWrapped')
         .withArgs(
@@ -844,12 +836,6 @@ describe('Name Wrapper', () => {
         EMPTY_ADDRESS,
       )
 
-      await expect(tx)
-        .to.emit(NameWrapper, 'NameUnwrapped')
-        .withArgs(namehash('wrapped2.eth'), EMPTY_ADDRESS)
-      await expect(tx)
-        .to.emit(NameWrapper, 'TransferSingle')
-        .withArgs(account2, account, EMPTY_ADDRESS, nameHash, 1)
       await expect(tx)
         .to.emit(NameWrapper, 'NameWrapped')
         .withArgs(

--- a/test/wrapper/NameWrapper.js
+++ b/test/wrapper/NameWrapper.js
@@ -5033,7 +5033,7 @@ describe('Name Wrapper', () => {
       expect(owner).to.equal(account)
     })
 
-    it('cannot renew a name to an expired state', async () => {
+    it('Renewing name less than required to unexpire it still has original owner/fuses', async () => {
       await NameWrapper.registerAndWrapETH2LD(
         label,
         account,
@@ -5052,9 +5052,21 @@ describe('Name Wrapper', () => {
       expect(expiryBefore).to.be.at.most(block1.timestamp + GRACE_PERIOD)
 
       //renew for less than the grace period
-      await expect(NameWrapper.renew(labelHash, 1 * DAY)).to.be.revertedWith(
-        `NameIsStillExpired()`,
+      await NameWrapper.renew(labelHash, 1 * DAY)
+
+      const [ownerAfter, fusesAfter, expiryAfter] = await NameWrapper.getData(
+        wrappedTokenId,
       )
+      expect(ownerAfter).to.equal(account)
+      // fuses remain the same
+      expect(fusesAfter).to.equal(
+        CANNOT_UNWRAP |
+          CANNOT_SET_RESOLVER |
+          IS_DOT_ETH |
+          PARENT_CANNOT_CONTROL,
+      )
+      // still expired
+      expect(expiryAfter).to.be.at.most(block1.timestamp + GRACE_PERIOD)
     })
   })
 

--- a/test/wrapper/NameWrapper.js
+++ b/test/wrapper/NameWrapper.js
@@ -5553,6 +5553,74 @@ describe('Name Wrapper', () => {
     })
   })
 
+  describe('Implicit Unwrap tests', () => {
+    const label1 = 'sub1'
+    const labelHash1 = labelhash('sub1')
+    const wrappedTokenId1 = namehash('sub1.eth')
+
+    const label2 = 'sub2'
+    const labelHash2 = labelhash('sub2')
+    const wrappedTokenId2 = namehash('sub2.sub1.eth')
+
+    before(async () => {
+      await BaseRegistrar.addController(NameWrapper.address)
+      await NameWrapper.setController(account, true)
+    })
+    it('Attack happens within the deprecation period where both .eth registrar controllers are active - Hack 1', async () => {
+      await NameWrapper.registerAndWrapETH2LD(
+        label1,
+        hacker,
+        1 * DAY,
+        EMPTY_ADDRESS,
+        CANNOT_UNWRAP,
+      )
+
+      // create `sub2.sub1.eth` w/o fuses burnt
+      await NameWrapperH.setSubnodeOwner(
+        wrappedTokenId1,
+        label2,
+        hacker,
+        CAN_DO_EVERYTHING,
+        MAX_EXPIRY,
+      )
+      expect(await NameWrapper.ownerOf(wrappedTokenId2)).to.equal(hacker)
+
+      // wait the ETH2LD expired and re-register to the hacker himself
+      await evm.advanceTime(GRACE_PERIOD + 1 * DAY + 1)
+      await evm.mine()
+
+      // XXX: note that at this step, the hackler should use the current .eth
+      // registrar to directly register `sub1.eth` to himself, without wrapping
+      // the name.
+      await BaseRegistrar.register(labelHash1, hacker, 10 * DAY)
+      expect(await EnsRegistry.owner(wrappedTokenId1)).to.equal(hacker)
+      expect(await BaseRegistrar.ownerOf(labelHash1)).to.equal(hacker)
+
+      // XXX: PREPARE HACK!
+      // set `EnsRegistry.owner` of `sub1.eth` as the hacker himself.
+      await EnsRegistryH.setOwner(wrappedTokenId1, hacker)
+
+      // XXX: PREPARE HACK!
+      // set controller owner as the NameWrapper contract, to bypass the check
+      await BaseRegistrarH.transferFrom(hacker, NameWrapper.address, labelHash1)
+      expect(await BaseRegistrar.ownerOf(labelHash1)).to.equal(
+        NameWrapper.address,
+      )
+
+      // set `sub2.sub1.eth` to the victim user w fuses burnt
+      // XXX: do this via `setChildFuses`
+      // Cannot setChildFuses as the owner has not been updated in the wrapper when reregistering
+      await expect(
+        NameWrapperH.setChildFuses(
+          wrappedTokenId1,
+          labelHash2,
+          PARENT_CANNOT_CONTROL | CANNOT_UNWRAP | CANNOT_CREATE_SUBDOMAIN,
+          MAX_EXPIRY,
+        ),
+      ).to.be.revertedWith(`Unauthorised("${wrappedTokenId2}", "${hacker}")`)
+    })
+  })
+
   describe('TLD recovery', () => {
     it('Wraps a name which get stuck forever can be recovered by ROOT owner', async () => {
       expect(await NameWrapper.ownerOf(namehash('xyz'))).to.equal(EMPTY_ADDRESS)

--- a/test/wrapper/NameWrapper.js
+++ b/test/wrapper/NameWrapper.js
@@ -788,10 +788,18 @@ describe('Name Wrapper', () => {
         EMPTY_ADDRESS,
       )
 
-      // Check for the Wrap and TransferSingle events
+      // Check the 4 events
+      // UnwrapETH2LD of the original owner
+      // TransferSingle burn of the original token
       // WrapETH2LD to the new owner with fuses
       // TransferSingle to mint the new token
 
+      await expect(tx)
+        .to.emit(NameWrapper, 'NameUnwrapped')
+        .withArgs(namehash('wrapped2.eth'), EMPTY_ADDRESS)
+      await expect(tx)
+        .to.emit(NameWrapper, 'TransferSingle')
+        .withArgs(account2, account, EMPTY_ADDRESS, nameHash, 1)
       await expect(tx)
         .to.emit(NameWrapper, 'NameWrapped')
         .withArgs(
@@ -836,6 +844,12 @@ describe('Name Wrapper', () => {
         EMPTY_ADDRESS,
       )
 
+      await expect(tx)
+        .to.emit(NameWrapper, 'NameUnwrapped')
+        .withArgs(namehash('wrapped2.eth'), EMPTY_ADDRESS)
+      await expect(tx)
+        .to.emit(NameWrapper, 'TransferSingle')
+        .withArgs(account2, account, EMPTY_ADDRESS, nameHash, 1)
       await expect(tx)
         .to.emit(NameWrapper, 'NameWrapped')
         .withArgs(


### PR DESCRIPTION
1. Remove registrar.nameExpires() from everything and check expiry from getData() just like a normal wrapped name

1. renew() and wrapETH2LD() update expiry based onregistrar.nameExpires()`

1. renew()  if name is not wrapped** does not update eth expiry but just passes the call directly to registrar.renew and then returns without changing the state within the wrapper.

The idea is to not automatically update the expiry inside the wrapper by calling the registrar, but instead only updating it on wrapETH2LD() and renew(). This means if anyone calls the old controller, it will not extend expiry and allow them to use the name within wrapping.

**Not wrapped is defined as: `registrar.ownerOf()` OR `registry.owner()` are not the Name Wrapper contract OR `NameWrapper.ownerOf()` is zero`