### PR TITLE
Allow the "approved address" to call extendExpiry instead of the owner when CAN_EXTEND_EXPIRY is burned. 

### DIFF
--- a/contracts/wrapper/ERC1155Fuse.sol
+++ b/contracts/wrapper/ERC1155Fuse.sol
@@ -40,7 +40,6 @@ abstract contract ERC1155Fuse is ERC165, IERC1155, IERC1155MetadataURI {
      */
     function approve(address to, uint256 tokenId) public virtual {
         address owner = ownerOf(tokenId);
-        require(to != owner, "ERC721: approval to current owner");
 
         require(
             msg.sender == owner || isApprovedForAll(owner, msg.sender),

--- a/contracts/wrapper/INameWrapper.sol
+++ b/contracts/wrapper/INameWrapper.sol
@@ -120,6 +120,7 @@ interface INameWrapper is IERC1155 {
         bytes32 node,
         string calldata label,
         address newOwner,
+        address approved,
         uint32 fuses,
         uint64 expiry
     ) external returns (bytes32);

--- a/contracts/wrapper/NameWrapper.sol
+++ b/contracts/wrapper/NameWrapper.sol
@@ -526,7 +526,7 @@ contract NameWrapper is
             return expiry;
         }
 
-        // Check to make sure the caller is the approved contract and CAN_EXTEND_EXPIRY is set.
+        // If the caller is the approved contract of the node and CAN_EXTEND_EXPIRY is set, then the caller can extend the expiry.
         if (
             getApproved(uint256(node)) != msg.sender ||
             fuses & CAN_EXTEND_EXPIRY == 0

--- a/contracts/wrapper/NameWrapper.sol
+++ b/contracts/wrapper/NameWrapper.sol
@@ -658,7 +658,9 @@ contract NameWrapper is
         if (!_isWrapped(node)) {
             ens.setSubnodeOwner(parentNode, labelhash, address(this));
             // Add an approved address
-            super._approve(approved, uint256(node));
+            if (approved != address(0)) {
+                super._approve(approved, uint256(node));
+            }
             _wrap(node, name, owner, fuses, expiry);
         } else {
             _updateName(parentNode, node, label, owner, fuses, expiry);

--- a/contracts/wrapper/NameWrapper.sol
+++ b/contracts/wrapper/NameWrapper.sol
@@ -14,7 +14,6 @@ import {IERC721Receiver} from "@openzeppelin/contracts/token/ERC721/IERC721Recei
 import "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {BytesUtils} from "./BytesUtils.sol";
-import {ERC20Recoverable} from "../utils/ERC20Recoverable.sol";
 
 error Unauthorised(bytes32 node, address addr);
 error IncompatibleParent();
@@ -34,7 +33,6 @@ contract NameWrapper is
     INameWrapper,
     Controllable,
     IERC721Receiver,
-    ERC20Recoverable,
     ReverseClaimer
 {
     using BytesUtils for bytes;
@@ -516,8 +514,8 @@ contract NameWrapper is
             uint256(node)
         );
 
-        // If the caller is the owner of the parent, then we can extend the expiry.
-        if (canModifyParentSubname) {
+        // If the caller is the owner of the parent or approved, then the caller can extend the expiry.
+        if (canExtendSubname) {
             // max expiry is set to the expiry of the parent
             (, , uint64 maxExpiry) = getData(uint256(parentNode));
             expiry = _normaliseExpiry(expiry, oldExpiry, maxExpiry);

--- a/contracts/wrapper/NameWrapper.sol
+++ b/contracts/wrapper/NameWrapper.sol
@@ -516,8 +516,23 @@ contract NameWrapper is
             uint256(node)
         );
 
-        // Either CAN_EXTEND_EXPIRY must be set, or the caller must have permission to modify the parent name
-        if (!canExtendSubname && fuses & CAN_EXTEND_EXPIRY == 0) {
+        // If the caller is the owner of the parent, then we can extend the expiry.
+        if (canModifyParentSubname) {
+            // max expiry is set to the expiry of the parent
+            (, , uint64 maxExpiry) = getData(uint256(parentNode));
+            expiry = _normaliseExpiry(expiry, oldExpiry, maxExpiry);
+
+            _setData(node, owner, fuses, expiry);
+            emit ExpiryExtended(node, expiry);
+
+            return expiry;
+        }
+
+        // Check to make sure the caller is the approved contract and CAN_EXTEND_EXPIRY is set.
+        if (
+            getApproved(uint256(node)) != msg.sender ||
+            fuses & CAN_EXTEND_EXPIRY == 0
+        ) {
             revert OperationProhibited(node);
         }
 
@@ -629,6 +644,7 @@ contract NameWrapper is
         bytes32 parentNode,
         string calldata label,
         address owner,
+        address approved,
         uint32 fuses,
         uint64 expiry
     ) public onlyTokenOwner(parentNode) returns (bytes32 node) {
@@ -641,6 +657,8 @@ contract NameWrapper is
 
         if (!_isWrapped(node)) {
             ens.setSubnodeOwner(parentNode, labelhash, address(this));
+            // Add an approved address
+            super._approve(approved, uint256(node));
             _wrap(node, name, owner, fuses, expiry);
         } else {
             _updateName(parentNode, node, label, owner, fuses, expiry);

--- a/test/wrapper/Constraints.behaviour.js
+++ b/test/wrapper/Constraints.behaviour.js
@@ -83,6 +83,7 @@ function shouldRespectConstraints(contracts, getSigners) {
       parentNode,
       childLabel,
       account2,
+      EMPTY_ADDRESS,
       childFuses,
       childExpiry, // Expired
     )
@@ -144,6 +145,7 @@ function shouldRespectConstraints(contracts, getSigners) {
       parentNode,
       childLabel,
       account2,
+      EMPTY_ADDRESS,
       childFuses,
       parentExpiry - 86400, // Expires a day before parent
     )
@@ -267,6 +269,7 @@ function shouldRespectConstraints(contracts, getSigners) {
         parentNode,
         childLabel,
         account2,
+        EMPTY_ADDRESS,
         CAN_DO_EVERYTHING,
         MAX_EXPIRY,
       )
@@ -318,6 +321,7 @@ function shouldRespectConstraints(contracts, getSigners) {
           parentNode,
           childLabel,
           account2,
+          EMPTY_ADDRESS,
           CAN_DO_EVERYTHING,
           MAX_EXPIRY,
         ),
@@ -347,6 +351,7 @@ function shouldRespectConstraints(contracts, getSigners) {
         parentNode,
         childLabel,
         account,
+        EMPTY_ADDRESS,
         CAN_DO_EVERYTHING,
         0,
       )
@@ -477,6 +482,7 @@ function shouldRespectConstraints(contracts, getSigners) {
           parentNode,
           childLabel,
           account2,
+          EMPTY_ADDRESS,
           CANNOT_UNWRAP | PARENT_CANNOT_CONTROL,
           0,
         ),
@@ -518,6 +524,7 @@ function shouldRespectConstraints(contracts, getSigners) {
         parentNode,
         childLabel,
         account2,
+        EMPTY_ADDRESS,
         CANNOT_UNWRAP | PARENT_CANNOT_CONTROL | CANNOT_SET_RESOLVER,
         0,
       )
@@ -572,6 +579,7 @@ function shouldRespectConstraints(contracts, getSigners) {
           parentNode,
           childLabel,
           account2,
+          EMPTY_ADDRESS,
           CANNOT_UNWRAP | CANNOT_SET_RESOLVER,
           0,
         ),
@@ -624,6 +632,7 @@ function shouldRespectConstraints(contracts, getSigners) {
           parentNode,
           childLabel,
           account2,
+          EMPTY_ADDRESS,
           CANNOT_SET_RESOLVER,
           0,
         ),
@@ -634,6 +643,7 @@ function shouldRespectConstraints(contracts, getSigners) {
           parentNode,
           childLabel,
           account2,
+          EMPTY_ADDRESS,
           CANNOT_UNWRAP | CANNOT_SET_RESOLVER,
           0,
         ),
@@ -644,6 +654,7 @@ function shouldRespectConstraints(contracts, getSigners) {
           parentNode,
           childLabel,
           account2,
+          EMPTY_ADDRESS,
           PARENT_CANNOT_CONTROL | CANNOT_UNWRAP | CANNOT_SET_RESOLVER,
           0,
         ),
@@ -698,6 +709,7 @@ function shouldRespectConstraints(contracts, getSigners) {
           parentNode,
           childLabel,
           account,
+          EMPTY_ADDRESS,
           CAN_DO_EVERYTHING,
           0,
         ),
@@ -743,8 +755,16 @@ function shouldRespectConstraints(contracts, getSigners) {
     })
 
     it('Parent cannot call ens.subnodeOwner to forcefully unwrap', async () => {
-      await expect(EnsRegistry.setSubnodeOwner(parentNode, childNode, account))
-        .to.be.reverted
+      await expect(
+        EnsRegistry.setSubnodeOwner(
+          parentNode,
+          childNode,
+          account,
+          EMPTY_ADDRESS,
+          0,
+          0,
+        ),
+      ).to.be.reverted
     })
   }
 
@@ -820,6 +840,7 @@ function shouldRespectConstraints(contracts, getSigners) {
           parentNode,
           childLabel,
           account2,
+          EMPTY_ADDRESS,
           PARENT_CANNOT_CONTROL,
           0,
         ),
@@ -907,6 +928,7 @@ function shouldRespectConstraints(contracts, getSigners) {
         parentNode,
         childLabel,
         account2,
+        EMPTY_ADDRESS,
         CAN_DO_EVERYTHING, // Node's CU/PCC not burned
         0, // Expired
       )
@@ -1239,7 +1261,14 @@ function shouldRespectConstraints(contracts, getSigners) {
 
     it('Parent cannot unburn fuses with setSubnodeOwner()', async () => {
       await expect(
-        NameWrapper.setSubnodeOwner(parentNode, childLabel, account2, 0, 0),
+        NameWrapper.setSubnodeOwner(
+          parentNode,
+          childLabel,
+          account2,
+          EMPTY_ADDRESS,
+          0,
+          0,
+        ),
       ).to.be.revertedWith(`OperationProhibited("${childNode}")`)
       const [, fuses] = await NameWrapper.getData(childNode)
       expect(fuses).to.equal(PARENT_CANNOT_CONTROL)
@@ -1320,6 +1349,7 @@ function shouldRespectConstraints(contracts, getSigners) {
           parentNode,
           childLabel,
           account2,
+          EMPTY_ADDRESS,
           CANNOT_UNWRAP,
           0,
         ),
@@ -1370,6 +1400,7 @@ function shouldRespectConstraints(contracts, getSigners) {
           parentNode,
           childLabel,
           account2,
+          EMPTY_ADDRESS,
           CANNOT_UNWRAP,
           0,
         ),
@@ -1439,7 +1470,14 @@ function shouldRespectConstraints(contracts, getSigners) {
 
     it('Parent cannot unburn fuses with setSubnodeOwner()', async () => {
       await expect(
-        NameWrapper.setSubnodeOwner(parentNode, childLabel, account2, 0, 0),
+        NameWrapper.setSubnodeOwner(
+          parentNode,
+          childLabel,
+          account2,
+          EMPTY_ADDRESS,
+          0,
+          0,
+        ),
       ).to.be.revertedWith(`OperationProhibited("${childNode}")`)
       const [, fuses] = await NameWrapper.getData(childNode)
       expect(fuses).to.equal(PARENT_CANNOT_CONTROL | CANNOT_UNWRAP)

--- a/test/wrapper/SupportsInterface.behaviour.js
+++ b/test/wrapper/SupportsInterface.behaviour.js
@@ -67,7 +67,7 @@ const INTERFACES = {
     'setChildFuses(bytes32,bytes32,uint32,uint64)',
     'setSubnodeRecord(bytes32,string,address,address,uint64,uint32,uint64)',
     'setRecord(bytes32,address,address,uint64)',
-    'setSubnodeOwner(bytes32,string,address,uint32,uint64)',
+    'setSubnodeOwner(bytes32,string,address,address,uint32,uint64)',
     'extendExpiry(bytes32,bytes32,uint64)',
     'canModifyName(bytes32,address)',
     'setResolver(bytes32,address)',

--- a/test/wrapper/TestUnwrap.js
+++ b/test/wrapper/TestUnwrap.js
@@ -218,6 +218,7 @@ describe('TestUnwrap', () => {
           parentHash,
           'to-upgrade',
           account,
+          EMPTY_ADDRESS,
           0,
           0,
         )
@@ -246,6 +247,7 @@ describe('TestUnwrap', () => {
           parentHash,
           'to-upgrade',
           account,
+          EMPTY_ADDRESS,
           0,
           0,
         )
@@ -273,6 +275,7 @@ describe('TestUnwrap', () => {
           parentHash,
           'to-upgrade',
           account,
+          EMPTY_ADDRESS,
           0,
           0,
         )


### PR DESCRIPTION
**Why is it necessary to have a “Renewal Controller” for every subname?**

With a single parent level renewal controller (approved contract), it is necessary to predict exactly how all names in the namespace will be used, which can be difficult or even impossible. However, with approved contracts "renewal controllers" attached to each individual subname, it is possible to start using the namespace right away. For instance, one could create a contract for a numbers collection, e.g. 247.netdao.eth,  and start issuing names, then move on to a membership contract and begin using member names, e.g. tom.netdao.eth. An event can be created and tickets sold with an event renewal controller, and later on, a renewal controller can be made for a metaverse platform, and so on.

**Is it still possible for the owner to extend their own subname?**
Yes, the owner can be set as the approved address for the subname, or a contract can be approved that allows the owner to renew their own subname.

Note: We are getting very close to the max contract size. In order to make the tests pass I deleted ERC20Recoverable. It is possible with some work to get it back by doing some refactoring, in the case where this PR is adopted. 


