### PR TITLE
Change BaseRegistrar and PriceOracle exports to IBaseRegistrar and IPriceOracle

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-const BaseRegistrar = require('./build/contracts/BaseRegistrar')
 const BaseRegistrarImplementation = require('./build/contracts/BaseRegistrarImplementation')
 const BulkRenewal = require('./build/contracts/BulkRenewal')
 const ENS = require('./build/contracts/ENS')
@@ -7,8 +6,9 @@ const ENSRegistryWithFallback = require('./build/contracts/ENSRegistryWithFallba
 const ExponentialPremiumPriceOracle = require('./build/contracts/ExponentialPremiumPriceOracle')
 const ETHRegistrarController = require('./build/contracts/ETHRegistrarController')
 const FIFSRegistrar = require('./build/contracts/FIFSRegistrar')
+const IBaseRegistrar = require('./build/contracts/IBaseRegistrar')
+const IPriceOracle = require('./build/contracts/IPriceOracle')
 const LinearPremiumPriceOracle = require('./build/contracts/LinearPremiumPriceOracle')
-const PriceOracle = require('./build/contracts/PriceOracle')
 const PublicResolver = require('./build/contracts/PublicResolver')
 const Resolver = require('./build/contracts/Resolver')
 const ReverseRegistrar = require('./build/contracts/ReverseRegistrar')
@@ -27,7 +27,6 @@ const SHA256Digest = require('./build/contracts/SHA256Digest')
 const SHA1Digest = require('./build/contracts/SHA1Digest')
 
 module.exports = {
-  BaseRegistrar,
   BaseRegistrarImplementation,
   BulkRenewal,
   ENS,
@@ -36,8 +35,9 @@ module.exports = {
   ExponentialPremiumPriceOracle,
   ETHRegistrarController,
   FIFSRegistrar,
+  IBaseRegistrar,
+  IPriceOracle,
   LinearPremiumPriceOracle,
-  PriceOracle,
   PublicResolver,
   Resolver,
   ReverseRegistrar,


### PR DESCRIPTION
Was upgrading from 0.0.8 to 0.0.17 and found this reference was broken. Based on dates, it may have been broken since 0.0.12 but I did not confirm.

I saw that there was another PR (#103), which is likely a better long-term solution, but wanted to get a quick fix up first.