### PR TITLE
Fix Name Wrapper interface issues

### DIFF
--- a/contracts/resolvers/PublicResolver.sol
+++ b/contracts/resolvers/PublicResolver.sol
@@ -11,10 +11,7 @@ import "./profiles/NameResolver.sol";
 import "./profiles/PubkeyResolver.sol";
 import "./profiles/TextResolver.sol";
 import "./Multicallable.sol";
-
-interface INameWrapper {
-    function ownerOf(uint256 id) external view returns (address);
-}
+import "../wrapper/INameWrapper.sol";
 
 /**
  * A simple resolver anyone can use; only allows the owner of a node to set its

--- a/contracts/wrapper/INameWrapper.sol
+++ b/contracts/wrapper/INameWrapper.sol
@@ -5,6 +5,7 @@ import "../registry/ENS.sol";
 import "../ethregistrar/IBaseRegistrar.sol";
 import "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
 import "./IMetadataService.sol";
+import "./INameWrapperUpgrade.sol";
 
 uint32 constant CANNOT_UNWRAP = 1;
 uint32 constant CANNOT_BURN_FUSES = 2;
@@ -42,6 +43,15 @@ interface INameWrapper is IERC1155 {
     function metadataService() external view returns (IMetadataService);
 
     function names(bytes32) external view returns (bytes memory);
+
+    function name() external view returns (string memory);
+
+    function upgradeContract() external view returns (INameWrapperUpgrade);
+
+    function supportsInterface(bytes4 interfaceID)
+        external
+        view
+        returns (bool);
 
     function wrap(
         bytes calldata name,
@@ -144,8 +154,29 @@ interface INameWrapper is IERC1155 {
             uint64
         );
 
+    function setMetadataService(IMetadataService _metadataService) external;
+
+    function uri(uint256 tokenId) external view returns (string memory);
+
+    function setUpgradeContract(INameWrapperUpgrade _upgradeAddress) external;
+
+    function upgrade(
+        bytes32 parentNode,
+        string calldata label,
+        address wrappedOwner,
+        address resolver
+    ) external; 
+
+    function upgradeETH2LD(
+        string calldata label,
+        address wrappedOwner,
+        address resolver
+    ) external;
+
     function allFusesBurned(bytes32 node, uint32 fuseMask)
         external
         view
         returns (bool);
+
+    function isWrapped(bytes32 node) external view returns (bool);
 }

--- a/contracts/wrapper/INameWrapper.sol
+++ b/contracts/wrapper/INameWrapper.sol
@@ -160,23 +160,8 @@ interface INameWrapper is IERC1155 {
 
     function setUpgradeContract(INameWrapperUpgrade _upgradeAddress) external;
 
-    function upgrade(
-        bytes32 parentNode,
-        string calldata label,
-        address wrappedOwner,
-        address resolver
-    ) external; 
-
-    function upgradeETH2LD(
-        string calldata label,
-        address wrappedOwner,
-        address resolver
-    ) external;
-
     function allFusesBurned(bytes32 node, uint32 fuseMask)
         external
         view
         returns (bool);
-
-    function isWrapped(bytes32 node) external view returns (bool);
 }

--- a/contracts/wrapper/NameWrapper.sol
+++ b/contracts/wrapper/NameWrapper.sol
@@ -765,7 +765,8 @@ contract NameWrapper is
         return fuses & fuseMask == fuseMask;
     }
 
-    function isWrapped(bytes32 node) public view returns (bool) {
+    // Note: This function only works for non .eth 2LDs. 
+    function isWrapped(bytes32 node) internal view returns (bool) {
         return
             ownerOf(uint256(node)) != address(0) &&
             ens.owner(node) == address(this);

--- a/contracts/wrapper/NameWrapper.sol
+++ b/contracts/wrapper/NameWrapper.sol
@@ -1,7 +1,7 @@
 //SPDX-License-Identifier: MIT
 pragma solidity ~0.8.17;
 
-import {ERC1155Fuse, IERC165} from "./ERC1155Fuse.sol";
+import {ERC1155Fuse, IERC165, IERC1155MetadataURI} from "./ERC1155Fuse.sol";
 import {Controllable} from "./Controllable.sol";
 import {INameWrapper, CANNOT_UNWRAP, CANNOT_BURN_FUSES, CANNOT_TRANSFER, CANNOT_SET_RESOLVER, CANNOT_SET_TTL, CANNOT_CREATE_SUBDOMAIN, PARENT_CANNOT_CONTROL, CAN_DO_EVERYTHING, IS_DOT_ETH, CAN_EXTEND_EXPIRY, PARENT_CONTROLLED_FUSES, USER_SETTABLE_FUSES} from "./INameWrapper.sol";
 import {INameWrapperUpgrade} from "./INameWrapperUpgrade.sol";
@@ -35,10 +35,10 @@ contract NameWrapper is
 {
     using BytesUtils for bytes;
 
-    ENS public immutable override ens;
-    IBaseRegistrar public immutable override registrar;
-    IMetadataService public override metadataService;
-    mapping(bytes32 => bytes) public override names;
+    ENS public immutable ens;
+    IBaseRegistrar public immutable registrar;
+    IMetadataService public metadataService;
+    mapping(bytes32 => bytes) public names;
     string public constant name = "NameWrapper";
 
     uint64 private constant GRACE_PERIOD = 90 days;
@@ -83,7 +83,7 @@ contract NameWrapper is
         public
         view
         virtual
-        override(ERC1155Fuse, IERC165)
+        override(ERC1155Fuse, INameWrapper)
         returns (bool)
     {
         return
@@ -152,7 +152,12 @@ contract NameWrapper is
      * @return string uri of the metadata service
      */
 
