### PR TITLE
fix: update cost of event NameRenewed

### DIFF
--- a/contracts/ethregistrar/ETHRegistrarController.sol
+++ b/contracts/ethregistrar/ETHRegistrarController.sol
@@ -223,7 +223,7 @@ contract ETHRegistrarController is
             payable(msg.sender).transfer(msg.value - price.base);
         }
 
-        emit NameRenewed(name, labelhash, msg.value, expires);
+        emit NameRenewed(name, labelhash, price.base, expires);
     }
 
     function withdraw() public {


### PR DESCRIPTION
Since the variable `cost` in the event `NameRenewed` is the actual cost taken. That is not the `msg.value` but is the `price.base`:
```solidity
    event NameRenewed(
        string name,
        bytes32 indexed label,
        uint256 cost,
        uint256 expires
    );
```