### PR TITLE
token delegation from multi-delegate to single

### DIFF
--- a/contracts/resolvers/PublicResolver.sol
+++ b/contracts/resolvers/PublicResolver.sol
@@ -40,22 +40,23 @@ contract PublicResolver is
      * A mapping of operators. An address that is authorised for an address
      * may make any changes to the name that the owner could, but may not update
      * the set of authorisations.
-     * owner => operator
+     * (owner, operator) => approved
      */
-    mapping(address => address) private _operatorApprovals;
+    mapping(address => mapping(address => bool)) private _operatorApprovals;
 
     /**
      * A mapping of delegates. The delegate that is set by an owner
      * for a name may make changes to the name's resolver, but may not update
      * the set of token approvals.
-     * (owner, name) => delegate
+     * (owner, name, delegate) => approved
      */
     mapping(address => mapping(bytes32 => address)) private _tokenApprovals;
 
     // Logged when an operator is added or removed.
     event ApprovalForAll(
         address indexed owner,
-        address indexed operator
+        address indexed operator,
+        bool approved
     );
 
     // Logged when a delegate is approved or  an approval is revoked.
@@ -78,27 +79,27 @@ contract PublicResolver is
     }
 
     /**
-     * @dev Allows for approving a single operator.
+     * @dev See {IERC1155-setApprovalForAll}.
      */
