### PR TITLE
Feature/discount price oracle

### DIFF
--- a/contracts/ethregistrar/StablePriceOracle.sol
+++ b/contracts/ethregistrar/StablePriceOracle.sol
@@ -20,6 +20,10 @@ contract StablePriceOracle is IPriceOracle {
     uint256 public immutable price3Letter;
     uint256 public immutable price4Letter;
     uint256 public immutable price5Letter;
+    uint256 public immutable minimumDiscountDuration;
+    uint256 public immutable discountPriceNumerator;
+    uint256 public immutable discountPriceDemoninator;
+    uint256 public immutable discountMaxYears;
 
     // Oracle address
     AggregatorInterface public immutable usdOracle;
@@ -33,6 +37,11 @@ contract StablePriceOracle is IPriceOracle {
         price3Letter = _rentPrices[2];
         price4Letter = _rentPrices[3];
         price5Letter = _rentPrices[4];
+
+        minimumDiscountDuration = 365 days;
+        discountPriceNumerator = 5;
+        discountPriceDemoninator = 100;
+        discountMaxYears = 10;
     }
 
     function price(
@@ -53,6 +62,17 @@ contract StablePriceOracle is IPriceOracle {
             basePrice = price2Letter * duration;
         } else {
             basePrice = price1Letter * duration;
+        }
+
+        if (duration > minimumDiscountDuration) {
+            uint256 discountYears = (duration / minimumDiscountDuration) - 1;
+            if (discountYears > discountMaxYears) {
+                discountYears = discountMaxYears;
+            }
+            basePrice =
+                basePrice -
+                (basePrice * discountPriceNumerator * discountYears) /
+                discountPriceDemoninator;
         }
 
         return

--- a/test/ethregistrar/TestStablePriceOracle.js
+++ b/test/ethregistrar/TestStablePriceOracle.js
@@ -30,6 +30,28 @@ contract('StablePriceOracle', function (accounts) {
     expect(
       parseInt((await priceOracle.price('foobie', 0, 3600)).base),
     ).to.equal(360)
+
+    expect(
+      parseInt(
+        (await priceOracle.price('foobie', 0, 60 * 60 * 24 * 365 * 1)).base,
+      ),
+    ).to.equal((60 * 60 * 24 * 365) / 10)
+  })
+
+  it('should return correct prices for longer durations', async () => {
+    expect(
+      parseInt(
+        (await priceOracle.price('foobie', 0, 60 * 60 * 24 * 365 * 1)).base,
+      ),
+    ).to.equal((60 * 60 * 24 * 365) / 10)
+  })
+
+  it('should respected a progressive discount', async () => {
+    const duration = 60 * 60 * 24 * 365 * 5 // 5 years
+    const discountPercentage = 20 / 100
+    expect(
+      parseInt((await priceOracle.price('foobie', 0, duration)).base),
+    ).to.equal(duration / 10 - (duration / 10) * discountPercentage)
   })
 
   it('should work with larger values', async () => {

--- a/test/ethregistrar/TestStablePriceOracle.js
+++ b/test/ethregistrar/TestStablePriceOracle.js
@@ -52,6 +52,12 @@ contract('StablePriceOracle', function (accounts) {
     expect(
       parseInt((await priceOracle.price('foobie', 0, duration)).base),
     ).to.equal(duration / 10 - (duration / 10) * discountPercentage)
+
+    const duration2 = 60 * 60 * 24 * 365 * 12 // 5 years
+    const discountPercentage2 = 50 / 100
+    expect(
+      parseInt((await priceOracle.price('foobie', 0, duration2)).base),
+    ).to.equal(duration2 / 10 - (duration2 / 10) * discountPercentage2)
   })
 
   it('should work with larger values', async () => {


### PR DESCRIPTION
* Adds a price oracle that discounts the price of a name after X years, until a max of Y years.
* Currently hardcodes these values
* Could be adjusted to be a progressive discount

Discussion here: https://discuss.ens.domains/t/a-method-to-increase-the-effective-number-of-ens-users/18440