### PR TITLE
Example contract to allow anyone to extend a subname

### DIFF
--- a/contracts/wrapper/OpenRenewalManager.sol
+++ b/contracts/wrapper/OpenRenewalManager.sol
@@ -20,6 +20,6 @@ contract OpenRenewalManager is ReverseClaimer {
         bytes32 labelhash,
         uint64 expiry
     ) public returns (uint64) {
-        nameWrapper.extendExpiry(parentNode, labelhash, expiry);
+        return nameWrapper.extendExpiry(parentNode, labelhash, expiry);
     }
 }

--- a/contracts/wrapper/OpenRenewalManager.sol
+++ b/contracts/wrapper/OpenRenewalManager.sol
@@ -1,0 +1,25 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ~0.8.17;
+
+import "../registry/ENS.sol";
+import {ReverseClaimer} from "../reverseRegistrar/ReverseClaimer.sol";
+import {INameWrapper} from "./INameWrapper.sol";
+
+contract OpenRenewalManager is ReverseClaimer {
+    INameWrapper immutable nameWrapper;
+
+    constructor(
+        ENS _ens,
+        INameWrapper wrapperAddress
+    ) ReverseClaimer(_ens, msg.sender) {
+        nameWrapper = wrapperAddress;
+    }
+
+    function extendExpiry(
+        bytes32 parentNode,
+        bytes32 labelhash,
+        uint64 expiry
+    ) public returns (uint64) {
+        nameWrapper.extendExpiry(parentNode, labelhash, expiry);
+    }
+}


### PR DESCRIPTION
1. Call `approve` on the NameWrapper to approve this contract as the "Subname Renewal Manager" for your name
2. Revoke the "Can Approve" permission on your wrapped name

Now _any_ account will be able to extend the expiry for _any_ subname under that name, similar to .eth 2LDs.

No fees (just gas). So this would not be useful to anyone looking to rent subnames for a fee. Instead, this is useful for people who want to issue "forever" subnames (possibly with immutable records too) and then guarantee that they will always be able to be extended, even if the parent owner goes AWOL.