### PR TITLE
Allow expired names in wrapper but unexpired in registrar renew

### DIFF
--- a/contracts/wrapper/NameWrapper.sol
+++ b/contracts/wrapper/NameWrapper.sol
@@ -294,8 +294,7 @@ contract NameWrapper is
         try registrar.ownerOf(tokenId) returns (address registrarOwner) {
             if (
                 registrarOwner != address(this) ||
-                ens.owner(node) != address(this) ||
-                ownerOf(uint256(node)) == address(0)
+                ens.owner(node) != address(this)
             ) {
                 return registrarExpiry;
             }
@@ -306,7 +305,8 @@ contract NameWrapper is
         // set expiry in Wrapper
         uint64 expiry = uint64(registrarExpiry) + GRACE_PERIOD;
 
-        (address owner, uint32 fuses, ) = getData(uint256(node));
+        //use super to allow names expired on the wrapper, but not expired on the registrar to renew()
+        (address owner, uint32 fuses, ) = super.getData(uint256(node));
         _setData(node, owner, fuses, expiry);
 
         return registrarExpiry;


### PR DESCRIPTION
Mitigation for the following situation:

Name is wrapped, name is then renewed on the old controller (possibly unknowingly - using an old or 3rd party ui). Owner thinks that the name is expiring in a year, but actually it expires on the wrapper tomorrow. Name expires and now is lost/burnt because the NameWrapper owns it, but no one can actually get ownership unless it expires on the .eth registrar.