### PR TITLE
add interface cmd to hardhat

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -17,6 +17,7 @@ const exec = promisify(_exec)
 // hardhat actions
 import './tasks/accounts'
 import './tasks/archive_scan'
+import './tasks/interface'
 import './tasks/save'
 import './tasks/seed'
 

--- a/tasks/interface.ts
+++ b/tasks/interface.ts
@@ -1,0 +1,17 @@
+import { Interface } from 'ethers/lib/utils'
+import { task } from 'hardhat/config'
+
+const { makeInterfaceId } = require('@openzeppelin/test-helpers')
+
+function computeInterfaceId(iface: Interface) {
+  return makeInterfaceId.ERC165(
+    Object.values(iface.functions).map((frag) => frag.format('sighash')),
+  )
+}
+
+task('interface', 'Prints the EIP165 interface ID of a contract')
+  .addPositionalParam('contract', 'The contract to print the interface ID of')
+  .setAction(async ({ contract }, hre) => {
+    const artifact = await hre.artifacts.readArtifact(contract)
+    console.log(computeInterfaceId(new Interface(artifact.abi)))
+  })


### PR DESCRIPTION
the `interface` cmd (used via `yarn hardhat interface`) allows getting the ERC165 interface id for a contract. just a small quality of life bump.

example:
```bash
$ yarn hardhat interface IVersionableResolver
0xd700ff33
```