### PR TITLE
Use addressOfClone2 instead of predictAddress

### DIFF
--- a/contracts/resolvers/DelegatableResolverFactory.sol
+++ b/contracts/resolvers/DelegatableResolverFactory.sol
@@ -38,6 +38,6 @@ contract DelegatableResolverFactory {
      */
     function predictAddress(address owner) external returns (address clone) {
         bytes memory data = abi.encodePacked(owner);
-        clone = address(implementation).predictAddress(data);
+        clone = address(implementation).addressOfClone2(data);
     }
 }

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@ensdomains/buffer": "^0.1.1",
     "@ensdomains/solsha1": "0.0.3",
     "@openzeppelin/contracts": "^4.1.0",
-    "clones-with-immutable-args": "Arachnid/clones-with-immutable-args#feature/create2",
+    "clones-with-immutable-args": "wighawag/clones-with-immutable-args",
     "dns-packet": "^5.3.0"
   },
   "directories": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3050,9 +3050,9 @@ clone@2.1.2, clone@^2.0.0:
   resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
   integrity sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==
 
-clones-with-immutable-args@Arachnid/clones-with-immutable-args#feature/create2:
-  version "1.0.0"
-  resolved "https://codeload.github.com/Arachnid/clones-with-immutable-args/tar.gz/802248d00be50ae2c8a860266aeca9b13fe317c8"
+clones-with-immutable-args@wighawag/clones-with-immutable-args:
+  version "1.1.2"
+  resolved "https://codeload.github.com/wighawag/clones-with-immutable-args/tar.gz/2df4bff4eef8c061b9a92a7edbbfe12dbf6bcdb0"
 
 code-point-at@^1.0.0:
   version "1.1.0"


### PR DESCRIPTION
[DelegatableResolverFactory](https://github.com/ensdomains/ens-contracts/blob/delegatable-resolver-with-factory/contracts/resolvers/DelegatableResolverFactory.sol) contract is using `predictAddress` function that has been renamed to `addressOfClone2` on [upstream repository](https://github.com/wighawag/clones-with-immutable-args/blob/master/src/ClonesWithImmutableArgs.sol)