-    function uri(uint256 tokenId) public view override returns (string memory) {
+    function uri(uint256 tokenId) 
+        public 
+        view 
+        override (INameWrapper, IERC1155MetadataURI) 
+        returns (string memory) 
+    {
         return metadataService.uri(tokenId);
     }
 
@@ -203,7 +208,6 @@ contract NameWrapper is
     function canModifyName(bytes32 node, address addr)
         public
         view
-        override
         returns (bool)
     {
         (address owner, uint32 fuses, uint64 expiry) = getData(uint256(node));
@@ -227,7 +231,7 @@ contract NameWrapper is
         address wrappedOwner,
         uint16 ownerControlledFuses,
         address resolver
-    ) public override {
+    ) public {
         uint256 tokenId = uint256(keccak256(bytes(label)));
         address registrant = registrar.ownerOf(tokenId);
         if (
@@ -274,7 +278,7 @@ contract NameWrapper is
         uint256 duration,
         address resolver,
         uint16 ownerControlledFuses
-    ) external override onlyController returns (uint256 registrarExpiry) {
+    ) external onlyController returns (uint256 registrarExpiry) {
         uint256 tokenId = uint256(keccak256(bytes(label)));
         registrarExpiry = registrar.register(tokenId, address(this), duration);
         _wrapETH2LD(
@@ -296,7 +300,6 @@ contract NameWrapper is
 
     function renew(uint256 tokenId, uint256 duration)
         external
-        override
         onlyController
         returns (uint256 expires)
     {
@@ -338,7 +341,7 @@ contract NameWrapper is
         bytes calldata name,
         address wrappedOwner,
         address resolver
-    ) public override {
+    ) public {
         (bytes32 labelhash, uint256 offset) = name.readLabel(0);
         bytes32 parentNode = name.namehash(offset);
         bytes32 node = _makeNode(parentNode, labelhash);
@@ -376,7 +379,7 @@ contract NameWrapper is
         bytes32 labelhash,
         address registrant,
         address controller
-    ) public override onlyTokenOwner(_makeNode(ETH_NODE, labelhash)) {
+    ) public onlyTokenOwner(_makeNode(ETH_NODE, labelhash)) {
         if (registrant == address(this)) {
             revert IncorrectTargetOwner(registrant);
         }
@@ -400,7 +403,7 @@ contract NameWrapper is
         bytes32 parentNode,
         bytes32 labelhash,
         address controller
-    ) public override onlyTokenOwner(_makeNode(parentNode, labelhash)) {
+    ) public onlyTokenOwner(_makeNode(parentNode, labelhash)) {
         if (parentNode == ETH_NODE) {
             revert IncompatibleParent();
         }
@@ -643,7 +646,6 @@ contract NameWrapper is
         uint64 ttl
     )
         public
-        override
         onlyTokenOwner(node)
         operationAllowed(
             node,
@@ -671,7 +673,6 @@ contract NameWrapper is
 
     function setResolver(bytes32 node, address resolver)
         public
-        override
         onlyTokenOwner(node)
         operationAllowed(node, CANNOT_SET_RESOLVER)
     {
@@ -686,7 +687,6 @@ contract NameWrapper is
 
     function setTTL(bytes32 node, uint64 ttl)
         public
-        override
         onlyTokenOwner(node)
         operationAllowed(node, CANNOT_SET_TTL)
     {
@@ -759,7 +759,6 @@ contract NameWrapper is
     function allFusesBurned(bytes32 node, uint32 fuseMask)
         public
         view
-        override
         returns (bool)
     {
         (, uint32 fuses, ) = getData(uint256(node));
@@ -777,7 +776,7 @@ contract NameWrapper is
         address,
         uint256 tokenId,
         bytes calldata data
-    ) public override returns (bytes4) {
+    ) public returns (bytes4) {
         //check if it's the eth registrar ERC721
         if (msg.sender != address(registrar)) {
             revert IncorrectTokenType();

--- a/test/wrapper/SupportsInterface.behaviour.js
+++ b/test/wrapper/SupportsInterface.behaviour.js
@@ -76,11 +76,8 @@ const INTERFACES = {
     'setMetadataService(address)',
     'uri(uint256)',
     'setUpgradeContract(address)',
-    'upgrade(bytes32,string,address,address)',
-    'upgradeETH2LD(string,address,address)',
     'ownerOf(uint256)',
     'allFusesBurned(bytes32,uint32)',
-    'isWrapped(bytes32)',
   ],
 }
 

--- a/test/wrapper/SupportsInterface.behaviour.js
+++ b/test/wrapper/SupportsInterface.behaviour.js
@@ -50,9 +50,12 @@ const INTERFACES = {
   ],
   INameWrapper: [
     'ens()',
+    'supportsInterface(bytes4)',
     'registrar()',
     'metadataService()',
     'names(bytes32)',
+    'name()',
+    'upgradeContract()',
     'wrap(bytes,address,address)',
     'wrapETH2LD(string,address,uint16,address)',
     'registerAndWrapETH2LD(string,address,uint256,address,uint16)',
@@ -70,8 +73,14 @@ const INTERFACES = {
     'setResolver(bytes32,address)',
     'setTTL(bytes32,uint64)',
     'getData(uint256)',
+    'setMetadataService(address)',
+    'uri(uint256)',
+    'setUpgradeContract(address)',
+    'upgrade(bytes32,string,address,address)',
+    'upgradeETH2LD(string,address,address)',
     'ownerOf(uint256)',
     'allFusesBurned(bytes32,uint32)',
+    'isWrapped(bytes32)',
   ],
 }
 


### PR DESCRIPTION
This PR fixes a number of issues with the INameWrapper interface including:
- Removing a duplicate INameWrapper interface
- Adding missing functions to the INameWrapper, e.g. isWrapped
- Removing unnecessary interface override statements. 

In order to get the tests to pass I needed to clear old build data. I used:
```
rm -fr node_modules build cache artifacts
yarn
```
@jefflau 