### PR TITLE
Relax `HexUtils` to support unpadded, add `ENSIP19.parse()`

### DIFF
--- a/contracts/utils/ENSIP19.sol
+++ b/contracts/utils/ENSIP19.sol
@@ -67,18 +67,6 @@ library ENSIP19 {
         );
     }
 
-    /// @dev Same as `reverseName()` but uses EVM Address + Chain ID.
-    function reverseName(
-        address addr,
-        uint64 chain
-    ) internal pure returns (string memory) {
-        return
-            reverseName(
-                abi.encodePacked(addr),
-                chain == CHAIN_ID_ETH ? COIN_TYPE_ETH : chain | EVM_BIT
-            );
-    }
-
     /// @dev Parse Reverse Name into Encoded Address + Coin Type.
     ///      Matches: /^[0-9a-fA-F]+\.([0-9a-f]{1,64}|addr|default)\.reverse$/.
     ///      Reverts `DNSDecodingFailed`.

--- a/contracts/utils/ENSIP19.sol
+++ b/contracts/utils/ENSIP19.sol
@@ -42,18 +42,6 @@ library ENSIP19 {
         isEVM = chainFromCoinType(coinType) != 0 || coinType == EVM_BIT;
     }
 
-    /// @dev Same as `reverseName()` but uses EVM Address + Chain ID.
-    function reverseName(
-        address addr,
-        uint64 chain
-    ) internal pure returns (string memory) {
-        return
-            reverseName(
-                abi.encodePacked(addr),
-                chain == CHAIN_ID_ETH ? COIN_TYPE_ETH : chain | EVM_BIT
-            );
-    }
-
     /// @dev Generate Reverse Name from Encoded Address + Coin Type.
     ///      Reverts `EmptyAddress` if `encodedAddress` is `0x`.
     /// @param encodedAddress The input address.
@@ -77,6 +65,18 @@ library ENSIP19 {
                 TLD_REVERSE
             )
         );
+    }
+
+    /// @dev Same as `reverseName()` but uses EVM Address + Chain ID.
+    function reverseName(
+        address addr,
+        uint64 chain
+    ) internal pure returns (string memory) {
+        return
+            reverseName(
+                abi.encodePacked(addr),
+                chain == CHAIN_ID_ETH ? COIN_TYPE_ETH : chain | EVM_BIT
+            );
     }
 
     /// @dev Parse Reverse Name into Encoded Address + Coin Type.

--- a/contracts/utils/ENSIP19.sol
+++ b/contracts/utils/ENSIP19.sol
@@ -42,19 +42,19 @@ library ENSIP19 {
         isEVM = chainFromCoinType(coinType) != 0 || coinType == EVM_BIT;
     }
 
