### PR TITLE
fix: NameCoder disallow literal-0 hashed label

### DIFF
--- a/contracts/utils/NameCoder.sol
+++ b/contracts/utils/NameCoder.sol
@@ -30,7 +30,8 @@ library NameCoder {
     error DNSEncodingFailed(string ens);
 
     /// @dev Same as `BytesUtils.readLabel()` but supports hashed labels.
-    ///      The last labelHash is zero.
+    ///      Only the last labelHash is zero.
+    ///      Disallows hashed label of zero (eg. `[0..0]`) to prevent confusion with terminator.
     ///      Reverts `DNSDecodingFailed`.
     /// @param name The DNS-encoded name.
     /// @param idx The offset into `name` to start reading.

--- a/contracts/utils/NameCoder.sol
+++ b/contracts/utils/NameCoder.sol
@@ -51,7 +51,9 @@ library NameCoder {
                 idx + 1,
                 newIdx - 1
             ); // will not revert
-            if (!valid) revert DNSDecodingFailed(name); // "readLabel: malformed"
+            if (!valid || labelHash == bytes32(0)) {
+                revert DNSDecodingFailed(name); // "readLabel: malformed" or null literal
+            }
         } else if (len > 0) {
             assembly {
                 labelHash := keccak256(add(add(name, idx), 32), len)

--- a/test/utils/TestNameCoder.ts
+++ b/test/utils/TestNameCoder.ts
@@ -10,7 +10,7 @@ async function fixture() {
   return hre.viem.deployContract('TestNameCoder', [])
 }
 
-describe('NameEncoder', () => {
+describe('NameCoder', () => {
   describe('valid', () => {
     for (let [title, ens] of [
       ['empty', ''],
@@ -71,6 +71,13 @@ describe('NameEncoder', () => {
     const F = await loadFixture(fixture)
     await expect(F)
       .read('decode', [toHex('\x03a.b\x00')])
+      .toBeRevertedWithCustomError('DNSDecodingFailed')
+  })
+
+  it('null hashed label', async () => {
+    const F = await loadFixture(fixture)
+    await expect(F)
+      .read('namehash', [dnsEncodeName(`[${'0'.repeat(64)}]`), 0n])
       .toBeRevertedWithCustomError('DNSDecodingFailed')
   })
 })


### PR DESCRIPTION
- change to revert on `[0000000000000000000000000000000000000000000000000000000000000000]`
- added test