### PR TITLE
Add `contenthash()` and `.write` to universalResolver/utils.ts

### DIFF
--- a/test/universalResolver/TestUniversalResolver.ts
+++ b/test/universalResolver/TestUniversalResolver.ts
@@ -44,7 +44,7 @@ const resolutions = makeResolutions({
   addresses: [
     {
       coinType: COIN_TYPE_ETH,
-      encodedAddress: anotherAddress,
+      value: anotherAddress,
     },
   ],
   texts: [{ key: 'description', value: 'Test' }],
@@ -252,7 +252,7 @@ describe('UniversalResolver', () => {
       const [res] = makeResolutions({
         name: testName,
         primary: {
-          name: testName,
+          value: testName,
         },
       })
       const [answer, resolver] = await F.UniversalResolver.read.resolve([
@@ -275,7 +275,7 @@ describe('UniversalResolver', () => {
         makeResolutions({
           name: testName,
           primary: {
-            name: testName,
+            value: testName,
           },
           errors: [
             {
@@ -464,7 +464,7 @@ describe('UniversalResolver', () => {
       const calls = makeResolutions({
         name: testName,
         primary: {
-          name: testName,
+          value: testName,
         },
         errors: [
           {
@@ -532,7 +532,7 @@ describe('UniversalResolver', () => {
       ])
       const [res] = makeResolutions({
         name: reverseName,
-        primary: { name: '' },
+        primary: { value: '' },
       })
       await F.Shapeshift1.write.setResponse([res.call, res.answer])
       const [name, resolver, reverseResolver] =
@@ -574,7 +574,7 @@ describe('UniversalResolver', () => {
         addresses: [
           {
             coinType: COIN_TYPE_ETH,
-            encodedAddress: F.owner,
+            value: F.owner,
           },
         ],
       })
@@ -604,7 +604,7 @@ describe('UniversalResolver', () => {
         addresses: [
           {
             coinType: COIN_TYPE_ETH,
-            encodedAddress: anotherAddress,
+            value: anotherAddress,
           },
         ],
       })
@@ -663,7 +663,7 @@ describe('UniversalResolver', () => {
       ])
       const [rev] = makeResolutions({
         name: reverseName,
-        primary: { name: testName },
+        primary: { value: testName },
       })
       await F.Shapeshift1.write.setExtended([true])
       await F.Shapeshift1.write.setOffchain([true])
@@ -678,7 +678,7 @@ describe('UniversalResolver', () => {
         addresses: [
           {
             coinType: COIN_TYPE_ETH,
-            encodedAddress: F.owner,
+            value: F.owner,
           },
         ],
       })
@@ -701,7 +701,7 @@ describe('UniversalResolver', () => {
       ])
       const [rev] = makeResolutions({
         name: reverseName,
-        primary: { name: testName },
+        primary: { value: testName },
       })
       await F.Shapeshift1.write.setExtended([true])
       await F.Shapeshift1.write.setOffchain([true])
@@ -716,7 +716,7 @@ describe('UniversalResolver', () => {
         addresses: [
           {
             coinType,
-            encodedAddress: F.owner,
+            value: F.owner,
           },
         ],
       })

--- a/test/universalResolver/mainnet.ts
+++ b/test/universalResolver/mainnet.ts
@@ -12,7 +12,7 @@ export const KNOWN_RESOLUTIONS: KnownProfile[] = [
     addresses: [
       {
         coinType: COIN_TYPE_ETH,
-        encodedAddress: '0x8c4Eb6988A199DAbcae0Ce31052b3f3aC591787e',
+        value: '0x8c4Eb6988A199DAbcae0Ce31052b3f3aC591787e',
         origin: 'on',
       },
     ],
@@ -29,7 +29,7 @@ export const KNOWN_RESOLUTIONS: KnownProfile[] = [
     addresses: [
       {
         coinType: COIN_TYPE_ETH,
-        encodedAddress: '0xb8c2C29ee19D8307cb7255e1Cd9CbDE883A267d5',
+        value: '0xb8c2C29ee19D8307cb7255e1Cd9CbDE883A267d5',
         origin: 'on',
       },
     ],
@@ -41,7 +41,7 @@ export const KNOWN_RESOLUTIONS: KnownProfile[] = [
     addresses: [
       {
         coinType: COIN_TYPE_ETH,
-        encodedAddress: '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
+        value: '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
         origin: 'on',
       },
     ],
@@ -53,7 +53,7 @@ export const KNOWN_RESOLUTIONS: KnownProfile[] = [
     addresses: [
       {
         coinType: COIN_TYPE_ETH,
-        encodedAddress: '0x51050ec063d393217b436747617ad1c2285aeeee',
+        value: '0x51050ec063d393217b436747617ad1c2285aeeee',
         origin: 'on',
       },
     ],
@@ -75,7 +75,7 @@ export const KNOWN_RESOLUTIONS: KnownProfile[] = [
     addresses: [
       {
         coinType: COIN_TYPE_ETH,
-        encodedAddress: '0x51050ec063d393217b436747617ad1c2285aeeee',
+        value: '0x51050ec063d393217b436747617ad1c2285aeeee',
         origin: 'on',
       },
     ],
@@ -103,15 +103,15 @@ export const KNOWN_RESOLUTIONS: KnownProfile[] = [
     addresses: [
       {
         coinType: 0n,
-        encodedAddress: '0x00142e6414903e4b24d05132352f71b75c165932a381',
+        value: '0x00142e6414903e4b24d05132352f71b75c165932a381',
       },
       {
         coinType: 2n,
-        encodedAddress: '0x00142016d413f40444a390ca68cd604e39c6ca94ecf4',
+        value: '0x00142016d413f40444a390ca68cd604e39c6ca94ecf4',
       },
       {
         coinType: COIN_TYPE_ETH,
-        encodedAddress: '0xC973b97c1F8f9E3b150E2C12d4856A24b3d563cb',
+        value: '0xC973b97c1F8f9E3b150E2C12d4856A24b3d563cb',
       },
     ],
   },
@@ -122,7 +122,7 @@ export const KNOWN_RESOLUTIONS: KnownProfile[] = [
     addresses: [
       {
         coinType: COIN_TYPE_ETH,
-        encodedAddress: '0x534631Bcf33BDb069fB20A93d2fdb9e4D4dD42CF',
+        value: '0x534631Bcf33BDb069fB20A93d2fdb9e4D4dD42CF',
         origin: 'on',
       },
     ],
@@ -141,7 +141,7 @@ export const KNOWN_RESOLUTIONS: KnownProfile[] = [
     addresses: [
       {
         coinType: COIN_TYPE_ETH,
-        encodedAddress: '0x035eBd096AFa6b98372494C7f08f3402324117D3',
+        value: '0x035eBd096AFa6b98372494C7f08f3402324117D3',
         origin: 'off',
       },
     ],
@@ -159,7 +159,7 @@ export const KNOWN_RESOLUTIONS: KnownProfile[] = [
     addresses: [
       {
         coinType: COIN_TYPE_ETH,
-        encodedAddress: '0x41563129cDbbD0c5D3e1c86cf9563926b243834d',
+        value: '0x41563129cDbbD0c5D3e1c86cf9563926b243834d',
         origin: 'off',
       },
     ],
@@ -178,7 +178,7 @@ export const KNOWN_RESOLUTIONS: KnownProfile[] = [
     addresses: [
       {
         coinType: COIN_TYPE_ETH,
-        encodedAddress: '0x6cEDe3712346471a57DBB07A610714a109Db2550',
+        value: '0x6cEDe3712346471a57DBB07A610714a109Db2550',
         origin: 'off',
       },
     ],
@@ -190,7 +190,7 @@ export const KNOWN_RESOLUTIONS: KnownProfile[] = [
     addresses: [
       {
         coinType: COIN_TYPE_ETH,
-        encodedAddress: '0x28816c4C4792467390C90e5B426F198570E29307',
+        value: '0x28816c4C4792467390C90e5B426F198570E29307',
         origin: 'off',
       },
     ],
@@ -202,7 +202,7 @@ export const KNOWN_RESOLUTIONS: KnownProfile[] = [
     addresses: [
       {
         coinType: COIN_TYPE_ETH,
-        encodedAddress: '0x51050ec063d393217b436747617ad1c2285aeeee',
+        value: '0x51050ec063d393217b436747617ad1c2285aeeee',
         origin: 'off',
       },
     ],
@@ -221,7 +221,7 @@ export const KNOWN_RESOLUTIONS: KnownProfile[] = [
     addresses: [
       {
         coinType: COIN_TYPE_ETH,
-        encodedAddress: '0x51050ec063d393217b436747617ad1c2285aeeee',
+        value: '0x51050ec063d393217b436747617ad1c2285aeeee',
         origin: 'off',
       },
     ],
@@ -233,7 +233,7 @@ export const KNOWN_RESOLUTIONS: KnownProfile[] = [
     addresses: [
       {
         coinType: COIN_TYPE_ETH,
-        encodedAddress: '0xAD59EA85DB6F36c93DF955C9780F99e0bF447FF2',
+        value: '0xAD59EA85DB6F36c93DF955C9780F99e0bF447FF2',
         origin: 'off',
       },
     ],
@@ -245,7 +245,7 @@ export const KNOWN_RESOLUTIONS: KnownProfile[] = [
     addresses: [
       {
         coinType: COIN_TYPE_ETH,
-        encodedAddress: '0x51050ec063d393217b436747617ad1c2285aeeee',
+        value: '0x51050ec063d393217b436747617ad1c2285aeeee',
         origin: 'on',
       },
     ],
@@ -258,7 +258,7 @@ export const KNOWN_RESOLUTIONS: KnownProfile[] = [
     addresses: [
       {
         coinType: COIN_TYPE_ETH,
-        encodedAddress: '0x682A689A89Db38a8F51CE58cA7Ee0705D1EDC523',
+        value: '0x682A689A89Db38a8F51CE58cA7Ee0705D1EDC523',
         origin: 'off',
       },
     ],
@@ -271,7 +271,7 @@ export const KNOWN_RESOLUTIONS: KnownProfile[] = [
     addresses: [
       {
         coinType: COIN_TYPE_ETH,
-        encodedAddress: '0x8e8Db5CcEF88cca9d624701Db544989C996E3216',
+        value: '0x8e8Db5CcEF88cca9d624701Db544989C996E3216',
         origin: 'batch',
       },
     ],
@@ -283,7 +283,7 @@ export const KNOWN_RESOLUTIONS: KnownProfile[] = [
     addresses: [
       {
         coinType: COIN_TYPE_ETH,
-        encodedAddress: '0x51050ec063d393217b436747617ad1c2285aeeee',
+        value: '0x51050ec063d393217b436747617ad1c2285aeeee',
         origin: 'batch',
       },
     ],

--- a/test/universalResolver/utils.ts
+++ b/test/universalResolver/utils.ts
@@ -16,12 +16,19 @@ export const RESOLVE_MULTICALL = parseAbi([
 
 export const ADDR_ABI = parseAbi([
   'function addr(bytes32) external view returns (address)',
+  'function setAddr(bytes32, address) external',
 ])
 
 export const PROFILE_ABI = parseAbi([
   'function addr(bytes32, uint256 coinType) external view returns (bytes)',
   'function text(bytes32, string key) external view returns (string)',
+  'function contenthash(bytes32) external view returns (bytes)',
   'function name(bytes32) external view returns (string)',
+
+  'function setAddr(bytes32, uint256 coinType, bytes value) external',
+  'function setText(bytes32, string key, string value) external',
+  'function setContenthash(bytes32, bytes value) external',
+  'function setName(bytes32, string name) external',
 ])
 
 export function getParentName(name: string) {
@@ -42,26 +49,27 @@ export const RESPONSE_FLAGS = {
 
 type KnownOrigin = 'on' | 'off' | 'batch'
 
-type AddressRecord = {
-  coinType: bigint
-  encodedAddress: Hex
+type StringRecord = {
+  value: string
   origin?: KnownOrigin
 }
 
-type TextRecord = {
-  key: string
-  value: string
+type BytesRecord = {
+  value: Hex
   origin?: KnownOrigin
+}
+
+type AddressRecord = BytesRecord & {
+  coinType: bigint
+}
+
+type TextRecord = StringRecord & {
+  key: string
 }
 
 type ErrorRecord = {
   call: Hex
   answer: Hex
-}
-
-type PrimaryRecord = {
-  name: string
-  origin?: KnownOrigin
 }
 
 export type KnownProfile = {
@@ -70,7 +78,8 @@ export type KnownProfile = {
   extended?: boolean
   addresses?: AddressRecord[]
   texts?: TextRecord[]
-  primary?: PrimaryRecord
+  contenthash?: BytesRecord
+  primary?: StringRecord
   errors?: ErrorRecord[]
 }
 
@@ -84,6 +93,7 @@ export type KnownReverse = {
 
 type Expected = {
   call: Hex
+  write: Hex
   answer: Hex
   expect(data: Hex): void
 }
@@ -102,6 +112,7 @@ export function bundleCalls(calls: KnownResolution[]): KnownBundle {
     return {
       call: calls[0].call,
       answer: calls[0].answer,
+      write: calls[0].write,
       unbundle: (x) => [x],
       expect(answer) {
         calls[0].expect(answer)
@@ -117,6 +128,10 @@ export function bundleCalls(calls: KnownResolution[]): KnownBundle {
       abi: RESOLVE_MULTICALL,
       // TODO: fix when we can use newer viem version
       result: [calls.map((x) => x.answer)] as never,
+    }),
+    write: encodeFunctionData({
+      abi: RESOLVE_MULTICALL,
+      args: [calls.map((x) => x.write)],
     }),
     unbundle: (data) =>
       decodeFunctionResult({
@@ -136,7 +151,7 @@ export function makeResolutions(p: KnownProfile): KnownResolution[] {
   const node = namehash(p.name)
   if (p.addresses) {
     const functionName = 'addr'
-    for (const { coinType, encodedAddress, origin } of p.addresses) {
+    for (const { coinType, value, origin } of p.addresses) {
       if (coinType === COIN_TYPE_ETH) {
         const abi = ADDR_ABI
         v.push({
@@ -144,19 +159,27 @@ export function makeResolutions(p: KnownProfile): KnownResolution[] {
           origin,
           call: encodeFunctionData({
             abi,
+            functionName,
             args: [node],
+          }),
+          write: encodeFunctionData({
+            abi,
+            functionName: 'setAddr',
+            args: [node, value],
           }),
           answer: encodeFunctionResult({
             abi,
+            functionName,
             // TODO: fix when we can use newer viem version
-            result: [encodedAddress] as never,
+            result: [value] as never,
           }),
           expect(data) {
             const actual = decodeFunctionResult({
               abi,
+              functionName,
               data,
             })
-            expect(actual, this.desc).toStrictEqual(getAddress(encodedAddress))
+            expect(actual, this.desc).toStrictEqual(getAddress(value))
           },
         })
       } else {
@@ -169,11 +192,16 @@ export function makeResolutions(p: KnownProfile): KnownResolution[] {
             functionName,
             args: [node, coinType],
           }),
+          write: encodeFunctionData({
+            abi,
+            functionName: 'setAddr',
+            args: [node, coinType, value],
+          }),
           answer: encodeFunctionResult({
             abi,
             functionName,
             // TODO: fix when we can use newer viem version
-            result: [encodedAddress] as never,
+            result: [value] as never,
           }),
           expect(data) {
             const actual = decodeFunctionResult({
@@ -181,7 +209,7 @@ export function makeResolutions(p: KnownProfile): KnownResolution[] {
               functionName,
               data,
             })
-            expect(actual, this.desc).toStrictEqual(encodedAddress)
+            expect(actual, this.desc).toStrictEqual(value)
           },
         })
       }
@@ -198,6 +226,11 @@ export function makeResolutions(p: KnownProfile): KnownResolution[] {
           abi,
           functionName,
           args: [node, key],
+        }),
+        write: encodeFunctionData({
+          abi,
+          functionName: 'setText',
+          args: [node, key, value],
         }),
         answer: encodeFunctionResult({
           abi,
@@ -216,10 +249,10 @@ export function makeResolutions(p: KnownProfile): KnownResolution[] {
       })
     }
   }
-  if (p.primary) {
+  if (p.contenthash) {
     const abi = PROFILE_ABI
-    const functionName = 'name'
-    const { name, origin } = p.primary
+    const functionName = 'contenthash'
+    const { value, origin } = p.contenthash
     v.push({
       desc: `${functionName}()`,
       origin,
@@ -228,11 +261,16 @@ export function makeResolutions(p: KnownProfile): KnownResolution[] {
         functionName,
         args: [node],
       }),
+      write: encodeFunctionData({
+        abi,
+        functionName: 'setContenthash',
+        args: [node, value],
+      }),
       answer: encodeFunctionResult({
         abi,
         functionName,
         // TODO: fix when we can use newer viem version
-        result: [name] as never,
+        result: [value] as never,
       }),
       expect(data) {
         const actual = decodeFunctionResult({
@@ -240,7 +278,40 @@ export function makeResolutions(p: KnownProfile): KnownResolution[] {
           functionName,
           data,
         })
-        expect(actual, this.desc).toStrictEqual(name)
+        expect(actual, this.desc).toStrictEqual(value)
+      },
+    })
+  }
+  if (p.primary) {
+    const abi = PROFILE_ABI
+    const functionName = 'name'
+    const { value, origin } = p.primary
+    v.push({
+      desc: `${functionName}()`,
+      origin,
+      call: encodeFunctionData({
+        abi,
+        functionName,
+        args: [node],
+      }),
+      write: encodeFunctionData({
+        abi,
+        functionName: 'setName',
+        args: [node, value],
+      }),
+      answer: encodeFunctionResult({
+        abi,
+        functionName,
+        // TODO: fix when we can use newer viem version
+        result: [value] as never,
+      }),
+      expect(data) {
+        const actual = decodeFunctionResult({
+          abi,
+          functionName,
+          data,
+        })
+        expect(actual, this.desc).toStrictEqual(value)
       },
     })
   }
@@ -249,6 +320,7 @@ export function makeResolutions(p: KnownProfile): KnownResolution[] {
       v.push({
         desc: `error(${call.slice(0, 10)})`,
         call,
+        write: '0x',
         answer,
         expect(data) {
           expect(data, this.desc).toStrictEqual(this.answer)


### PR DESCRIPTION
- added `KnownProfile.contenthash` to get/set`contenthash()`
- added `Expected.write` for use in setters
      - `KnownBundle.write` is `multicall()`

---

The setters weren't necessary for `UR` testing, as `DummyShapeshifterResolver` doesn't use setters, but `PublicResolver` and  namechain `OwnedResolver` both use setters.