### PR TITLE
fix: universal resolver gas issues

### DIFF
--- a/contracts/resolvers/Resolver.sol
+++ b/contracts/resolvers/Resolver.sol
@@ -34,13 +34,17 @@ interface Resolver is
     /* Deprecated events */
     event ContentChanged(bytes32 indexed node, bytes32 hash);
 
-    function setApprovalForAll(address, bool) external; 
+    function setApprovalForAll(address, bool) external;
 
-    function approve(bytes32 node, address delegate, bool approved) external; 
+    function approve(bytes32 node, address delegate, bool approved) external;
 
     function isApprovedForAll(address account, address operator) external;
 
-    function isApprovedFor(address owner, bytes32 node, address delegate) external;
+    function isApprovedFor(
+        address owner,
+        bytes32 node,
+        address delegate
+    ) external;
 
     function setABI(
         bytes32 node,

--- a/contracts/utils/DummyOldResolver.sol
+++ b/contracts/utils/DummyOldResolver.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.17;
+pragma solidity 0.4.11;
 
 contract DummyOldResolver {
-    function test() public pure returns (bool) {
+    function test() public returns (bool) {
         return true;
     }
 
-    function name(bytes32) public pure returns (string memory) {
+    function name(bytes32) public returns (string memory) {
         return "test.eth";
     }
 }

--- a/contracts/utils/DummyOldResolver.sol
+++ b/contracts/utils/DummyOldResolver.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.17;
+
+contract DummyOldResolver {
+    function test() public pure returns (bool) {
+        return true;
+    }
+
+    function name(bytes32) public pure returns (string memory) {
+        return "test.eth";
+    }
+}

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -6,12 +6,11 @@ import '@nomiclabs/hardhat-truffle5'
 import '@nomiclabs/hardhat-waffle'
 import dotenv from 'dotenv'
 import 'hardhat-abi-exporter'
+import 'hardhat-contract-sizer'
 import 'hardhat-deploy'
 import 'hardhat-gas-reporter'
-import { HardhatUserConfig, task } from 'hardhat/config'
-import { Artifact } from 'hardhat/types'
+import { HardhatUserConfig } from 'hardhat/config'
 import { promisify } from 'util'
-import 'hardhat-contract-sizer'
 
 const exec = promisify(_exec)
 
@@ -84,6 +83,16 @@ const config: HardhatUserConfig = {
           optimizer: {
             enabled: true,
             runs: 1300,
+          },
+        },
+      },
+      // for DummyOldResolver contract
+      {
+        version: '0.4.11',
+        settings: {
+          optimizer: {
+            enabled: true,
+            runs: 200,
           },
         },
       },

--- a/test/utils/TestUniversalResolver.js
+++ b/test/utils/TestUniversalResolver.js
@@ -618,7 +618,7 @@ contract('UniversalResolver', function (accounts) {
         dns.hexEncodeName(oldResolverReverseNode),
         { gasLimit: 8000000 },
       )
-      expect(estimate.lt(8000000)).to.be.true
+      expect(estimate.lt(200000)).to.be.true
     })
   })
 })

--- a/test/utils/TestUniversalResolver.js
+++ b/test/utils/TestUniversalResolver.js
@@ -33,7 +33,8 @@ contract('UniversalResolver', function (accounts) {
     nameWrapper,
     reverseRegistrar,
     reverseNode,
-    batchGateway
+    batchGateway,
+    dummyOldResolver
 
   before(async () => {
     batchGateway = (await ethers.getContractAt('BatchGateway', ZERO_ADDRESS))
@@ -55,6 +56,8 @@ contract('UniversalResolver', function (accounts) {
     nameWrapper = await deploy('DummyNameWrapper')
     reverseRegistrar = await deploy('ReverseRegistrar', ens.address)
     reverseNode = accounts[0].toLowerCase().substring(2) + '.addr.reverse'
+    oldResolverReverseNode =
+      accounts[10].toLowerCase().substring(2) + '.addr.reverse'
     await ens.setSubnodeOwner(EMPTY_BYTES32, sha3('reverse'), accounts[0], {
       from: accounts[0],
     })
@@ -75,6 +78,7 @@ contract('UniversalResolver', function (accounts) {
       'http://universal-offchain-resolver.local/',
     ])
     dummyOffchainResolver = await deploy('DummyOffchainResolver')
+    dummyOldResolver = await deploy('DummyOldResolver')
 
     await ens.setSubnodeOwner(EMPTY_BYTES32, sha3('eth'), accounts[0], {
       from: accounts[0],
@@ -124,6 +128,16 @@ contract('UniversalResolver', function (accounts) {
       from: accounts[0],
     })
     await publicResolver.setName(namehash.hash(reverseNode), 'test.eth')
+
+    const oldResolverSigner = await ethers.getSigner(accounts[10])
+    const _reverseRegistrar = reverseRegistrar.connect(oldResolverSigner)
+    const _ens = ens.connect(oldResolverSigner)
+
+    await _reverseRegistrar.claim(accounts[10])
+    await _ens.setResolver(
+      namehash.hash(oldResolverReverseNode),
+      dummyOldResolver.address,
+    )
   })
 
   const resolveCallbackSig = ethers.utils.hexDataSlice(
@@ -598,6 +612,13 @@ contract('UniversalResolver', function (accounts) {
       expect(result['1']).to.equal(accounts[1])
       expect(result['2']).to.equal(publicResolver.address)
       expect(result['3']).to.equal(publicResolver.address)
+    })
+    it('should not use all the gas on a revert', async () => {
+      const estimate = await universalResolver.estimateGas['reverse(bytes)'](
+        dns.hexEncodeName(oldResolverReverseNode),
+        { gasLimit: 8000000 },
+      )
+      expect(estimate.lt(8000000)).to.be.true
     })
   })
 })


### PR DESCRIPTION
previously, if the universalresolver's `_hasExtendedResolver()` function tried to call `supportsInterface()` on a contract without the function, it would always use the remaining gas for the function (calling invalid instruction = use all gas)

now the call to `supportsInterface()` has a manual gas limit of 50k, which is 10x normal usage so should be fine for edge cases as well. if the function doesn't exist the 50k gas limit will be used up instead of the limit of the whole call.