### PR TITLE
Add missing MIT license to most files

### DIFF
--- a/contracts/dnsregistrar/PublicSuffixList.sol
+++ b/contracts/dnsregistrar/PublicSuffixList.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.4;
 
 interface PublicSuffixList {

--- a/contracts/dnsregistrar/SimplePublicSuffixList.sol
+++ b/contracts/dnsregistrar/SimplePublicSuffixList.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.4;
 pragma experimental ABIEncoderV2;
 

--- a/contracts/dnsregistrar/TLDPublicSuffixList.sol
+++ b/contracts/dnsregistrar/TLDPublicSuffixList.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.4;
 
 import "../dnssec-oracle/BytesUtils.sol";

--- a/contracts/dnsregistrar/mocks/DummyParser.sol
+++ b/contracts/dnsregistrar/mocks/DummyParser.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.4;
 
 import "../../dnssec-oracle/BytesUtils.sol";

--- a/contracts/dnssec-oracle/BytesUtils.sol
+++ b/contracts/dnssec-oracle/BytesUtils.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.4;
 
 library BytesUtils {

--- a/contracts/dnssec-oracle/Owned.sol
+++ b/contracts/dnssec-oracle/Owned.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.4;
 
 /**

--- a/contracts/dnssec-oracle/RRUtils.sol
+++ b/contracts/dnssec-oracle/RRUtils.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.4;
 
 import "./BytesUtils.sol";

--- a/contracts/dnssec-oracle/algorithms/Algorithm.sol
+++ b/contracts/dnssec-oracle/algorithms/Algorithm.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.4;
 
 /**

--- a/contracts/dnssec-oracle/algorithms/EllipticCurve.sol
+++ b/contracts/dnssec-oracle/algorithms/EllipticCurve.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.4;
 
 /**

--- a/contracts/dnssec-oracle/algorithms/ModexpPrecompile.sol
+++ b/contracts/dnssec-oracle/algorithms/ModexpPrecompile.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.4;
 
 library ModexpPrecompile {

--- a/contracts/dnssec-oracle/algorithms/P256SHA256Algorithm.sol
+++ b/contracts/dnssec-oracle/algorithms/P256SHA256Algorithm.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.4;
 
 import "./Algorithm.sol";

--- a/contracts/dnssec-oracle/algorithms/RSASHA1Algorithm.sol
+++ b/contracts/dnssec-oracle/algorithms/RSASHA1Algorithm.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.4;
 
 import "./Algorithm.sol";

--- a/contracts/dnssec-oracle/algorithms/RSASHA256Algorithm.sol
+++ b/contracts/dnssec-oracle/algorithms/RSASHA256Algorithm.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.4;
 
 import "./Algorithm.sol";

--- a/contracts/dnssec-oracle/algorithms/RSAVerify.sol
+++ b/contracts/dnssec-oracle/algorithms/RSAVerify.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.4;
 
 import "../BytesUtils.sol";

--- a/contracts/dnssec-oracle/digests/Digest.sol
+++ b/contracts/dnssec-oracle/digests/Digest.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.4;
 
 /**

--- a/contracts/dnssec-oracle/digests/SHA1Digest.sol
+++ b/contracts/dnssec-oracle/digests/SHA1Digest.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.4;
 
 import "./Digest.sol";

--- a/contracts/dnssec-oracle/digests/SHA256Digest.sol
+++ b/contracts/dnssec-oracle/digests/SHA256Digest.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.4;
 
 import "./Digest.sol";

--- a/contracts/ethregistrar/BaseRegistrarImplementation.sol
+++ b/contracts/ethregistrar/BaseRegistrarImplementation.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity >=0.8.4;
 
 import "../registry/ENS.sol";

--- a/contracts/ethregistrar/IBaseRegistrar.sol
+++ b/contracts/ethregistrar/IBaseRegistrar.sol
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ~0.8.17;
+
 import "../registry/ENS.sol";
 import "./IBaseRegistrar.sol";
 import "@openzeppelin/contracts/token/ERC721/IERC721.sol";

--- a/contracts/ethregistrar/IBulkRenewal.sol
+++ b/contracts/ethregistrar/IBulkRenewal.sol
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ~0.8.17;
+
 interface IBulkRenewal {
     function rentPrice(
         string[] calldata names,

--- a/contracts/ethregistrar/StringUtils.sol
+++ b/contracts/ethregistrar/StringUtils.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity >=0.8.4;
 
 library StringUtils {

--- a/contracts/registry/ENS.sol
+++ b/contracts/registry/ENS.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity >=0.8.4;
 
 interface ENS {

--- a/contracts/registry/ENSRegistry.sol
+++ b/contracts/registry/ENSRegistry.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity >=0.8.4;
 
 import "./ENS.sol";

--- a/contracts/resolvers/OwnedResolver.sol
+++ b/contracts/resolvers/OwnedResolver.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity >=0.8.4;
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "./profiles/ABIResolver.sol";

--- a/contracts/reverseRegistrar/IReverseRegistrar.sol
+++ b/contracts/reverseRegistrar/IReverseRegistrar.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity >=0.8.4;
 
 interface IReverseRegistrar {

--- a/contracts/reverseRegistrar/ReverseRegistrar.sol
+++ b/contracts/reverseRegistrar/ReverseRegistrar.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity >=0.8.4;
 
 import "../registry/ENS.sol";

--- a/contracts/root/Controllable.sol
+++ b/contracts/root/Controllable.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.4;
 
 import "@openzeppelin/contracts/access/Ownable.sol";

--- a/contracts/root/Ownable.sol
+++ b/contracts/root/Ownable.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.4;
 
 contract Ownable {

--- a/contracts/root/Root.sol
+++ b/contracts/root/Root.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.4;
 
 import "../registry/ENS.sol";

--- a/test/dnssec-oracle/TestBytesUtils.sol
+++ b/test/dnssec-oracle/TestBytesUtils.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.4;
 
 import "../../contracts/dnssec-oracle/RRUtils.sol";

--- a/test/dnssec-oracle/TestRRUtils.sol
+++ b/test/dnssec-oracle/TestRRUtils.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.4;
 
 import "../../contracts/dnssec-oracle/RRUtils.sol";


### PR DESCRIPTION
This add missing MIT license to most files discovered by running `yarn build` over and over.

To suppress the warning and solve https://github.com/ensdomains/ens-contracts/issues/174