-    /// @dev Generate Reverse Name from Encoded Address + Coin Type.
-    ///      Reverts `EmptyAddress` if `encodedAddress` is `0x`.
-    /// @param encodedAddress The input address.
+    /// @dev Generate Reverse Name from Address + Coin Type.
+    ///      Reverts `EmptyAddress` if `addressBytes` is `0x`.
+    /// @param addressBytes The input address.
     /// @param coinType The coin type.
     /// @return name The ENS reverse name, eg. `1234abcd.addr.reverse`.
     function reverseName(
-        bytes memory encodedAddress,
+        bytes memory addressBytes,
         uint256 coinType
     ) internal pure returns (string memory name) {
-        if (encodedAddress.length == 0) revert EmptyAddress();
+        if (addressBytes.length == 0) revert EmptyAddress();
         name = string(
             abi.encodePacked(
-                HexUtils.bytesToHex(encodedAddress),
+                HexUtils.bytesToHex(addressBytes),
                 bytes1("."),
                 coinType == COIN_TYPE_ETH
                     ? SLUG_ETH
@@ -67,19 +67,19 @@ library ENSIP19 {
         );
     }
 
-    /// @dev Parse Reverse Name into Encoded Address + Coin Type.
+    /// @dev Parse Reverse Name into Address + Coin Type.
     ///      Matches: /^[0-9a-fA-F]+\.([0-9a-f]{1,64}|addr|default)\.reverse$/.
     ///      Reverts `DNSDecodingFailed`.
     /// @param name The DNS-encoded name.
-    /// @return encodedAddress The address or empty if invalid.
+    /// @return addressBytes The address or empty if invalid.
     /// @return coinType The coin type.
     function parse(
         bytes memory name
-    ) internal pure returns (bytes memory encodedAddress, uint256 coinType) {
+    ) internal pure returns (bytes memory addressBytes, uint256 coinType) {
         (, uint256 offset) = NameCoder.readLabel(name, 0);
         bool valid;
-        (encodedAddress, valid) = HexUtils.hexToBytes(name, 1, offset);
-        if (!valid) return ("", 0); // encodedAddress not hex
+        (addressBytes, valid) = HexUtils.hexToBytes(name, 1, offset);
+        if (!valid) return ("", 0); // addressBytes not hex
         (bytes32 labelHash, uint256 offset2) = NameCoder.readLabel(
             name,
             offset

--- a/contracts/utils/ENSIP19.sol
+++ b/contracts/utils/ENSIP19.sol
@@ -79,7 +79,7 @@ library ENSIP19 {
         (, uint256 offset) = NameCoder.readLabel(name, 0);
         bool valid;
         (addressBytes, valid) = HexUtils.hexToBytes(name, 1, offset);
-        if (!valid) return ("", 0); // addressBytes not hex
+        if (!valid || addressBytes.length == 0) return ("", 0); // addressBytes not 1+ hex
         (bytes32 labelHash, uint256 offset2) = NameCoder.readLabel(
             name,
             offset
@@ -88,6 +88,8 @@ library ENSIP19 {
             coinType = COIN_TYPE_ETH;
         } else if (labelHash == keccak256(bytes(SLUG_DEFAULT))) {
             coinType = EVM_BIT;
+        } else if (labelHash == bytes32(0)) {
+            return ("", 0); // no slug
         } else {
             bytes32 word;
             (word, valid) = HexUtils.hexStringToBytes32(

--- a/contracts/utils/ENSIP19.sol
+++ b/contracts/utils/ENSIP19.sol
@@ -2,9 +2,15 @@
 pragma solidity ^0.8.0;
 
 import {HexUtils} from "../utils/HexUtils.sol";
+import {NameCoder} from "../utils/NameCoder.sol";
 
+uint32 constant CHAIN_ID_ETH = 1;
 uint256 constant COIN_TYPE_ETH = 60;
 uint256 constant EVM_BIT = 1 << 31;
+
+string constant SLUG_ETH = "addr"; // <=> COIN_TYPE_ETH
+string constant SLUG_DEFAULT = "default"; // <=> EVM_BIT
+string constant TLD_REVERSE = "reverse";
 
 /// @dev Library for generating reverse names according to ENSIP-19.
 /// https://docs.ens.domains/ensip/19
@@ -18,13 +24,22 @@ library ENSIP19 {
     function chainFromCoinType(
         uint256 coinType
     ) internal pure returns (uint32 chain) {
-        if (coinType == COIN_TYPE_ETH) return 1;
+        if (coinType == COIN_TYPE_ETH) return CHAIN_ID_ETH;
         return
             uint32(
                 uint32(coinType) == coinType && (coinType & EVM_BIT) != 0
                     ? coinType ^ EVM_BIT
                     : 0
             );
+    }
+
+    /// @dev Determine if Coin Type is for an EVM address.
+    /// @param coinType The coin type.
+    /// @return isEVM True if coin type represents an EVM address.
+    function isEVMCoinType(
+        uint256 coinType
+    ) internal pure returns (bool isEVM) {
+        isEVM = chainFromCoinType(coinType) != 0 || coinType == EVM_BIT;
     }
 
     /// @dev Same as `reverseName()` but uses EVM Address + Chain ID.
@@ -35,7 +50,7 @@ library ENSIP19 {
         return
             reverseName(
                 abi.encodePacked(addr),
-                chain == 1 ? COIN_TYPE_ETH : chain | EVM_BIT
+                chain == CHAIN_ID_ETH ? COIN_TYPE_ETH : chain | EVM_BIT
             );
     }
 
@@ -52,14 +67,52 @@ library ENSIP19 {
         name = string(
             abi.encodePacked(
                 HexUtils.bytesToHex(encodedAddress),
-                ".",
+                bytes1("."),
                 coinType == COIN_TYPE_ETH
-                    ? "addr"
+                    ? SLUG_ETH
                     : coinType == EVM_BIT
-                        ? "default"
+                        ? SLUG_DEFAULT
                         : HexUtils.unpaddedUintToHex(coinType, true),
-                ".reverse"
+                bytes1("."),
+                TLD_REVERSE
             )
         );
+    }
+
+    /// @dev Parse Reverse Name into Encoded Address + Coin Type.
+    ///      Matches: /^[0-9a-fA-F]+\.([0-9a-f]{1,64}|addr|default)\.reverse$/.
+    ///      Reverts `DNSDecodingFailed`.
+    /// @param name The DNS-encoded name.
+    /// @return encodedAddress The address or empty if invalid.
+    /// @return coinType The coin type.
+    function parse(
+        bytes memory name
+    ) internal pure returns (bytes memory encodedAddress, uint256 coinType) {
+        (, uint256 offset) = NameCoder.readLabel(name, 0);
+        bool valid;
+        (encodedAddress, valid) = HexUtils.hexToBytes(name, 1, offset);
+        if (!valid) return ("", 0); // encodedAddress not hex
+        (bytes32 labelHash, uint256 offset2) = NameCoder.readLabel(
+            name,
+            offset
+        );
+        if (labelHash == keccak256(bytes(SLUG_ETH))) {
+            coinType = COIN_TYPE_ETH;
+        } else if (labelHash == keccak256(bytes(SLUG_DEFAULT))) {
+            coinType = EVM_BIT;
+        } else {
+            bytes32 word;
+            (word, valid) = HexUtils.hexStringToBytes32(
+                name,
+                1 + offset,
+                offset2
+            );
+            if (!valid) return ("", 0); // invalid coinType
+            coinType = uint256(word);
+        }
+        (labelHash, offset) = NameCoder.readLabel(name, offset2);
+        if (labelHash != keccak256(bytes(TLD_REVERSE))) return ("", 0); // invalid tld
+        (labelHash, ) = NameCoder.readLabel(name, offset);
+        if (labelHash != bytes32(0)) return ("", 0); // not tld
     }
 }

--- a/contracts/utils/HexUtils.sol
+++ b/contracts/utils/HexUtils.sol
@@ -2,45 +2,90 @@
 pragma solidity ^0.8.4;
 
 library HexUtils {
-    /// @dev Attempts to parse bytes32 from a hex string
-    /// @param str The string to parse
-    /// @param idx The offset to start parsing at
-    /// @param lastIdx The (exclusive) last index in `str` to consider. Use `str.length` to scan the whole string.
+    /// @dev Convert `hexString[pos:end]` to `bytes32`.
+    ///      Accepts 0-64 hex-chars.
+    ///      Uses right alignment: `1` &rarr; `0000000000000000000000000000000000000000000000000000000000000001`.
+    /// @param hexString The string to parse.
+    /// @param pos The index to start parsing.
+    /// @param end The (exclusive) index to stop parsing.
+    /// @return word The parsed bytes32.
+    /// @return valid True if the parse was successful.
     function hexStringToBytes32(
-        bytes memory str,
-        uint256 idx,
-        uint256 lastIdx
-    ) internal pure returns (bytes32, bool) {
-        require(lastIdx - idx <= 64);
-        (bytes memory r, bool valid) = hexToBytes(str, idx, lastIdx);
-        if (!valid) {
-            return (bytes32(0), false);
+        bytes memory hexString,
+        uint256 pos,
+        uint256 end
+    ) internal pure returns (bytes32 word, bool valid) {
+        uint256 nibbles = end - pos;
+        if (nibbles > 64 || end > hexString.length) {
+            return (bytes32(0), false); // too large or out of bounds
         }
-        bytes32 ret;
+        uint256 src;
         assembly {
-            ret := shr(mul(4, sub(64, sub(lastIdx, idx))), mload(add(r, 32)))
+            src := add(add(hexString, 32), pos)
         }
-        return (ret, true);
+        valid = unsafeBytes(src, 0, nibbles);
+        assembly {
+            let pad := sub(32, shr(1, add(nibbles, 1))) // number of bytes
+            word := shr(shl(3, pad), mload(0)) // right align
+        }
     }
 
-    function hexToBytes(
-        bytes memory str,
-        uint256 idx,
-        uint256 lastIdx
-    ) internal pure returns (bytes memory r, bool valid) {
-        uint256 hexLength = lastIdx - idx;
-        if (hexLength % 2 == 1) {
-            revert("Invalid string length");
-        }
-        r = new bytes(hexLength / 2);
-        valid = true;
-        assembly {
-            // check that the index to read to is not past the end of the string
-            if gt(lastIdx, mload(str)) {
-                revert(0, 0)
-            }
+    /// @dev Convert `hexString[pos:end]` to `address`.
+    ///      Accepts 40-64 hex-chars.
+    ///      Uses right alignment: `FF8000000000000000000000000000000000000001` &rarr; `8000000000000000000000000000000000000001`.
+    /// @param hexString The string to parse.
+    /// @param pos The index to start parsing.
+    /// @param end The (exclusive) index to stop parsing.
+    /// @return addr The parsed address.
+    /// @return valid True if the parse was successful.
+    function hexToAddress(
+        bytes memory hexString,
+        uint256 pos,
+        uint256 end
+    ) internal pure returns (address addr, bool valid) {
+        if (end - pos < 40) return (address(0), false); // too short
+        bytes32 word;
+        (word, valid) = hexStringToBytes32(hexString, pos, end);
+        addr = address(uint160(uint256(word)));
+    }
 
-            function getHex(c) -> ascii {
+    /// @dev Convert `hexString[pos:end]` to `bytes`.
+    ///      Accepts 0+ hex-chars.
+    /// @param pos The index to start parsing.
+    /// @param end The (exclusive) index to stop parsing.
+    /// @return v The parsed bytes.
+    /// @return valid True if the parse was successful.
+    function hexToBytes(
+        bytes memory hexString,
+        uint256 pos,
+        uint256 end
+    ) internal pure returns (bytes memory v, bool valid) {
+        uint256 nibbles = end - pos;
+        v = new bytes((1 + nibbles) >> 1); // round up
+        uint256 src;
+        uint256 dst;
+        assembly {
+            src := add(add(hexString, 32), pos)
+            dst := add(v, 32)
+        }
+        valid = unsafeBytes(src, dst, nibbles);
+    }
+
+    /// @dev Convert arbitrary hex-encoded memory to bytes.
+    ///      If nibbles is odd, leading hex-char is padded, eg. `F` &rarr; `0x0F`.
+    ///      Matches: /^[0-9a-f]*$/i.
+    /// @param src The memory offset of first hex-char of input.
+    /// @param dst The memory offset of first byte of output (cannot alias `src`).
+    /// @param nibbles The number of hex-chars to convert.
+    /// @return valid True if all characters were hex.
+    function unsafeBytes(
+        uint256 src,
+        uint256 dst,
+        uint256 nibbles
+    ) internal pure returns (bool valid) {
+        assembly {
+            function getHex(c, i) -> ascii {
+                c := byte(i, c)
                 // chars 48-57: 0-9
                 if and(gt(c, 47), lt(c, 58)) {
                     ascii := sub(c, 48)
@@ -57,43 +102,38 @@ library HexUtils {
                     leave
                 }
                 // invalid char
-                ascii := 0xff
+                ascii := 0x100
             }
-
-            let ptr := add(str, 32)
+            valid := true
+            let end := add(src, nibbles)
+            if and(nibbles, 1) {
+                let b := getHex(mload(src), 0)
+                mstore8(dst, b)
+                src := add(src, 1)
+                dst := add(dst, 1)
+                if gt(b, 255) {
+                    valid := false
+                    src := end
+                }
+            }
             for {
-                let i := idx
-            } lt(i, lastIdx) {
-                i := add(i, 2)
+
+            } lt(src, end) {
+                src := add(src, 2)
+                dst := add(dst, 1)
             } {
-                let byte1 := getHex(byte(0, mload(add(ptr, i))))
-                let byte2 := getHex(byte(0, mload(add(ptr, add(i, 1)))))
-                // if either byte is invalid, set invalid and break loop
-                if or(eq(byte1, 0xff), eq(byte2, 0xff)) {
+                let word := mload(src)
+                let b := or(shl(4, getHex(word, 0)), getHex(word, 1))
+                if gt(b, 255) {
                     valid := false
                     break
                 }
-                let combined := or(shl(4, byte1), byte2)
-                mstore8(add(add(r, 32), div(sub(i, idx), 2)), combined)
+                mstore8(dst, b)
             }
         }
     }
 
-    /// @dev Attempts to parse an address from a hex string
-    /// @param str The string to parse
-    /// @param idx The offset to start parsing at
-    /// @param lastIdx The (exclusive) last index in `str` to consider. Use `str.length` to scan the whole string.
-    function hexToAddress(
-        bytes memory str,
-        uint256 idx,
-        uint256 lastIdx
-    ) internal pure returns (address, bool) {
-        if (lastIdx - idx < 40) return (address(0x0), false);
-        (bytes32 r, bool valid) = hexStringToBytes32(str, idx, lastIdx);
-        return (address(uint160(uint256(r))), valid);
-    }
-
-    /// @dev Format an address as a hex string.
+    /// @dev Format `address` as a hex string.
     /// @param addr The address to format.
     /// @return hexString The corresponding hex string w/o a 0x-prefix.
     function addressToHex(
@@ -109,14 +149,14 @@ library HexUtils {
         unsafeHex(12, dst, 40);
     }
 
-    /// @dev Format an integer as a variable-length hex string without zero padding.
+    /// @dev Format `uint256` as a variable-length hex string without zero padding.
     /// * unpaddedUintToHex(0, true)  = "0"
     /// * unpaddedUintToHex(1, true)  = "1"
     /// * unpaddedUintToHex(0, false) = "00"
     /// * unpaddedUintToHex(1, false) = "01"
     /// @param value The number to format.
     /// @param dropZeroNibble If true, the leading byte will use one nibble if less than 16.
-    /// @return hexString The corresponding hex string w/o a 0x-prefix.
+    /// @return hexString The corresponding hex string w/o an 0x-prefix.
     function unpaddedUintToHex(
         uint256 value,
         bool dropZeroNibble
@@ -141,7 +181,7 @@ library HexUtils {
         unsafeHex(0, dst, nibbles);
     }
 
-    /// @dev Format bytes as a hex string.
+    /// @dev Format `bytes` as a hex string.
     /// @param v The bytes to format.
     /// @return hexString The corresponding hex string w/o a 0x-prefix.
     function bytesToHex(
@@ -160,7 +200,7 @@ library HexUtils {
 
     /// @dev Converts arbitrary memory to a hex string.
     /// @param src The memory offset of first nibble of input.
-    /// @param dst The memory offset of first hex-char of output.
+    /// @param dst The memory offset of first hex-char of output (can alias `src`).
     /// @param nibbles The number of nibbles to convert and the byte-length of the output.
     function unsafeHex(
         uint256 src,

--- a/contracts/utils/TestENSIP19.sol
+++ b/contracts/utils/TestENSIP19.sol
@@ -11,9 +11,19 @@ contract TestENSIP19 {
         return ENSIP19.reverseName(encodedAddress, coinType);
     }
 
+    function parse(
+        bytes memory name
+    ) external pure returns (bytes memory, uint256) {
+        return ENSIP19.parse(name);
+    }
+
     function chainFromCoinType(
         uint256 coinType
-    ) external pure returns (uint32 chain) {
+    ) external pure returns (uint32) {
         return ENSIP19.chainFromCoinType(coinType);
+    }
+
+    function isEVMCoinType(uint256 coinType) external pure returns (bool) {
+        return ENSIP19.isEVMCoinType(coinType);
     }
 }

--- a/contracts/utils/TestHexUtils.sol
+++ b/contracts/utils/TestHexUtils.sol
@@ -4,30 +4,28 @@ pragma solidity ~0.8.17;
 import {HexUtils} from "./HexUtils.sol";
 
 contract TestHexUtils {
-    using HexUtils for *;
-
     function hexToBytes(
         bytes calldata name,
-        uint256 idx,
-        uint256 lastInx
+        uint256 pos,
+        uint256 end
     ) public pure returns (bytes memory, bool) {
-        return name.hexToBytes(idx, lastInx);
+        return HexUtils.hexToBytes(name, pos, end);
     }
 
     function hexStringToBytes32(
         bytes calldata name,
-        uint256 idx,
-        uint256 lastInx
+        uint256 pos,
+        uint256 end
     ) public pure returns (bytes32, bool) {
-        return name.hexStringToBytes32(idx, lastInx);
+        return HexUtils.hexStringToBytes32(name, pos, end);
     }
 
     function hexToAddress(
         bytes calldata input,
-        uint256 idx,
-        uint256 lastInx
+        uint256 pos,
+        uint256 end
     ) public pure returns (address, bool) {
-        return input.hexToAddress(idx, lastInx);
+        return HexUtils.hexToAddress(input, pos, end);
     }
 
     function addressToHex(

--- a/test/fixtures/ensip19.ts
+++ b/test/fixtures/ensip19.ts
@@ -10,19 +10,28 @@ export function chainFromCoinType(coinType: bigint): number {
     : 0
 }
 
-export function shortCoin(coinType: bigint) {
-  const chain = chainFromCoinType(coinType)
-  return chain || coinType == EVM_BIT ? `chain:${chain}` : `coin:${coinType}`
+export function isEVMCoinType(coinType: bigint) {
+  return !!chainFromCoinType(coinType) || coinType === EVM_BIT
 }
 
-export function getReverseName(encodedAddress: Hex, coinType = COIN_TYPE_ETH) {
-  const hex = encodedAddress.slice(2)
-  if (!hex) throw new Error('empty address')
-  return `${hex.toLowerCase()}.${
+export function shortCoin(coinType: bigint) {
+  return isEVMCoinType(coinType)
+    ? `chain:${chainFromCoinType(coinType)}`
+    : `coin:${coinType}`
+}
+
+export function getReverseNamespace(coinType: bigint) {
+  return `${
     coinType == COIN_TYPE_ETH
       ? 'addr'
       : coinType == EVM_BIT
       ? 'default'
       : coinType.toString(16)
   }.reverse`
+}
+
+export function getReverseName(encodedAddress: Hex, coinType = COIN_TYPE_ETH) {
+  const hex = encodedAddress.slice(2)
+  if (!hex) throw new Error('empty address')
+  return `${hex.toLowerCase()}.${getReverseNamespace(coinType)}`
 }

--- a/test/utils/TestENSIP19.ts
+++ b/test/utils/TestENSIP19.ts
@@ -52,7 +52,7 @@ describe('ENSIP19', () => {
     }
   })
 
-  describe('parse()', () => {
+  describe('parse(reverseName(a, c)) == (a, c)', () => {
     for (const addr of addrs) {
       it(addr, async () => {
         const F = await loadFixture(fixture)
@@ -64,8 +64,14 @@ describe('ENSIP19', () => {
         }
       })
     }
+  })
 
+  describe('parse() errors', () => {
     for (const name of [
+      '', // empty
+      '1234', // only address
+      'zzz', // only invalid address
+      'reverse', // only tld
       'zzz.addr.reverse', // invalid address
       '.default.reverse', // empty address
       'abc.reverse', // no address
@@ -73,7 +79,7 @@ describe('ENSIP19', () => {
       '1234.addr.eth', // invalid tld
       '1234.addr.reverse.eth', // not tld
     ]) {
-      it(name, async () => {
+      it(name || '<empty>', async () => {
         const F = await loadFixture(fixture)
         await expect(
           F.read.parse([dnsEncodeName(name)]),

--- a/test/utils/TestENSIP19.ts
+++ b/test/utils/TestENSIP19.ts
@@ -59,9 +59,12 @@ describe('ENSIP19', () => {
     }
 
     for (const name of [
-      'zzz.addr.reverse',
-      '.default.reverse',
-      'abc.reverse',
+      'zzz.addr.reverse', // invalid address
+      '.default.reverse', // empty address
+      'abc.reverse', // no address
+      '1234.addr', // no tld
+      '1234.addr.eth', // invalid tld
+      '1234.addr.reverse.eth', // not tld
     ]) {
       it(name, async () => {
         const F = await loadFixture(fixture)

--- a/test/utils/TestENSIP19.ts
+++ b/test/utils/TestENSIP19.ts
@@ -21,7 +21,14 @@ const addrs = [
   '0x800000000000000000000000000000000000000000000000000000000000000001', // 33 bytes
 ] as const
 
-const coinTypes = [COIN_TYPE_ETH, EVM_BIT, 0n, 1n]
+const coinTypes = [
+  COIN_TYPE_ETH,
+  EVM_BIT,
+  0n, // btc
+  0x123n,
+  EVM_BIT | 1n,
+  0x1_8000_0123n, // 33 bits
+]
 
 describe('ENSIP19', () => {
   describe('reverseName()', () => {

--- a/test/utils/TestENSIP19.ts
+++ b/test/utils/TestENSIP19.ts
@@ -6,12 +6,20 @@ import {
   COIN_TYPE_ETH,
   EVM_BIT,
   getReverseName,
+  isEVMCoinType,
   shortCoin,
 } from '../fixtures/ensip19.js'
+import { dnsEncodeName } from '../fixtures/dnsEncodeName.js'
 
 async function fixture() {
-  return hre.viem.deployContract('TestENSIP19', [])
+  return hre.viem.deployContract('TestENSIP19')
 }
+
+const addrs = [
+  '0x81',
+  '0x8000000000000000000000000000000000000001',
+  '0x800000000000000000000000000000000000000000000000000000000000000001', // 33 bytes
+] as const
 
 const coinTypes = [COIN_TYPE_ETH, EVM_BIT, 0n, 1n]
 
@@ -24,11 +32,7 @@ describe('ENSIP19', () => {
         .toBeRevertedWithCustomError('EmptyAddress')
     })
 
-    for (const addr of [
-      '0x81',
-      '0x8000000000000000000000000000000000000001',
-      '0x800000000000000000000000000000000000000000000000000000000000000001', // 33 bytes
-    ] as const) {
+    for (const addr of addrs) {
       it(addr, async () => {
         const F = await loadFixture(fixture)
         for (const coinType of coinTypes) {
@@ -41,6 +45,33 @@ describe('ENSIP19', () => {
     }
   })
 
+  describe('parse()', () => {
+    for (const addr of addrs) {
+      it(addr, async () => {
+        const F = await loadFixture(fixture)
+        for (const coinType of coinTypes) {
+          await expect(
+            F.read.parse([dnsEncodeName(getReverseName(addr, coinType))]),
+            shortCoin(coinType),
+          ).resolves.toStrictEqual([addr, coinType])
+        }
+      })
+    }
+
+    for (const name of [
+      'zzz.addr.reverse',
+      '.default.reverse',
+      'abc.reverse',
+    ]) {
+      it(name, async () => {
+        const F = await loadFixture(fixture)
+        await expect(
+          F.read.parse([dnsEncodeName(name)]),
+        ).resolves.toStrictEqual(['0x', 0n])
+      })
+    }
+  })
+
   describe('chainFromCoinType()', () => {
     for (const coinType of coinTypes) {
       it(shortCoin(coinType), async () => {
@@ -48,6 +79,17 @@ describe('ENSIP19', () => {
         await expect(
           F.read.chainFromCoinType([coinType]),
         ).resolves.toStrictEqual(chainFromCoinType(coinType))
+      })
+    }
+  })
+
+  describe('isEVMCoinType()', () => {
+    for (const coinType of coinTypes) {
+      it(shortCoin(coinType), async () => {
+        const F = await loadFixture(fixture)
+        await expect(F.read.isEVMCoinType([coinType])).resolves.toStrictEqual(
+          isEVMCoinType(coinType),
+        )
       })
     }
   })

--- a/test/utils/TestHexUtils.ts
+++ b/test/utils/TestHexUtils.ts
@@ -133,7 +133,7 @@ describe('HexUtils', () => {
       ).resolves.toMatchObject([zeroAddress, false])
     })
 
-    it('does allow sizes larger than 40 characters', async () => {
+    it('does not allow sizes larger than 40 characters', async () => {
       const F = await loadFixture(fixture)
       await expect(
         F.read.hexToAddress([
@@ -141,12 +141,9 @@ describe('HexUtils', () => {
             '5cee339e13375638553bdf5a6e36ba80fb9f6a4f0783680884d92b558aa471da',
           ),
           0n,
-          64n,
+          41n,
         ]),
-      ).resolves.toMatchObject([
-        '0x6e36ba80Fb9f6A4F0783680884d92b558aA471Da',
-        true,
-      ])
+      ).resolves.toMatchObject([zeroAddress, false])
     })
   })
 

--- a/test/utils/TestHexUtils.ts
+++ b/test/utils/TestHexUtils.ts
@@ -1,82 +1,48 @@
 import { loadFixture } from '@nomicfoundation/hardhat-toolbox-viem/network-helpers.js'
 import { expect } from 'chai'
 import hre from 'hardhat'
-import { stringToHex, toHex, zeroAddress, zeroHash } from 'viem'
+import { type Hex, stringToHex, toHex, zeroAddress, zeroHash } from 'viem'
 
 async function fixture() {
-  const hexUtils = await hre.viem.deployContract('TestHexUtils', [])
+  return hre.viem.deployContract('TestHexUtils')
+}
 
-  return { hexUtils }
+function unprefixedHexStr(length: number) {
+  return Array.from({ length }, (_, i) =>
+    ((i + length) & 15).toString(16),
+  ).join('')
 }
 
 describe('HexUtils', () => {
   describe('hexToBytes()', () => {
-    it('converts a hex string to bytes', async () => {
-      const { hexUtils } = await loadFixture(fixture)
-
-      await expect(
-        hexUtils.read.hexToBytes([
-          stringToHex(
-            '5cee339e13375638553bdf5a6e36ba80fb9f6a4f0783680884d92b558aa471da',
-          ),
-          0n,
-          64n,
-        ]),
-      ).resolves.toMatchObject([
-        '0x5cee339e13375638553bdf5a6e36ba80fb9f6a4f0783680884d92b558aa471da',
-        true,
-      ])
-    })
-
-    it('handles short strings', async () => {
-      const { hexUtils } = await loadFixture(fixture)
-
-      await expect(
-        hexUtils.read.hexToBytes([stringToHex('5cee'), 0n, 4n]),
-      ).resolves.toMatchObject(['0x5cee', true])
-    })
-
-    it('handles long strings', async () => {
-      const { hexUtils } = await loadFixture(fixture)
-
-      await expect(
-        hexUtils.read.hexToBytes([
-          stringToHex(
-            '5cee339e13375638553bdf5a6e36ba80fb9f6a4f0783680884d92b558aa471da010203',
-          ),
-          0n,
-          70n,
-        ]),
-      ).resolves.toMatchObject([
-        '0x5cee339e13375638553bdf5a6e36ba80fb9f6a4f0783680884d92b558aa471da010203',
-        true,
-      ])
-    })
+    for (let n = 0; n <= 65; n++) {
+      const raw = unprefixedHexStr(n)
+      const hex = (n & 1 ? `0x0${raw}` : `0x${raw}`) as Hex
+      it(`0x${raw}`, async () => {
+        const F = await loadFixture(fixture)
+        await expect(
+          F.read.hexToBytes([stringToHex(raw), 0n, BigInt(n)]),
+        ).resolves.toStrictEqual([hex, true])
+      })
+    }
   })
 
   describe('hexStringToBytes32()', () => {
-    it('converts a hex string to bytes32', async () => {
-      const { hexUtils } = await loadFixture(fixture)
-
-      await expect(
-        hexUtils.read.hexStringToBytes32([
-          stringToHex(
-            '5cee339e13375638553bdf5a6e36ba80fb9f6a4f0783680884d92b558aa471da',
-          ),
-          0n,
-          64n,
-        ]),
-      ).resolves.toMatchObject([
-        '0x5cee339e13375638553bdf5a6e36ba80fb9f6a4f0783680884d92b558aa471da',
-        true,
-      ])
-    })
+    for (let n = 0; n <= 64; n++) {
+      const raw = unprefixedHexStr(n)
+      const hex = ('0x' + raw.padStart(64, '0')) as Hex
+      it(`0x${raw}`, async () => {
+        const F = await loadFixture(fixture)
+        await expect(
+          F.read.hexStringToBytes32([stringToHex(raw), 0n, BigInt(n)]),
+        ).resolves.toStrictEqual([hex, true])
+      })
+    }
 
     it('uses the correct index to read from', async () => {
-      const { hexUtils } = await loadFixture(fixture)
-
+      const F = await loadFixture(fixture)
       await expect(
-        hexUtils.read.hexStringToBytes32([
+        F.read.hexStringToBytes32([
           stringToHex(
             'zzzzz0x5cee339e13375638553bdf5a6e36ba80fb9f6a4f0783680884d92b558aa471da',
           ),
@@ -90,10 +56,9 @@ describe('HexUtils', () => {
     })
 
     it('correctly parses all the hex characters', async () => {
-      const { hexUtils } = await loadFixture(fixture)
-
+      const F = await loadFixture(fixture)
       await expect(
-        hexUtils.read.hexStringToBytes32([
+        F.read.hexStringToBytes32([
           stringToHex('0123456789abcdefABCDEF0123456789abcdefABCD'),
           0n,
           40n,
@@ -105,10 +70,9 @@ describe('HexUtils', () => {
     })
 
     it('returns invalid when the string contains non-hex characters', async () => {
-      const { hexUtils } = await loadFixture(fixture)
-
+      const F = await loadFixture(fixture)
       await expect(
-        hexUtils.read.hexStringToBytes32([
+        F.read.hexStringToBytes32([
           stringToHex(
             'zcee339e13375638553bdf5a6e36ba80fb9f6a4f0783680884d92b558aa471da',
           ),
@@ -118,27 +82,32 @@ describe('HexUtils', () => {
       ).resolves.toMatchObject([zeroHash, false])
     })
 
-    it('reverts when the string is too short', async () => {
-      const { hexUtils } = await loadFixture(fixture)
+    it('invalid when the string is too short', async () => {
+      const F = await loadFixture(fixture)
+      await expect(
+        F.read.hexStringToBytes32([stringToHex('abcd'), 0n, 64n]),
+      ).resolves.toMatchObject([zeroHash, false])
+    })
 
-      await expect(hexUtils)
-        .read('hexStringToBytes32', [
+    it('invalid when the string is too long', async () => {
+      const F = await loadFixture(fixture)
+      await expect(
+        F.read.hexStringToBytes32([
           stringToHex(
             '5cee339e13375638553bdf5a6e36ba80fb9f6a4f0783680884d92b558aa471da',
           ),
-          1n,
-          65n,
-        ])
-        .toBeRevertedWithoutReason()
+          0n,
+          64n + 4n,
+        ]),
+      ).resolves.toMatchObject([zeroHash, false])
     })
   })
 
   describe('hexToAddress()', async () => {
     it('converts a hex string to an address', async () => {
-      const { hexUtils } = await loadFixture(fixture)
-
+      const F = await loadFixture(fixture)
       await expect(
-        hexUtils.read.hexToAddress([
+        F.read.hexToAddress([
           stringToHex(
             '5cee339e13375638553bdf5a6e36ba80fb9f6a4f0783680884d92b558aa471da',
           ),
@@ -152,10 +121,9 @@ describe('HexUtils', () => {
     })
 
     it('does not allow sizes smaller than 40 characters', async () => {
-      const { hexUtils } = await loadFixture(fixture)
-
+      const F = await loadFixture(fixture)
       await expect(
-        hexUtils.read.hexToAddress([
+        F.read.hexToAddress([
           stringToHex(
             '5cee339e13375638553bdf5a6e36ba80fb9f6a4f0783680884d92b558aa471da',
           ),
@@ -164,38 +132,21 @@ describe('HexUtils', () => {
         ]),
       ).resolves.toMatchObject([zeroAddress, false])
     })
-  })
 
-  describe('special cases for hexStringToBytes32()', () => {
-    const hex32Bytes =
-      '5cee339e13375638553bdf5a6e36ba80fb9f6a4f0783680884d92b558aa471da'
-
-    it('odd length 1', async () => {
-      const { hexUtils } = await loadFixture(fixture)
-
-      await expect(hexUtils)
-        .read('hexStringToBytes32', [stringToHex(hex32Bytes), 0n, 63n])
-        .toBeRevertedWithString('Invalid string length')
-    })
-
-    it('odd length 2', async () => {
-      const { hexUtils } = await loadFixture(fixture)
-
-      await expect(hexUtils)
-        .read('hexStringToBytes32', [stringToHex(hex32Bytes + '00'), 1n, 64n])
-        .toBeRevertedWithString('Invalid string length')
-    })
-
-    it('exceed length', async () => {
-      const { hexUtils } = await loadFixture(fixture)
-
-      await expect(hexUtils)
-        .read('hexStringToBytes32', [
-          stringToHex(hex32Bytes + '1234'),
+    it('does allow sizes larger than 40 characters', async () => {
+      const F = await loadFixture(fixture)
+      await expect(
+        F.read.hexToAddress([
+          stringToHex(
+            '5cee339e13375638553bdf5a6e36ba80fb9f6a4f0783680884d92b558aa471da',
+          ),
           0n,
-          64n + 4n,
-        ])
-        .toBeRevertedWithoutReason()
+          64n,
+        ]),
+      ).resolves.toMatchObject([
+        '0x6e36ba80Fb9f6A4F0783680884d92b558aA471Da',
+        true,
+      ])
     })
   })
 
@@ -206,8 +157,8 @@ describe('HexUtils', () => {
       '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
     ] as const) {
       it(addr, async () => {
-        const { hexUtils } = await loadFixture(fixture)
-        await expect(hexUtils.read.addressToHex([addr])).resolves.toStrictEqual(
+        const F = await loadFixture(fixture)
+        await expect(F.read.addressToHex([addr])).resolves.toStrictEqual(
           addr.slice(2).toLowerCase(),
         )
       })
@@ -218,8 +169,8 @@ describe('HexUtils', () => {
     for (let n = 0; n <= 33; n++) {
       const data = toHex(Uint8Array.from({ length: n }, (_, i) => n + i))
       it(data, async () => {
-        const { hexUtils } = await loadFixture(fixture)
-        await expect(hexUtils.read.bytesToHex([data])).resolves.toStrictEqual(
+        const F = await loadFixture(fixture)
+        await expect(F.read.bytesToHex([data])).resolves.toStrictEqual(
           data.slice(2),
         )
       })
@@ -231,13 +182,13 @@ describe('HexUtils', () => {
       const uint = (1n << BigInt(n << 3)) - 1n
       const hex = uint.toString(16)
       it(`0x${hex}`, async () => {
-        const { hexUtils } = await loadFixture(fixture)
+        const F = await loadFixture(fixture)
         await expect(
-          hexUtils.read.unpaddedUintToHex([uint, true]),
+          F.read.unpaddedUintToHex([uint, true]),
           'true',
         ).resolves.toStrictEqual(hex)
         await expect(
-          hexUtils.read.unpaddedUintToHex([uint, false]),
+          F.read.unpaddedUintToHex([uint, false]),
           'false',
         ).resolves.toStrictEqual(hex.length & 1 ? `0${hex}` : hex)
       })


### PR DESCRIPTION
* changed [HexUtils.sol](https://github.com/ensdomains/ens-contracts/blob/feat/bet-368-relax-hex/contracts/utils/HexUtils.sol) to support unpadded hex and not revert unnecessarily 
    * uses right alignment so `0x100` is `0x0100`
    * all callsites respect `valid` so results in better errors
    * more gas efficient
    * updated [TestHexUtils.ts](https://github.com/ensdomains/ens-contracts/blob/feat/bet-368-relax-hex/test/utils/TestHexUtils.ts) with expanded test coverage
* added `parse()` and `isEVMCoinType()` to [ENSIP19.sol](https://github.com/ensdomains/ens-contracts/blob/feat/bet-368-relax-hex/contracts/utils/ENSIP19.sol)
    * updated [TestENSIP19.ts](https://github.com/ensdomains/ens-contracts/blob/feat/bet-368-relax-hex/test/utils/TestENSIP19.ts)