### PR TITLE
Minor QA things

### DIFF
--- a/contracts/ethregistrar/ETHRegistrarController.sol
+++ b/contracts/ethregistrar/ETHRegistrarController.sol
@@ -20,6 +20,7 @@ error CommitmentTooOld(bytes32 commitment);
 error NameNotAvailable(string name);
 error DurationTooShort(uint256 duration);
 error ResolverRequiredWhenDataSupplied();
+error ResolverRequiredWhenReverseRecord();
 error UnexpiredCommitmentExists(bytes32 commitment);
 error InsufficientValue();
 error Unauthorised(bytes32 node);
@@ -120,6 +121,9 @@ contract ETHRegistrarController is
         uint16 ownerControlledFuses
     ) public pure override returns (bytes32) {
         bytes32 label = keccak256(bytes(name));
+        if (resolver == address(0) && reverseRecord == true) {
+            revert ResolverRequiredWhenReverseRecord();
+        }
         if (data.length > 0 && resolver == address(0)) {
             revert ResolverRequiredWhenDataSupplied();
         }

--- a/contracts/ethregistrar/IETHRegistrarController.sol
+++ b/contracts/ethregistrar/IETHRegistrarController.sol
@@ -24,6 +24,8 @@ interface IETHRegistrarController {
 
     function commit(bytes32) external;
 
+    function commitments(bytes32) external view returns (uint256);
+
     function register(
         string calldata,
         address,


### PR DESCRIPTION
Add commitments(bytes32) to interface for the Registrar as I was adding this manually to mine for some UI checks in a hook.

Also

While writing some unit tests I was reviewing the ENS contracts for all possible revert() instances and came across an instance with makeCommitment that allows the resolver to be address(0) and setting reverseResolver True will revert as the resolver is address(0).

As i saw there is a check for resolver != address(0) when data is supplied I thought it should be considered a similar/same kind of check.

A flawed frontend can submit commitments which can never register etc.