### PR TITLE
Reduce power of approve(). Protect extend and add approved to upgrade

### DIFF
--- a/contracts/wrapper/INameWrapper.sol
+++ b/contracts/wrapper/INameWrapper.sol
@@ -62,7 +62,7 @@ interface INameWrapper is IERC1155 {
         address wrappedOwner,
         uint16 ownerControlledFuses,
         address resolver
-    ) external;
+    ) external returns (uint64 expires);
 
     function registerAndWrapETH2LD(
         string calldata label,

--- a/contracts/wrapper/INameWrapperUpgrade.sol
+++ b/contracts/wrapper/INameWrapperUpgrade.sol
@@ -7,6 +7,7 @@ interface INameWrapperUpgrade {
         address wrappedOwner,
         uint32 fuses,
         uint64 expiry,
+        address approved,
         bytes calldata extraData
     ) external;
 }

--- a/contracts/wrapper/NameWrapper.sol
+++ b/contracts/wrapper/NameWrapper.sol
@@ -511,6 +511,10 @@ contract NameWrapper is
     ) public returns (uint64) {
         bytes32 node = _makeNode(parentNode, labelhash);
 
+        if (!_isWrapped(node)) {
+            revert NameIsNotWrapped();
+        }
+
         // this flag is used later, when checking fuses
         bool canModifyParentSubname = canModifySubnames(parentNode, msg.sender);
         // only allow the owner of the name or owner of the parent name

--- a/contracts/wrapper/NameWrapper.sol
+++ b/contracts/wrapper/NameWrapper.sol
@@ -562,6 +562,8 @@ contract NameWrapper is
             uint256(node)
         );
 
+        address approved = getApproved(uint256(node));
+
         _burn(uint256(node));
 
         upgradeContract.wrapFromUpgrade(
@@ -569,6 +571,7 @@ contract NameWrapper is
             currentOwner,
             fuses,
             expiry,
+            approved,
             extraData
         );
     }

--- a/contracts/wrapper/mocks/TestUnwrap.sol
+++ b/contracts/wrapper/mocks/TestUnwrap.sol
@@ -55,6 +55,7 @@ contract TestUnwrap is Ownable {
         address wrappedOwner,
         uint32 fuses,
         uint64 expiry,
+        address approved,
         bytes calldata extraData
     ) public {
         (bytes32 labelhash, uint256 offset) = name.readLabel(0);

--- a/contracts/wrapper/mocks/UpgradedNameWrapperMock.sol
+++ b/contracts/wrapper/mocks/UpgradedNameWrapperMock.sol
@@ -24,6 +24,7 @@ contract UpgradedNameWrapperMock is INameWrapperUpgrade {
         address wrappedOwner,
         uint32 fuses,
         uint64 expiry,
+        address approved,
         bytes extraData
     );
 
@@ -32,6 +33,7 @@ contract UpgradedNameWrapperMock is INameWrapperUpgrade {
         address wrappedOwner,
         uint32 fuses,
         uint64 expiry,
+        address approved,
         bytes calldata extraData
     ) public {
         (bytes32 labelhash, uint256 offset) = name.readLabel(0);
@@ -53,7 +55,14 @@ contract UpgradedNameWrapperMock is INameWrapperUpgrade {
                 "No approval for registry"
             );
         }
-        emit NameUpgraded(name, wrappedOwner, fuses, expiry, extraData);
+        emit NameUpgraded(
+            name,
+            wrappedOwner,
+            fuses,
+            expiry,
+            approved,
+            extraData
+        );
     }
 
     function _makeNode(

--- a/test/wrapper/TestUnwrap.js
+++ b/test/wrapper/TestUnwrap.js
@@ -184,7 +184,14 @@ describe('TestUnwrap', () => {
         await TestUnwrap.setWrapperApproval(NameWrapper.address, true)
 
         await expect(
-          TestUnwrap.wrapFromUpgrade(encodedName, account, 0, 0, 0),
+          TestUnwrap.wrapFromUpgrade(
+            encodedName,
+            account,
+            0,
+            0,
+            EMPTY_ADDRESS,
+            0,
+          ),
         ).to.be.revertedWith('Unauthorised')
       })
     })
@@ -276,7 +283,14 @@ describe('TestUnwrap', () => {
         await TestUnwrap.setWrapperApproval(NameWrapper.address, true)
 
         await expect(
-          TestUnwrap.wrapFromUpgrade(encodedName, account, 0, 0, 0),
+          TestUnwrap.wrapFromUpgrade(
+            encodedName,
+            account,
+            0,
+            0,
+            EMPTY_ADDRESS,
+            0,
+          ),
         ).to.be.revertedWith('Unauthorised')
       })
     })


### PR DESCRIPTION
* Fixes an issue with extendExpiry that allows name to be burnt without resetting approve
* Fix issue with upgrade that didn't take into account approvals
* Add additional tests for the above issues
* Reduce the power of approvals to only allow access to extendExpiry

Thanks to @ZhangZhuoSJTU for the extra tests, and helping us find some issues with extendExpiry and upgrade