### PR TITLE
Feature/Allow signed messages to claim reverse nodes

### DIFF
--- a/contracts/reverseRegistrar/IReverseRegistrar.sol
+++ b/contracts/reverseRegistrar/IReverseRegistrar.sol
@@ -11,6 +11,15 @@ interface IReverseRegistrar {
         address resolver
     ) external returns (bytes32);
 
+    function claimForAddrWithSignature(
+        address addr,
+        address owner,
+        address resolver,
+        address relayer,
+        uint256 signatureExpiry,
+        bytes calldata signature
+    ) external returns (bytes32);
+
     function claimWithResolver(
         address owner,
         address resolver
@@ -22,6 +31,16 @@ interface IReverseRegistrar {
         address addr,
         address owner,
         address resolver,
+        string memory name
+    ) external returns (bytes32);
+
+    function setNameForAddrWithSignature(
+        address addr,
+        address owner,
+        address resolver,
+        address relayer,
+        uint256 signatureExpiry,
+        bytes calldata signature,
         string memory name
     ) external returns (bytes32);
 

--- a/contracts/reverseRegistrar/ReverseRegistrar.sol
+++ b/contracts/reverseRegistrar/ReverseRegistrar.sol
@@ -132,6 +132,7 @@ contract ReverseRegistrar is Ownable, Controllable, IReverseRegistrar {
                 signatureExpiry
             )
         );
