### PR TITLE
Fix namewrapper deploy

### DIFF
--- a/deploy/wrapper/01_deploy_name_wrapper.ts
+++ b/deploy/wrapper/01_deploy_name_wrapper.ts
@@ -50,7 +50,9 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   )
   await tx2.wait()
 
-  const artifact = await deployments.getArtifact('INameWrapper')
+  const artifact = await deployments.getArtifact(
+    'contracts/wrapper/INameWrapper.sol:INameWrapper',
+  )
   const interfaceId = computeInterfaceId(new Interface(artifact.abi))
   const providerWithEns = new ethers.providers.StaticJsonRpcProvider(
     ethers.provider.connection.url,


### PR DESCRIPTION
`NameWrapper` deploy script was using `INameWrapper` as the interface but there are multiple instances of `INameWrapper`, switched to fully qualified name so it knows which one to use