-    function setApprovalForAll(address operator) external {
+    function setApprovalForAll(address operator, bool approved) external {
         require(
             msg.sender != operator,
-            "Setting approval status for self"
+            "ERC1155: setting approval status for self"
         );
 
-        _operatorApprovals[msg.sender] = operator;
-        emit ApprovalForAll(msg.sender, operator);
+        _operatorApprovals[msg.sender][operator] = approved;
+        emit ApprovalForAll(msg.sender, operator, approved);
     }
 
     /**
-     * @dev Check to see if the operator is approved for all.
+     * @dev See {IERC1155-isApprovedForAll}.
      */
     function isApprovedForAll(address account, address operator)
         public
         view
         returns (bool)
     {
-        return _operatorApprovals[account] == operator;
+        return _operatorApprovals[account][operator];
     }
 
 

--- a/contracts/resolvers/PublicResolver.sol
+++ b/contracts/resolvers/PublicResolver.sol
@@ -45,12 +45,12 @@ contract PublicResolver is
     mapping(address => mapping(address => bool)) private _operatorApprovals;
 
     /**
-     * A mapping of delegates. A delegate that is authorised by an owner
+     * A mapping of delegates. The delegate that is set by an owner
      * for a name may make changes to the name's resolver, but may not update
      * the set of token approvals.
      * (owner, name, delegate) => approved
      */
-    mapping(address => mapping(bytes32 => mapping(address => bool))) private _tokenApprovals;
+    mapping(address => mapping(bytes32 => address)) private _tokenApprovals;
 
     // Logged when an operator is added or removed.
     event ApprovalForAll(
@@ -63,8 +63,7 @@ contract PublicResolver is
     event Approved(
         address owner,
         bytes32 indexed node,
-        address indexed delegate,
-        bool indexed approved
+        address indexed delegate
     );
 
     constructor(
@@ -107,14 +106,14 @@ contract PublicResolver is
     /**
      * @dev Approve a delegate to be able to updated records on a node.
      */
-    function approve(bytes32 node, address delegate, bool approved) external {
+    function approve(bytes32 node, address delegate) external {
         require(
             msg.sender != delegate,
             "Setting delegate status for self"
         );
 
-        _tokenApprovals[msg.sender][node][delegate] = approved;
-        emit Approved(msg.sender, node, delegate, approved);
+        _tokenApprovals[msg.sender][node] = delegate;
+        emit Approved(msg.sender, node, delegate);
     }
 
     /**
@@ -125,7 +124,7 @@ contract PublicResolver is
         view
         returns (bool)
     {
-        return _tokenApprovals[owner][node][delegate];
+        return _tokenApprovals[owner][node] == delegate;
     }
 
     function isAuthorised(bytes32 node) internal view override returns (bool) {

--- a/contracts/resolvers/PublicResolver.sol
+++ b/contracts/resolvers/PublicResolver.sol
@@ -40,23 +40,22 @@ contract PublicResolver is
      * A mapping of operators. An address that is authorised for an address
      * may make any changes to the name that the owner could, but may not update
      * the set of authorisations.
-     * (owner, operator) => approved
+     * owner => operator
      */
-    mapping(address => mapping(address => bool)) private _operatorApprovals;
+    mapping(address => address) private _operatorApprovals;
 
     /**
      * A mapping of delegates. The delegate that is set by an owner
      * for a name may make changes to the name's resolver, but may not update
      * the set of token approvals.
-     * (owner, name, delegate) => approved
+     * (owner, name) => delegate
      */
     mapping(address => mapping(bytes32 => address)) private _tokenApprovals;
 
     // Logged when an operator is added or removed.
     event ApprovalForAll(
         address indexed owner,
-        address indexed operator,
-        bool approved
+        address indexed operator
     );
 
     // Logged when a delegate is approved or  an approval is revoked.
@@ -79,27 +78,27 @@ contract PublicResolver is
     }
 
     /**
-     * @dev See {IERC1155-setApprovalForAll}.
+     * @dev Allows for approving a single operator.
      */
-    function setApprovalForAll(address operator, bool approved) external {
+    function setApprovalForAll(address operator) external {
         require(
             msg.sender != operator,
-            "ERC1155: setting approval status for self"
+            "Setting approval status for self"
         );
 
-        _operatorApprovals[msg.sender][operator] = approved;
-        emit ApprovalForAll(msg.sender, operator, approved);
+        _operatorApprovals[msg.sender] = operator;
+        emit ApprovalForAll(msg.sender, operator);
     }
 
     /**
-     * @dev See {IERC1155-isApprovedForAll}.
+     * @dev Check to see if the operator is approved for all.
      */
     function isApprovedForAll(address account, address operator)
         public
         view
         returns (bool)
     {
-        return _operatorApprovals[account][operator];
+        return _operatorApprovals[account] == operator;
     }
 
 

--- a/test/ethregistrar/TestEthRegistrarController.js
+++ b/test/ethregistrar/TestEthRegistrarController.js
@@ -868,7 +868,7 @@ contract('ETHRegistrarController', function () {
       { value: BUFFERED_REGISTRATION_COST },
     )
 
-    await resolver2.setApprovalForAll(controller.address, true)
+    await resolver2.setApprovalForAll(controller.address)
 
     const gasB = await controller2.estimateGas.register(
       label,

--- a/test/ethregistrar/TestEthRegistrarController.js
+++ b/test/ethregistrar/TestEthRegistrarController.js
@@ -868,7 +868,7 @@ contract('ETHRegistrarController', function () {
       { value: BUFFERED_REGISTRATION_COST },
     )
 
-    await resolver2.setApprovalForAll(controller.address)
+    await resolver2.setApprovalForAll(controller.address, true)
 
     const gasB = await controller2.estimateGas.register(
       label,

--- a/test/resolvers/TestPublicResolver.js
+++ b/test/resolvers/TestPublicResolver.js
@@ -1171,7 +1171,7 @@ contract('PublicResolver', function(accounts) {
 
   describe('token approvals', async () => {
     it('permits delegate to be approved', async () => {
-      await resolver.approve(node, accounts[1], true, {
+      await resolver.approve(node, accounts[1], {
         from: accounts[0],
       })
       assert.equal(
@@ -1181,7 +1181,7 @@ contract('PublicResolver', function(accounts) {
     })
 
     it('permits delegated users to make changes', async () => {
-      await resolver.approve(node, accounts[1], true, {
+      await resolver.approve(node, accounts[1], {
         from: accounts[0],
       })
       assert.equal(
@@ -1195,7 +1195,7 @@ contract('PublicResolver', function(accounts) {
     })
 
     it('permits delegations to be cleared', async () => {
-      await resolver.approve(node, accounts[1], false, {
+      await resolver.approve(node, EMPTY_ADDRESS, {
         from: accounts[0],
       })
       await exceptions.expectFailure(
@@ -1206,7 +1206,7 @@ contract('PublicResolver', function(accounts) {
     })
 
     it('permits non-owners to set delegations', async () => {
-      await resolver.approve(node, accounts[2], true, {
+      await resolver.approve(node, accounts[2], {
         from: accounts[1],
       })
 
@@ -1219,7 +1219,7 @@ contract('PublicResolver', function(accounts) {
     })
 
     it('checks the delegation for the current owner', async () => {
-      await resolver.approve(node, accounts[2], true, {
+      await resolver.approve(node, accounts[2], {
         from: accounts[1],
       })
       await ens.setOwner(node, accounts[1], { from: accounts[0] })
@@ -1233,7 +1233,7 @@ contract('PublicResolver', function(accounts) {
     it('emits a Approved log', async () => {
       var owner = accounts[0]
       var delegate = accounts[1]
-      var tx = await resolver.approve(node, delegate, true, {
+      var tx = await resolver.approve(node, delegate, {
         from: owner,
       })
       assert.equal(tx.logs.length, 1)
@@ -1241,12 +1241,11 @@ contract('PublicResolver', function(accounts) {
       assert.equal(tx.logs[0].args.owner, owner)
       assert.equal(tx.logs[0].args.node, node)
       assert.equal(tx.logs[0].args.delegate, delegate)
-      assert.equal(tx.logs[0].args.approved, true)
     })
 
     it('reverts if attempting to delegate self as an delegate', async () => {
       await expect(
-        resolver.approve(node, accounts[1], true, { from: accounts[1] })
+        resolver.approve(node, accounts[1], { from: accounts[1] })
       ).to.be.revertedWith('Setting delegate status for self')
     })
   })

--- a/test/resolvers/TestPublicResolver.js
+++ b/test/resolvers/TestPublicResolver.js
@@ -1067,7 +1067,7 @@ contract('PublicResolver', function(accounts) {
 
   describe('authorisations', async () => {
     it('permits authorisations to be set', async () => {
-      await resolver.setApprovalForAll(accounts[1], {
+      await resolver.setApprovalForAll(accounts[1], true, {
         from: accounts[0],
       })
       assert.equal(
@@ -1077,7 +1077,7 @@ contract('PublicResolver', function(accounts) {
     })
 
     it('permits authorised users to make changes', async () => {
-      await resolver.setApprovalForAll(accounts[1], {
+      await resolver.setApprovalForAll(accounts[1], true, {
         from: accounts[0],
       })
       assert.equal(
@@ -1091,7 +1091,7 @@ contract('PublicResolver', function(accounts) {
     })
 
     it('permits authorisations to be cleared', async () => {
-      await resolver.setApprovalForAll(EMPTY_ADDRESS, {
+      await resolver.setApprovalForAll(accounts[1], false, {
         from: accounts[0],
       })
       await exceptions.expectFailure(
@@ -1102,7 +1102,7 @@ contract('PublicResolver', function(accounts) {
     })
 
     it('permits non-owners to set authorisations', async () => {
-      await resolver.setApprovalForAll(accounts[2], {
+      await resolver.setApprovalForAll(accounts[2], true, {
         from: accounts[1],
       })
 
@@ -1115,7 +1115,7 @@ contract('PublicResolver', function(accounts) {
     })
 
     it('checks the authorisation for the current owner', async () => {
-      await resolver.setApprovalForAll(accounts[2], {
+      await resolver.setApprovalForAll(accounts[2], true, {
         from: accounts[1],
       })
       await ens.setOwner(node, accounts[1], { from: accounts[0] })
@@ -1136,19 +1136,20 @@ contract('PublicResolver', function(accounts) {
     it('emits an ApprovalForAll log', async () => {
       var owner = accounts[0]
       var operator = accounts[1]
-      var tx = await resolver.setApprovalForAll(operator, {
+      var tx = await resolver.setApprovalForAll(operator, true, {
         from: owner,
       })
       assert.equal(tx.logs.length, 1)
       assert.equal(tx.logs[0].event, 'ApprovalForAll')
       assert.equal(tx.logs[0].args.owner, owner)
       assert.equal(tx.logs[0].args.operator, operator)
+      assert.equal(tx.logs[0].args.approved, true)
     })
 
     it('reverts if attempting to approve self as an operator', async () => {
       await expect(
-        resolver.setApprovalForAll(accounts[1], { from: accounts[1] })
-      ).to.be.revertedWith('Setting approval status for self')
+        resolver.setApprovalForAll(accounts[1], true, { from: accounts[1] })
+      ).to.be.revertedWith('ERC1155: setting approval status for self')
     })
 
     it('permits name wrapper owner to make changes if owner is set to name wrapper address', async () => {

--- a/test/resolvers/TestPublicResolver.js
+++ b/test/resolvers/TestPublicResolver.js
@@ -1067,7 +1067,7 @@ contract('PublicResolver', function(accounts) {
 
   describe('authorisations', async () => {
     it('permits authorisations to be set', async () => {
-      await resolver.setApprovalForAll(accounts[1], true, {
+      await resolver.setApprovalForAll(accounts[1], {
         from: accounts[0],
       })
       assert.equal(
@@ -1077,7 +1077,7 @@ contract('PublicResolver', function(accounts) {
     })
 
     it('permits authorised users to make changes', async () => {
-      await resolver.setApprovalForAll(accounts[1], true, {
+      await resolver.setApprovalForAll(accounts[1], {
         from: accounts[0],
       })
       assert.equal(
@@ -1091,7 +1091,7 @@ contract('PublicResolver', function(accounts) {
     })
 
     it('permits authorisations to be cleared', async () => {
-      await resolver.setApprovalForAll(accounts[1], false, {
+      await resolver.setApprovalForAll(EMPTY_ADDRESS, {
         from: accounts[0],
       })
       await exceptions.expectFailure(
@@ -1102,7 +1102,7 @@ contract('PublicResolver', function(accounts) {
     })
 
     it('permits non-owners to set authorisations', async () => {
-      await resolver.setApprovalForAll(accounts[2], true, {
+      await resolver.setApprovalForAll(accounts[2], {
         from: accounts[1],
       })
 
@@ -1115,7 +1115,7 @@ contract('PublicResolver', function(accounts) {
     })
 
     it('checks the authorisation for the current owner', async () => {
-      await resolver.setApprovalForAll(accounts[2], true, {
+      await resolver.setApprovalForAll(accounts[2], {
         from: accounts[1],
       })
       await ens.setOwner(node, accounts[1], { from: accounts[0] })
@@ -1136,20 +1136,19 @@ contract('PublicResolver', function(accounts) {
     it('emits an ApprovalForAll log', async () => {
       var owner = accounts[0]
       var operator = accounts[1]
-      var tx = await resolver.setApprovalForAll(operator, true, {
+      var tx = await resolver.setApprovalForAll(operator, {
         from: owner,
       })
       assert.equal(tx.logs.length, 1)
       assert.equal(tx.logs[0].event, 'ApprovalForAll')
       assert.equal(tx.logs[0].args.owner, owner)
       assert.equal(tx.logs[0].args.operator, operator)
-      assert.equal(tx.logs[0].args.approved, true)
     })
 
     it('reverts if attempting to approve self as an operator', async () => {
       await expect(
-        resolver.setApprovalForAll(accounts[1], true, { from: accounts[1] })
-      ).to.be.revertedWith('ERC1155: setting approval status for self')
+        resolver.setApprovalForAll(accounts[1], { from: accounts[1] })
+      ).to.be.revertedWith('Setting approval status for self')
     })
 
     it('permits name wrapper owner to make changes if owner is set to name wrapper address', async () => {


### PR DESCRIPTION
This PR changes the token delegation in the public resolver from multi-delegation to single delegation. The advantage with single delegation is that it is much easier to discover and clear old delegations.