### PR TITLE
bug: `ABIResolver.ABI()` Out of Gas

### DIFF
--- a/contracts/resolvers/profiles/ABIResolver.sol
+++ b/contracts/resolvers/profiles/ABIResolver.sol
@@ -41,7 +41,7 @@ abstract contract ABIResolver is IABIResolver, ResolverBase {
 
         for (
             uint256 contentType = 1;
-            contentType <= contentTypes;
+            contentType > 0 && contentType <= contentTypes;
             contentType <<= 1
         ) {
             if (

--- a/test/resolvers/TestPublicResolver.ts
+++ b/test/resolvers/TestPublicResolver.ts
@@ -583,6 +583,13 @@ describe('PublicResolver', () => {
         publicResolver.read.ABI([targetNode, 0xffffffffn]),
       ).resolves.toMatchObject([0n, '0x'])
     })
+
+    it('can try all content types', async () => {
+      const { publicResolver } = await loadFixture(fixture)
+      await expect(
+        publicResolver.read.ABI([targetNode, (1n << 256n) - 1n]),
+      ).resolves.toMatchObject([0n, '0x'])
+    })
   })
 
   describe('test', () => {
@@ -1144,7 +1151,7 @@ describe('PublicResolver', () => {
       await publicResolver.write.setAddr([targetNode, ensRegistry.address])
 
       const supportsInterfaceArtifact = await hre.artifacts.readArtifact(
-        '@openzeppelin/contracts/interfaces/IERC165.sol:IERC165',
+        'IERC165',
       )
       const supportsInterfaceId = createInterfaceId(
         supportsInterfaceArtifact.abi,
@@ -1164,7 +1171,7 @@ describe('PublicResolver', () => {
       await publicResolver.write.setAddr([targetNode, accounts[0].address])
 
       const supportsInterfaceArtifact = await hre.artifacts.readArtifact(
-        '@openzeppelin/contracts/interfaces/IERC165.sol:IERC165',
+        'IERC165',
       )
       const supportsInterfaceId = createInterfaceId(
         supportsInterfaceArtifact.abi,


### PR DESCRIPTION
- fixed `ABIResolver.ABI()` when `contentTypes` has 255th bit set and there is no stored value
- added [test](https://github.com/ensdomains/ens-contracts/blob/fix/abi-max-type/test/resolvers/TestPublicResolver.ts#L587-L592)