### PR TITLE
Fix/universal resolver support for hashed labels

### DIFF
--- a/contracts/dnsregistrar/DNSClaimChecker.sol
+++ b/contracts/dnsregistrar/DNSClaimChecker.sol
@@ -4,10 +4,12 @@ pragma solidity ^0.8.4;
 import "../dnssec-oracle/DNSSEC.sol";
 import "../dnssec-oracle/BytesUtils.sol";
 import "../dnssec-oracle/RRUtils.sol";
+import "../utils/HexUtils.sol";
 import "@ensdomains/buffer/contracts/Buffer.sol";
 
 library DNSClaimChecker {
     using BytesUtils for bytes;
+    using HexUtils for bytes;
     using RRUtils for *;
     using Buffer for Buffer.buffer;
 

--- a/contracts/dnsregistrar/OffchainDNSResolver.sol
+++ b/contracts/dnsregistrar/OffchainDNSResolver.sol
@@ -9,6 +9,7 @@ import "../dnssec-oracle/BytesUtils.sol";
 import "../dnssec-oracle/DNSSEC.sol";
 import "../dnssec-oracle/RRUtils.sol";
 import "../registry/ENSRegistry.sol";
+import "../utils/HexUtils.sol";
 
 error OffchainLookup(
     address sender,
@@ -31,6 +32,7 @@ uint16 constant TYPE_TXT = 16;
 contract OffchainDNSResolver is IExtendedResolver {
     using RRUtils for *;
     using BytesUtils for bytes;
+    using HexUtils for bytes;
 
     ENS public immutable ens;
     DNSSEC public immutable oracle;

--- a/contracts/dnssec-oracle/BytesUtils.sol
+++ b/contracts/dnssec-oracle/BytesUtils.sol
@@ -397,33 +397,4 @@ library BytesUtils {
         }
         return type(uint256).max;
     }
-
-    /**
-     * @dev Attempts to parse an address from a hex string
-     * @param str The string to parse
-     * @param idx The offset to start parsing at
-     * @param lastIdx The (exclusive) last index in `str` to consider. Use `str.length` to scan the whole string.
-     */
-    function hexToAddress(
-        bytes memory str,
-        uint256 idx,
-        uint256 lastIdx
-    ) internal pure returns (address, bool) {
-        if (lastIdx - idx < 40) return (address(0x0), false);
-        uint256 ret = 0;
-        for (uint256 i = idx; i < idx + 40; i++) {
-            ret <<= 4;
-            uint256 x = readUint8(str, i);
-            if (x >= 48 && x < 58) {
-                ret |= x - 48;
-            } else if (x >= 65 && x < 71) {
-                ret |= x - 55;
-            } else if (x >= 97 && x < 103) {
-                ret |= x - 87;
-            } else {
-                return (address(0x0), false);
-            }
-        }
-        return (address(uint160(ret)), true);
-    }
 }

--- a/contracts/utils/HexUtils.sol
+++ b/contracts/utils/HexUtils.sol
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.4;
+
+library HexUtils {
+    /**
+     * @dev Attempts to parse bytes32 from a hex string
+     * @param str The string to parse
+     * @param idx The offset to start parsing at
+     * @param lastIdx The (exclusive) last index in `str` to consider. Use `str.length` to scan the whole string.
+     */
+    function hexStringToBytes32(
+        bytes memory str,
+        uint256 idx,
+        uint256 lastIdx
+    ) internal pure returns (bytes32 r, bool valid) {
+        valid = true;
+        assembly {
+            // check that the index to read to is not past the end of the string
+            if gt(lastIdx, mload(str)) {
+                revert(0, 0)
+            }
+
+            function getHex(c) -> ascii {
+                // chars 48-57: 0-9
+                if and(gt(c, 47), lt(c, 58)) {
+                    ascii := sub(c, 48)
+                    leave
+                }
+                // chars 65-70: A-F
+                if and(gt(c, 64), lt(c, 71)) {
+                    ascii := add(sub(c, 65), 10)
+                    leave
+                }
+                // chars 97-102: a-f
+                if and(gt(c, 96), lt(c, 103)) {
+                    ascii := add(sub(c, 97), 10)
+                    leave
+                }
+                // invalid char
+                ascii := 0xff
+            }
+
+            let ptr := add(str, 32)
+            for {
+                let i := idx
+            } lt(i, lastIdx) {
+                i := add(i, 2)
+            } {
+                let byte1 := getHex(byte(0, mload(add(ptr, i))))
+                let byte2 := getHex(byte(0, mload(add(ptr, add(i, 1)))))
+                // if either byte is invalid, set invalid and break loop
+                if or(eq(byte1, 0xff), eq(byte2, 0xff)) {
+                    valid := false
+                    break
+                }
+                let combined := or(shl(4, byte1), byte2)
+                r := or(shl(8, r), combined)
+            }
+        }
+    }
+
+    /**
+     * @dev Attempts to parse an address from a hex string
+     * @param str The string to parse
+     * @param idx The offset to start parsing at
+     * @param lastIdx The (exclusive) last index in `str` to consider. Use `str.length` to scan the whole string.
+     */
+    function hexToAddress(
+        bytes memory str,
+        uint256 idx,
+        uint256 lastIdx
+    ) internal pure returns (address, bool) {
+        if (lastIdx - idx < 40) return (address(0x0), false);
+        (bytes32 r, bool valid) = hexStringToBytes32(str, idx, lastIdx);
+        return (address(uint160(uint256(r))), valid);
+    }
+}

--- a/contracts/utils/TestHexUtils.sol
+++ b/contracts/utils/TestHexUtils.sol
@@ -1,0 +1,24 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ~0.8.17;
+
+import {HexUtils} from "./HexUtils.sol";
+
+contract TestHexUtils {
+    using HexUtils for *;
+
+    function hexStringToBytes32(
+        bytes calldata name,
+        uint256 idx,
+        uint256 lastInx
+    ) public pure returns (bytes32, bool) {
+        return name.hexStringToBytes32(idx, lastInx);
+    }
+
+    function hexToAddress(
+        bytes calldata input,
+        uint256 idx,
+        uint256 lastInx
+    ) public pure returns (address, bool) {
+        return input.hexToAddress(idx, lastInx);
+    }
+}

--- a/contracts/utils/UniversalResolver.sol
+++ b/contracts/utils/UniversalResolver.sol
@@ -10,7 +10,7 @@ import {IExtendedResolver} from "../resolvers/profiles/IExtendedResolver.sol";
 import {Resolver, INameResolver, IAddrResolver} from "../resolvers/Resolver.sol";
 import {NameEncoder} from "./NameEncoder.sol";
 import {BytesUtils} from "../wrapper/BytesUtils.sol";
-import "hardhat/console.sol";
+import {HexUtils} from "./HexUtils.sol";
 
 error OffchainLookup(
     address sender,
@@ -55,6 +55,7 @@ contract UniversalResolver is ERC165, Ownable {
     using Address for address;
     using NameEncoder for string;
     using BytesUtils for bytes;
+    using HexUtils for bytes;
 
     string[] public batchGatewayURLs;
     ENS public immutable registry;
@@ -465,7 +466,8 @@ contract UniversalResolver is ERC165, Ownable {
             name[nextLabel - 1] == 0x5d
         ) {
             // Encrypted label
-            labelHash = hexStringToBytes32(name[offset + 2:nextLabel - 1]);
+            (labelHash, ) = bytes(name[offset + 2:nextLabel - 1])
+                .hexStringToBytes32(0, 64);
         } else {
             labelHash = keccak256(name[offset + 1:nextLabel]);
         }
@@ -567,34 +569,5 @@ contract UniversalResolver is ERC165, Ownable {
                 extraDatas
             )
         );
-    }
-
-    function hexStringToBytes32(
-        bytes memory b
-    ) internal pure returns (bytes32 r) {
-        assembly {
-            function getHex(c) -> ascii {
-                if and(gt(c, 47), lt(c, 58)) {
-                    ascii := sub(c, 48)
-                }
-                if and(gt(c, 64), lt(c, 71)) {
-                    ascii := add(sub(c, 65), 10)
-                }
-                if and(gt(c, 96), lt(c, 103)) {
-                    ascii := add(sub(c, 97), 10)
-                }
-            }
-            let ptr := add(b, 32)
-            for {
-                let i := 0
-            } lt(i, 64) {
-                i := add(i, 2)
-            } {
-                let byte1 := byte(0, mload(add(ptr, i)))
-                let byte2 := byte(0, mload(add(ptr, add(i, 1))))
-                let combined := or(shl(4, getHex(byte1)), getHex(byte2))
-                r := or(shl(8, r), combined)
-            }
-        }
     }
 }