+
         bytes32 message = hash.toEthSignedMessageHash();
 
         if (
@@ -196,6 +197,37 @@ contract ReverseRegistrar is Ownable, Controllable, IReverseRegistrar {
         string memory name
     ) public override returns (bytes32) {
         bytes32 node = claimForAddr(addr, owner, resolver);
+        NameResolver(resolver).setName(node, name);
+        return node;
+    }
+
+    /**
+     * @dev Sets the `name()` record for the reverse ENS record associated with
+     * the account provided. Updates the resolver to a designated resolver
+     * Only callable by controllers and authorised users
+     * @param addr The reverse record to set
+     * @param owner The owner of the reverse node
+     * @param resolver The resolver of the reverse node
+     * @param name The name to set for this address.
+     * @return The ENS node hash of the reverse record.
+     */
+    function setNameForAddrWithSignature(
+        address addr,
+        address owner,
+        address resolver,
+        address relayer,
+        uint256 signatureExpiry,
+        bytes memory signature,
+        string memory name
+    ) public returns (bytes32) {
+        bytes32 node = claimForAddrWithSignature(
+            addr,
+            owner,
+            resolver,
+            relayer,
+            signatureExpiry,
+            signature
+        );
         NameResolver(resolver).setName(node, name);
         return node;
     }

--- a/contracts/reverseRegistrar/ReverseRegistrar.sol
+++ b/contracts/reverseRegistrar/ReverseRegistrar.sol
@@ -15,12 +15,6 @@ bytes32 constant lookup = 0x3031323334353637383961626364656600000000000000000000
 
 bytes32 constant ADDR_REVERSE_NODE = 0x91d1777781884d03a6757a803996e38de2a42967fb37eeaca72729271025a9e2;
 
-bytes4 constant claimForAddrWithSignatureFuncId = bytes4(
-    keccak256(
-        "claimForAddrWithSignature(address,address,address,address,uint256,bytes)"
-    )
-);
-
 error InvalidSignature();
 
 // namehash('addr.reverse')
@@ -116,7 +110,7 @@ contract ReverseRegistrar is Ownable, Controllable, IReverseRegistrar {
         address relayer,
         uint256 signatureExpiry,
         bytes memory signature
-    ) public returns (bytes32) {
+    ) public override returns (bytes32) {
         bytes32 labelHash = sha3HexAddress(addr);
         bytes32 reverseNode = keccak256(
             abi.encodePacked(ADDR_REVERSE_NODE, labelHash)
@@ -124,7 +118,7 @@ contract ReverseRegistrar is Ownable, Controllable, IReverseRegistrar {
 
         bytes32 hash = keccak256(
             abi.encodePacked(
-                claimForAddrWithSignatureFuncId,
+                IReverseRegistrar.claimForAddrWithSignature.selector,
                 addr,
                 owner,
                 resolver,
@@ -219,7 +213,7 @@ contract ReverseRegistrar is Ownable, Controllable, IReverseRegistrar {
         uint256 signatureExpiry,
         bytes memory signature,
         string memory name
-    ) public returns (bytes32) {
+    ) public override returns (bytes32) {
         bytes32 node = claimForAddrWithSignature(
             addr,
             owner,

--- a/contracts/reverseRegistrar/ReverseRegistrar.sol
+++ b/contracts/reverseRegistrar/ReverseRegistrar.sol
@@ -137,7 +137,8 @@ contract ReverseRegistrar is Ownable, Controllable, IReverseRegistrar {
         if (
             !SignatureChecker.isValidSignatureNow(addr, message, signature) ||
             relayer != msg.sender ||
-            signatureExpiry < block.timestamp
+            signatureExpiry < block.timestamp ||
+            signatureExpiry > block.timestamp + 1 days
         ) {
             revert InvalidSignature();
         }

--- a/test/reverseRegistrar/TestReverseRegistrar.js
+++ b/test/reverseRegistrar/TestReverseRegistrar.js
@@ -20,11 +20,13 @@ function assertReverseClaimedEventEmitted(tx, addr, node) {
 }
 
 contract('ReverseRegistrar', function (accounts) {
-  let node, node2, node3, dummyOwnableReverseNode
+  let node, node2, node3, dummyOwnableReverseNode, signers
 
   let registrar, resolver, ens, nameWrapper, dummyOwnable, defaultResolver
 
   beforeEach(async () => {
+    signers = await ethers.getSigners()
+
     node = getReverseNode(accounts[0])
     node2 = getReverseNode(accounts[1])
     node3 = getReverseNode(accounts[2])
@@ -250,6 +252,58 @@ contract('ReverseRegistrar', function (accounts) {
         await resolver.name(dummyOwnableReverseNode),
         'dummyownable.eth',
       )
+    })
+  })
+
+  describe('claimForAddrWithSignature', () => {
+    it('allows an account to sign a message to allow a relayer to claim the address', async () => {
+      const funcId = ethers.utils
+        .id(
+          'claimForAddrWithSignature(address,address,address,address,uint256,bytes)',
+        )
+        .substring(0, 10)
+      const block = await ethers.provider.getBlock('latest')
+      const signatureExpiry = block.timestamp + 3600
+      const signature = await signers[0].signMessage(
+        ethers.utils.arrayify(
+          ethers.utils.solidityKeccak256(
+            ['bytes4', 'address', 'address', 'address', 'address', 'uint256'],
+            [
+              funcId,
+              accounts[0],
+              accounts[1],
+              resolver.address,
+              accounts[2],
+              signatureExpiry,
+            ],
+          ),
+        ),
+      )
+
+      await registrar.claimForAddrWithSignature(
+        accounts[0],
+        accounts[1],
+        resolver.address,
+        accounts[2],
+        signatureExpiry,
+        signature,
+        {
+          from: accounts[2],
+        },
+      )
+      assert.equal(await ens.owner(node), accounts[1])
+    })
+
+    it('event ReverseClaimed is emitted', async () => {
+      const tx = await registrar.claimForAddr(
+        accounts[0],
+        accounts[1],
+        resolver.address,
+        {
+          from: accounts[0],
+        },
+      )
+      assertReverseClaimedEventEmitted(tx, accounts[0], node)
     })
   })
 


### PR DESCRIPTION
* Allows an address to assign a relayer to claim on its behalf
* Would allow contract wallets to claim their reverse node after deploy as it uses ERC-1271 method of verification
* Uses expiry instead of a nonce. However possible attack is to trick a user into signing a message far into the future which would allow them to change the reverse node possibly indefinitely. Have added upper limit to expiry. May consider moving back to a nonce for replay attack protection.