### PR TITLE
Simplify ownable <-> controllable inheritance

### DIFF
--- a/contracts/reverseRegistrar/ReverseRegistrar.sol
+++ b/contracts/reverseRegistrar/ReverseRegistrar.sol
@@ -15,7 +15,7 @@ bytes32 constant ADDR_REVERSE_NODE = 0x91d1777781884d03a6757a803996e38de2a42967f
 
 // namehash('addr.reverse')
 
-contract ReverseRegistrar is Ownable, Controllable, IReverseRegistrar {
+contract ReverseRegistrar is Controllable, IReverseRegistrar {
     ENS public immutable ens;
     NameResolver public defaultResolver;
 
@@ -26,7 +26,7 @@ contract ReverseRegistrar is Ownable, Controllable, IReverseRegistrar {
      * @dev Constructor
      * @param ensAddr The address of the ENS registry.
      */
-    constructor(ENS ensAddr) {
+    constructor(ENS ensAddr) Controllable() {
         ens = ensAddr;
 
         // Assign ownership of the reverse record to our deployer

--- a/contracts/root/Controllable.sol
+++ b/contracts/root/Controllable.sol
@@ -15,6 +15,8 @@ contract Controllable is Ownable {
         _;
     }
 
+    constructor() Ownable(msg.sender) {}
+
     function setController(address controller, bool enabled) public onlyOwner {
         controllers[controller] = enabled;
         emit ControllerChanged(controller, enabled);

--- a/contracts/root/Root.sol
+++ b/contracts/root/Root.sol
@@ -4,7 +4,7 @@ import "../registry/ENS.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "./Controllable.sol";
 
-contract Root is Ownable, Controllable {
+contract Root is Controllable {
     bytes32 private constant ROOT_NODE = bytes32(0);
 
     bytes4 private constant INTERFACE_META_ID =
@@ -15,7 +15,7 @@ contract Root is Ownable, Controllable {
     ENS public ens;
     mapping(bytes32 => bool) public locked;
 
-    constructor(ENS _ens) public {
+    constructor(ENS _ens) public Controllable() {
         ens = _ens;
     }
 

--- a/contracts/wrapper/NameWrapper.sol
+++ b/contracts/wrapper/NameWrapper.sol
@@ -60,7 +60,7 @@ contract NameWrapper is
         ENS _ens,
         IBaseRegistrar _registrar,
         IMetadataService _metadataService
-    ) ReverseClaimer(_ens, msg.sender) {
+    ) ReverseClaimer(_ens, msg.sender) Controllable() {
         ens = _ens;
         registrar = _registrar;
         metadataService = _metadataService;


### PR DESCRIPTION
In the new `ens-contracts` the inheritance between Controllable and Ownable is weirdly set up with the constructor chain calls. This PR fixes that as well as cleans up usages.