--- a/test/utils/HexUtils.js
+++ b/test/utils/HexUtils.js
@@ -1,0 +1,105 @@
+const { use, expect } = require('chai')
+const { solidity } = require('ethereum-waffle')
+const { ethers } = require('hardhat')
+const { toUtf8Bytes } = require('ethers/lib/utils')
+
+use(solidity)
+
+const NULL_HASH =
+  '0x0000000000000000000000000000000000000000000000000000000000000000'
+
+describe('HexUtils', () => {
+  let HexUtils
+
+  before(async () => {
+    const HexUtilsFactory = await ethers.getContractFactory('TestHexUtils')
+    HexUtils = await HexUtilsFactory.deploy()
+  })
+
+  describe('hexStringToBytes32()', () => {
+    it('Converts a hex string to bytes32', async () => {
+      let [bytes32, valid] = await HexUtils.hexStringToBytes32(
+        toUtf8Bytes(
+          '5cee339e13375638553bdf5a6e36ba80fb9f6a4f0783680884d92b558aa471da',
+        ),
+        0,
+        64,
+      )
+      expect(bytes32).to.equal(
+        '0x5cee339e13375638553bdf5a6e36ba80fb9f6a4f0783680884d92b558aa471da',
+      )
+      expect(valid).to.equal(true)
+    })
+    it('Uses the correct index to read from', async () => {
+      let [bytes32, valid] = await HexUtils.hexStringToBytes32(
+        toUtf8Bytes(
+          'zzzzz0x5cee339e13375638553bdf5a6e36ba80fb9f6a4f0783680884d92b558aa471da',
+        ),
+        7,
+        71,
+      )
+      expect(bytes32).to.equal(
+        '0x5cee339e13375638553bdf5a6e36ba80fb9f6a4f0783680884d92b558aa471da',
+      )
+      expect(valid).to.equal(true)
+    })
+    it('Correctly parses all hex characters', async () => {
+      let [bytes32, valid] = await HexUtils.hexStringToBytes32(
+        toUtf8Bytes('0123456789abcdefABCDEF'),
+        0,
+        22,
+      )
+      expect(bytes32).to.equal(
+        '0x0000000000000000000000000000000000000000000123456789abcdefabcdef',
+      )
+      expect(valid).to.equal(true)
+    })
+    it('Returns invalid when the string contains non-hex characters', async () => {
+      const [bytes32, valid] = await HexUtils.hexStringToBytes32(
+        toUtf8Bytes(
+          'zcee339e13375638553bdf5a6e36ba80fb9f6a4f0783680884d92b558aa471da',
+        ),
+        0,
+        64,
+      )
+      expect(bytes32).to.equal(NULL_HASH)
+      expect(valid).to.equal(false)
+    })
+    it('Reverts when the string is too short', async () => {
+      await expect(
+        HexUtils.hexStringToBytes32(
+          toUtf8Bytes(
+            '5cee339e13375638553bdf5a6e36ba80fb9f6a4f0783680884d92b558aa471da',
+          ),
+          1,
+          65,
+        ),
+      ).to.be.reverted
+    })
+  })
+
+  describe('hexToAddress()', () => {
+    it('Converts a hex string to an address', async () => {
+      let [address, valid] = await HexUtils.hexToAddress(
+        toUtf8Bytes(
+          '5cee339e13375638553bdf5a6e36ba80fb9f6a4f0783680884d92b558aa471da',
+        ),
+        0,
+        40,
+      )
+      expect(address).to.equal('0x5ceE339e13375638553bdF5a6e36BA80fB9f6a4F')
+      expect(valid).to.equal(true)
+    })
+    it('Does not allow sizes smaller than 40 characters', async () => {
+      let [address, valid] = await HexUtils.hexToAddress(
+        toUtf8Bytes(
+          '5cee339e13375638553bdf5a6e36ba80fb9f6a4f0783680884d92b558aa471da',
+        ),
+        0,
+        39,
+      )
+      expect(address).to.equal('0x0000000000000000000000000000000000000000')
+      expect(valid).to.equal(false)
+    })
+  })
+})

--- a/test/utils/TestUniversalResolver.js
+++ b/test/utils/TestUniversalResolver.js
@@ -153,6 +153,14 @@ contract('UniversalResolver', function (accounts) {
       )
       expect(result['0']).to.equal(accounts[1])
     })
+    it('should allow encrypted labels', async () => {
+      const result = await universalResolver.callStatic.findResolver(
+        dns.hexEncodeName(
+          '[9c22ff5f21f0b81b113e63f7db6da94fedef11b2119b4088b89664fb9a3cb658].eth',
+        ),
+      )
+      expect(result['0']).to.equal(publicResolver.address)
+    })
   })
 
   describe('resolve()', () => {


### PR DESCRIPTION
names with unknown labels (e.g. "[5cee339e13375638553bdf5a6e36ba80fb9f6a4f0783680884d92b558aa471da].eth") don't currently work with UR (label being re-hashed instead of using the string as the hash). this PR adds support for them by converting the label directly to a bytes32 labelhash.