### PR TITLE
Preventing setExpiry from being called on unregistered/unwrapped names.

### DIFF
--- a/contracts/wrapper/NameWrapper.sol
+++ b/contracts/wrapper/NameWrapper.sol
@@ -445,6 +445,9 @@ contract NameWrapper is
         (address owner, uint32 fuses, uint64 oldExpiry) = getData(
             uint256(node)
         );
+        if (owner == address(0) || ens.owner(node) != address(this)) {
+            revert NameIsNotWrapped();
+        }
 
         // the parent owner can always set expiry, so no need to check fuses
         if (!canModifyParentName) {


### PR DESCRIPTION
Since the `setExpiry()` method does not alter fuses, perhaps this isn't needed. But I went ahead and added the `NameIsNotWrapped` changes that you made elsewhere for audit mitigations.