### PR TITLE
Add default fallback to `AddrResolver`

### DIFF
--- a/contracts/resolvers/profiles/AddrResolver.sol
+++ b/contracts/resolvers/profiles/AddrResolver.sol
@@ -1,62 +1,24 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.4;
 
-import "../ResolverBase.sol";
-import "./IAddrResolver.sol";
-import "./IAddressResolver.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
+import {ResolverBase} from "../ResolverBase.sol";
+import {IAddrResolver} from "./IAddrResolver.sol";
+import {IAddressResolver} from "./IAddressResolver.sol";
+import {ENSIP19, COIN_TYPE_ETH, EVM_BIT} from "../../utils/ENSIP19.sol";
 
 abstract contract AddrResolver is
     IAddrResolver,
     IAddressResolver,
     ResolverBase
 {
-    uint256 private constant COIN_TYPE_ETH = 60;
-
     mapping(uint64 => mapping(bytes32 => mapping(uint256 => bytes))) versionable_addresses;
 
-    /// Sets the address associated with an ENS node.
-    /// May only be called by the owner of that node in the ENS registry.
-    /// @param node The node to update.
-    /// @param a The address to set.
-    function setAddr(
-        bytes32 node,
-        address a
-    ) external virtual authorised(node) {
-        setAddr(node, COIN_TYPE_ETH, addressToBytes(a));
-    }
+    /// @notice The supplied address could not be converted to `address`.
+    /// @dev Error selector: `0x8d666f60`
+    error InvalidEVMAddress(bytes addressBytes);
 
-    /// Returns the address associated with an ENS node.
-    /// @param node The ENS node to query.
-    /// @return The associated address.
-    function addr(
-        bytes32 node
-    ) public view virtual override returns (address payable) {
-        bytes memory a = addr(node, COIN_TYPE_ETH);
-        if (a.length == 0) {
-            return payable(0);
-        }
-        return bytesToAddress(a);
-    }
-
-    function setAddr(
-        bytes32 node,
-        uint256 coinType,
-        bytes memory a
-    ) public virtual authorised(node) {
-        emit AddressChanged(node, coinType, a);
-        if (coinType == COIN_TYPE_ETH) {
-            emit AddrChanged(node, bytesToAddress(a));
-        }
-        versionable_addresses[recordVersions[node]][node][coinType] = a;
-    }
-
-    function addr(
-        bytes32 node,
-        uint256 coinType
-    ) public view virtual override returns (bytes memory) {
-        return versionable_addresses[recordVersions[node]][node][coinType];
-    }
-
+    /// @inheritdoc IERC165
     function supportsInterface(
         bytes4 interfaceID
     ) public view virtual override returns (bool) {
@@ -66,19 +28,86 @@ abstract contract AddrResolver is
             super.supportsInterface(interfaceID);
     }
 
-    function bytesToAddress(
-        bytes memory b
-    ) internal pure returns (address payable a) {
-        require(b.length == 20);
-        assembly {
-            a := div(mload(add(b, 32)), exp(256, 12))
+    /// @notice Set `addr(60)` of the associated ENS node.
+    /// @dev `address(0)` is stored as `bytes(0)`.
+    /// @param node The node to update.
+    /// @param _addr The address to set.
+    function setAddr(
+        bytes32 node,
+        address _addr
+    ) external virtual authorised(node) {
+        setAddr(
+            node,
+            COIN_TYPE_ETH,
+            _addr == address(0) ? new bytes(0) : abi.encodePacked(_addr)
+        );
+    }
+
+    /// @notice Get `addr(60)` as `address` of the associated ENS node.
+    /// @param node The node to query.
+    /// @return addr_ The associated address.
+    function addr(
+        bytes32 node
+    ) public view virtual override returns (address payable addr_) {
+        addr_ = payable(address(bytes20(addr(node, COIN_TYPE_ETH))));
+    }
+
+    /// @notice Set the address for coin type of the associated ENS node.
+    ///         If coin type is EVM, require exactly 0 or 20 bytes and replace empty 20 bytes with 0 bytes.
+    /// @param node The node to update.
+    /// @param coinType The coin type.
+    /// @param addressBytes The address to set.
+    function setAddr(
+        bytes32 node,
+        uint256 coinType,
+        bytes memory addressBytes
+    ) public virtual authorised(node) {
+        if (addressBytes.length != 0 && ENSIP19.isEVMCoinType(coinType)) {
+            if (addressBytes.length != 20) {
+                revert InvalidEVMAddress(addressBytes);
+            } else if (bytes20(addressBytes) == bytes20(0)) {
+                addressBytes = "";
+            }
+        }
+        emit AddressChanged(node, coinType, addressBytes);
+        if (coinType == COIN_TYPE_ETH) {
+            emit AddrChanged(node, address(bytes20(addressBytes)));
+        }
+        versionable_addresses[recordVersions[node]][node][
+            coinType
+        ] = addressBytes;
+    }
+
+    /// @notice Get the address for coin type of the associated ENS node.
+    ///         If coin type is EVM and empty, defaults to `addr(node, EVM_BIT)`.
+    /// @param node The node to query.
+    /// @param coinType The coin type.
+    /// @return addressBytes The assocated address.
+    function addr(
+        bytes32 node,
+        uint256 coinType
+    ) public view virtual override returns (bytes memory addressBytes) {
+        mapping(uint256 => bytes) storage addrs = versionable_addresses[
+            recordVersions[node]
+        ][node];
+        addressBytes = addrs[coinType];
+        if (
+            addressBytes.length == 0 && ENSIP19.chainFromCoinType(coinType) > 0
+        ) {
+            addressBytes = addrs[EVM_BIT];
         }
     }
 
-    function addressToBytes(address a) internal pure returns (bytes memory b) {
-        b = new bytes(20);
-        assembly {
-            mstore(add(b, 32), mul(a, exp(256, 12)))
-        }
+    /// @notice Determine if coin type of the associated ENS node has been set explicitly.
+    /// @param node The node to query.
+    /// @param coinType The coin type.
+    /// @return has True if `setAddr(node, coinType)` has been set.
+    function hasAddr(
+        bytes32 node,
+        uint256 coinType
+    ) external view returns (bool has) {
+        has =
+            versionable_addresses[recordVersions[node]][node][coinType].length >
+            0;
     }
 }

--- a/contracts/resolvers/profiles/AddrResolver.sol
+++ b/contracts/resolvers/profiles/AddrResolver.sol
@@ -2,6 +2,7 @@
 pragma solidity >=0.8.4;
 
 import {IERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
+
 import {ResolverBase} from "../ResolverBase.sol";
 import {IAddrResolver} from "./IAddrResolver.sol";
 import {IAddressResolver} from "./IAddressResolver.sol";
@@ -18,16 +19,6 @@ abstract contract AddrResolver is
     /// @dev Error selector: `0x8d666f60`
     error InvalidEVMAddress(bytes addressBytes);
 
-    /// @inheritdoc IERC165
-    function supportsInterface(
-        bytes4 interfaceID
-    ) public view virtual override returns (bool) {
-        return
-            interfaceID == type(IAddrResolver).interfaceId ||
-            interfaceID == type(IAddressResolver).interfaceId ||
-            super.supportsInterface(interfaceID);
-    }
-
     /// @notice Set `addr(60)` of the associated ENS node.
     /// @dev `address(0)` is stored as `bytes(0)`.
     /// @param node The node to update.
@@ -39,7 +30,7 @@ abstract contract AddrResolver is
         setAddr(
             node,
             COIN_TYPE_ETH,
-            _addr == address(0) ? new bytes(0) : abi.encodePacked(_addr)
+            _addr == address(0) ? bytes("") : abi.encodePacked(_addr)
         );
     }
 
@@ -109,5 +100,15 @@ abstract contract AddrResolver is
         has =
             versionable_addresses[recordVersions[node]][node][coinType].length >
             0;
+    }
+
+    /// @inheritdoc IERC165
+    function supportsInterface(
+        bytes4 interfaceID
+    ) public view virtual override returns (bool) {
+        return
+            interfaceID == type(IAddrResolver).interfaceId ||
+            interfaceID == type(IAddressResolver).interfaceId ||
+            super.supportsInterface(interfaceID);
     }
 }

--- a/contracts/resolvers/profiles/AddrResolver.sol
+++ b/contracts/resolvers/profiles/AddrResolver.sol
@@ -5,7 +5,7 @@ import {ResolverBase, IERC165} from "../ResolverBase.sol";
 import {IAddrResolver} from "./IAddrResolver.sol";
 import {IAddressResolver} from "./IAddressResolver.sol";
 import {IHasAddressResolver} from "./IHasAddressResolver.sol";
-import {ENSIP19, COIN_TYPE_ETH, EVM_BIT} from "../../utils/ENSIP19.sol";
+import {ENSIP19, COIN_TYPE_ETH, COIN_TYPE_DEFAULT} from "../../utils/ENSIP19.sol";
 
 abstract contract AddrResolver is
     IAddrResolver,
@@ -20,18 +20,14 @@ abstract contract AddrResolver is
     error InvalidEVMAddress(bytes addressBytes);
 
     /// @notice Set `addr(60)` of the associated ENS node.
-    ///         `address(0)` is stored as `bytes(0)`.
+    ///         `address(0)` is stored as `new bytes(20)`.
     /// @param node The node to update.
     /// @param _addr The address to set.
     function setAddr(
         bytes32 node,
         address _addr
     ) external virtual authorised(node) {
-        setAddr(
-            node,
-            COIN_TYPE_ETH,
-            _addr == address(0) ? bytes("") : abi.encodePacked(_addr)
-        );
+        setAddr(node, COIN_TYPE_ETH, abi.encodePacked(_addr));
     }
 
     /// @notice Get `addr(60)` as `address` of the associated ENS node.
@@ -44,7 +40,7 @@ abstract contract AddrResolver is
     }
 
     /// @notice Set the address for coin type of the associated ENS node.
-    ///         If coin type is EVM, require exactly 0 or 20 bytes.
+    ///         Reverts `InvalidEVMAddress` if coin type is EVM and not 0 or 20 bytes.
     /// @param node The node to update.
     /// @param coinType The coin type.
     /// @param addressBytes The address to set.
@@ -70,7 +66,7 @@ abstract contract AddrResolver is
     }
 
     /// @notice Get the address for coin type of the associated ENS node.
-    ///         If coin type is EVM and empty, defaults to `addr(EVM_BIT)`.
+    ///         If coin type is EVM and empty, defaults to `addr(COIN_TYPE_DEFAULT)`.
     /// @param node The node to query.
     /// @param coinType The coin type.
     /// @return addressBytes The assocated address.
@@ -85,7 +81,7 @@ abstract contract AddrResolver is
         if (
             addressBytes.length == 0 && ENSIP19.chainFromCoinType(coinType) > 0
         ) {
-            addressBytes = addrs[EVM_BIT];
+            addressBytes = addrs[COIN_TYPE_DEFAULT];
         }
     }
 

--- a/contracts/resolvers/profiles/AddrResolver.sol
+++ b/contracts/resolvers/profiles/AddrResolver.sol
@@ -27,7 +27,11 @@ abstract contract AddrResolver is
         bytes32 node,
         address _addr
     ) external virtual authorised(node) {
-        setAddr(node, COIN_TYPE_ETH, abi.encodePacked(_addr));
+        setAddr(
+            node,
+            COIN_TYPE_ETH,
+            _addr == address(0) ? bytes("") : abi.encodePacked(_addr)
+        );
     }
 
     /// @notice Get `addr(60)` as `address` of the associated ENS node.
@@ -85,10 +89,7 @@ abstract contract AddrResolver is
         }
     }
 
-    /// @notice Determine if coin type of the associated ENS node has been set explicitly.
-    /// @param node The node to query.
-    /// @param coinType The coin type.
-    /// @return True if `setAddr(node, coinType)` has been set.
+    /// @inheritdoc IHasAddressResolver
     function hasAddr(
         bytes32 node,
         uint256 coinType

--- a/contracts/resolvers/profiles/AddrResolver.sol
+++ b/contracts/resolvers/profiles/AddrResolver.sol
@@ -20,7 +20,7 @@ abstract contract AddrResolver is
     error InvalidEVMAddress(bytes addressBytes);
 
     /// @notice Set `addr(60)` of the associated ENS node.
-    /// @dev `address(0)` is stored as `bytes(0)`.
+    ///         `address(0)` is stored as `bytes(0)`.
     /// @param node The node to update.
     /// @param _addr The address to set.
     function setAddr(
@@ -44,7 +44,7 @@ abstract contract AddrResolver is
     }
 
     /// @notice Set the address for coin type of the associated ENS node.
-    ///         If coin type is EVM, require exactly 0 or 20 bytes and replace empty 20 bytes with 0 bytes.
+    ///         If coin type is EVM, require exactly 0 or 20 bytes.
     /// @param node The node to update.
     /// @param coinType The coin type.
     /// @param addressBytes The address to set.

--- a/contracts/resolvers/profiles/AddrResolver.sol
+++ b/contracts/resolvers/profiles/AddrResolver.sol
@@ -4,11 +4,13 @@ pragma solidity >=0.8.4;
 import {ResolverBase, IERC165} from "../ResolverBase.sol";
 import {IAddrResolver} from "./IAddrResolver.sol";
 import {IAddressResolver} from "./IAddressResolver.sol";
+import {IHasAddressResolver} from "./IHasAddressResolver.sol";
 import {ENSIP19, COIN_TYPE_ETH, EVM_BIT} from "../../utils/ENSIP19.sol";
 
 abstract contract AddrResolver is
     IAddrResolver,
     IAddressResolver,
+    IHasAddressResolver,
     ResolverBase
 {
     mapping(uint64 => mapping(bytes32 => mapping(uint256 => bytes))) versionable_addresses;
@@ -25,20 +27,16 @@ abstract contract AddrResolver is
         bytes32 node,
         address _addr
     ) external virtual authorised(node) {
-        setAddr(
-            node,
-            COIN_TYPE_ETH,
-            _addr == address(0) ? bytes("") : abi.encodePacked(_addr)
-        );
+        setAddr(node, COIN_TYPE_ETH, abi.encodePacked(_addr));
     }
 
     /// @notice Get `addr(60)` as `address` of the associated ENS node.
     /// @param node The node to query.
-    /// @return addr_ The associated address.
+    /// @return The associated address.
     function addr(
         bytes32 node
-    ) public view virtual override returns (address payable addr_) {
-        addr_ = payable(address(bytes20(addr(node, COIN_TYPE_ETH))));
+    ) public view virtual override returns (address payable) {
+        return payable(address(bytes20(addr(node, COIN_TYPE_ETH))));
     }
 
     /// @notice Set the address for coin type of the associated ENS node.
@@ -51,12 +49,12 @@ abstract contract AddrResolver is
         uint256 coinType,
         bytes memory addressBytes
     ) public virtual authorised(node) {
-        if (addressBytes.length != 0 && ENSIP19.isEVMCoinType(coinType)) {
-            if (addressBytes.length != 20) {
-                revert InvalidEVMAddress(addressBytes);
-            } else if (bytes20(addressBytes) == bytes20(0)) {
-                addressBytes = "";
-            }
+        if (
+            addressBytes.length != 0 &&
+            addressBytes.length != 20 &&
+            ENSIP19.isEVMCoinType(coinType)
+        ) {
+            revert InvalidEVMAddress(addressBytes);
         }
         emit AddressChanged(node, coinType, addressBytes);
         if (coinType == COIN_TYPE_ETH) {
@@ -90,23 +88,24 @@ abstract contract AddrResolver is
     /// @notice Determine if coin type of the associated ENS node has been set explicitly.
     /// @param node The node to query.
     /// @param coinType The coin type.
-    /// @return has True if `setAddr(node, coinType)` has been set.
+    /// @return True if `setAddr(node, coinType)` has been set.
     function hasAddr(
         bytes32 node,
         uint256 coinType
-    ) external view returns (bool has) {
-        has =
+    ) external view returns (bool) {
+        return
             versionable_addresses[recordVersions[node]][node][coinType].length >
             0;
     }
 
     /// @inheritdoc IERC165
     function supportsInterface(
-        bytes4 interfaceID
+        bytes4 interfaceId
     ) public view virtual override returns (bool) {
         return
-            interfaceID == type(IAddrResolver).interfaceId ||
-            interfaceID == type(IAddressResolver).interfaceId ||
-            super.supportsInterface(interfaceID);
+            type(IAddrResolver).interfaceId == interfaceId ||
+            type(IAddressResolver).interfaceId == interfaceId ||
+            type(IHasAddressResolver).interfaceId == interfaceId ||
+            super.supportsInterface(interfaceId);
     }
 }

--- a/contracts/resolvers/profiles/AddrResolver.sol
+++ b/contracts/resolvers/profiles/AddrResolver.sol
@@ -1,9 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.4;
 
-import {IERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
-
-import {ResolverBase} from "../ResolverBase.sol";
+import {ResolverBase, IERC165} from "../ResolverBase.sol";
 import {IAddrResolver} from "./IAddrResolver.sol";
 import {IAddressResolver} from "./IAddressResolver.sol";
 import {ENSIP19, COIN_TYPE_ETH, EVM_BIT} from "../../utils/ENSIP19.sol";

--- a/contracts/resolvers/profiles/AddrResolver.sol
+++ b/contracts/resolvers/profiles/AddrResolver.sol
@@ -70,7 +70,7 @@ abstract contract AddrResolver is
     }
 
     /// @notice Get the address for coin type of the associated ENS node.
-    ///         If coin type is EVM and empty, defaults to `addr(node, EVM_BIT)`.
+    ///         If coin type is EVM and empty, defaults to `addr(EVM_BIT)`.
     /// @param node The node to query.
     /// @param coinType The coin type.
     /// @return addressBytes The assocated address.

--- a/contracts/resolvers/profiles/IHasAddressResolver.sol
+++ b/contracts/resolvers/profiles/IHasAddressResolver.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.4;
+
+interface IHasAddressResolver {
+    function hasAddr(
+        bytes32 node,
+        uint256 coinType
+    ) external view returns (bool);
+}

--- a/contracts/resolvers/profiles/IHasAddressResolver.sol
+++ b/contracts/resolvers/profiles/IHasAddressResolver.sol
@@ -2,6 +2,10 @@
 pragma solidity >=0.8.4;
 
 interface IHasAddressResolver {
+    /// @notice Determine if an addresss is stored for the coin type of the associated ENS node.
+    /// @param node The node to query.
+    /// @param coinType The coin type.
+    /// @return True if the associated address is not empty.
     function hasAddr(
         bytes32 node,
         uint256 coinType

--- a/contracts/universalResolver/AbstractUniversalResolver.sol
+++ b/contracts/universalResolver/AbstractUniversalResolver.sol
@@ -13,7 +13,7 @@ import {IAddressResolver} from "../resolvers/profiles/IAddressResolver.sol";
 import {IMulticallable} from "../resolvers/IMulticallable.sol";
 import {NameCoder} from "../utils/NameCoder.sol";
 import {BytesUtils} from "../utils/BytesUtils.sol";
-import {ENSIP19, COIN_TYPE_ETH, EVM_BIT} from "../utils/ENSIP19.sol";
+import {ENSIP19, COIN_TYPE_ETH, COIN_TYPE_DEFAULT} from "../utils/ENSIP19.sol";
 
 abstract contract AbstractUniversalResolver is
     IUniversalResolver,
@@ -214,7 +214,10 @@ abstract contract AbstractUniversalResolver is
             ? abi.encodeCall(IAddrResolver.addr, (node))
             : abi.encodeCall(IAddressResolver.addr, (node, coinType));
         if (useFallback) {
-            calls[1] = abi.encodeCall(IAddressResolver.addr, (node, EVM_BIT));
+            calls[1] = abi.encodeCall(
+                IAddressResolver.addr,
+                (node, COIN_TYPE_DEFAULT)
+            );
         }
     }
 

--- a/contracts/utils/ENSIP19.sol
+++ b/contracts/utils/ENSIP19.sol
@@ -5,11 +5,12 @@ import {HexUtils} from "../utils/HexUtils.sol";
 import {NameCoder} from "../utils/NameCoder.sol";
 
 uint32 constant CHAIN_ID_ETH = 1;
+
 uint256 constant COIN_TYPE_ETH = 60;
-uint256 constant EVM_BIT = 1 << 31;
+uint256 constant COIN_TYPE_DEFAULT = 1 << 31; // 0x8000_0000
 
 string constant SLUG_ETH = "addr"; // <=> COIN_TYPE_ETH
-string constant SLUG_DEFAULT = "default"; // <=> EVM_BIT
+string constant SLUG_DEFAULT = "default"; // <=> COIN_TYPE_DEFAULT
 string constant TLD_REVERSE = "reverse";
 
 /// @dev Library for generating reverse names according to ENSIP-19.
@@ -20,51 +21,48 @@ library ENSIP19 {
 
     /// @dev Extract Chain ID from `coinType`.
     /// @param coinType The coin type.
-    /// @return chain The Chain ID or 0 if non-EVM Chain.
+    /// @return The Chain ID or 0 if non-EVM Chain.
     function chainFromCoinType(
         uint256 coinType
-    ) internal pure returns (uint32 chain) {
+    ) internal pure returns (uint32) {
         if (coinType == COIN_TYPE_ETH) return CHAIN_ID_ETH;
-        return
-            uint32(
-                uint32(coinType) == coinType && (coinType & EVM_BIT) != 0
-                    ? coinType ^ EVM_BIT
-                    : 0
-            );
+        coinType ^= COIN_TYPE_DEFAULT;
+        return uint32(coinType < COIN_TYPE_DEFAULT ? coinType : 0);
     }
 
     /// @dev Determine if Coin Type is for an EVM address.
     /// @param coinType The coin type.
-    /// @return isEVM True if coin type represents an EVM address.
-    function isEVMCoinType(
-        uint256 coinType
-    ) internal pure returns (bool isEVM) {
-        isEVM = chainFromCoinType(coinType) != 0 || coinType == EVM_BIT;
+    /// @return True if coin type represents an EVM address.
+    function isEVMCoinType(uint256 coinType) internal pure returns (bool) {
+        return coinType == COIN_TYPE_DEFAULT || chainFromCoinType(coinType) > 0;
     }
 
     /// @dev Generate Reverse Name from Address + Coin Type.
     ///      Reverts `EmptyAddress` if `addressBytes` is `0x`.
     /// @param addressBytes The input address.
     /// @param coinType The coin type.
-    /// @return name The ENS reverse name, eg. `1234abcd.addr.reverse`.
+    /// @return The ENS reverse name, eg. `1234abcd.addr.reverse`.
     function reverseName(
         bytes memory addressBytes,
         uint256 coinType
-    ) internal pure returns (string memory name) {
-        if (addressBytes.length == 0) revert EmptyAddress();
-        name = string(
-            abi.encodePacked(
-                HexUtils.bytesToHex(addressBytes),
-                bytes1("."),
-                coinType == COIN_TYPE_ETH
-                    ? SLUG_ETH
-                    : coinType == EVM_BIT
-                        ? SLUG_DEFAULT
-                        : HexUtils.unpaddedUintToHex(coinType, true),
-                bytes1("."),
-                TLD_REVERSE
-            )
-        );
+    ) internal pure returns (string memory) {
+        if (addressBytes.length == 0) {
+            revert EmptyAddress();
+        }
+        return
+            string(
+                abi.encodePacked(
+                    HexUtils.bytesToHex(addressBytes),
+                    bytes1("."),
+                    coinType == COIN_TYPE_ETH
+                        ? SLUG_ETH
+                        : coinType == COIN_TYPE_DEFAULT
+                            ? SLUG_DEFAULT
+                            : HexUtils.unpaddedUintToHex(coinType, true),
+                    bytes1("."),
+                    TLD_REVERSE
+                )
+            );
     }
 
     /// @dev Parse Reverse Name into Address + Coin Type.
@@ -87,7 +85,7 @@ library ENSIP19 {
         if (labelHash == keccak256(bytes(SLUG_ETH))) {
             coinType = COIN_TYPE_ETH;
         } else if (labelHash == keccak256(bytes(SLUG_DEFAULT))) {
-            coinType = EVM_BIT;
+            coinType = COIN_TYPE_DEFAULT;
         } else if (labelHash == bytes32(0)) {
             return ("", 0); // no slug
         } else {

--- a/test/fixtures/ensip19.ts
+++ b/test/fixtures/ensip19.ts
@@ -1,17 +1,16 @@
 import type { Hex } from 'viem'
 
 export const COIN_TYPE_ETH = 60n
-export const EVM_BIT = 1n << 31n
+export const COIN_TYPE_DEFAULT = 1n << 31n
 
 export function chainFromCoinType(coinType: bigint): number {
   if (coinType == COIN_TYPE_ETH) return 1
-  return coinType == BigInt.asUintN(32, coinType) && coinType & EVM_BIT
-    ? Number(coinType ^ EVM_BIT)
-    : 0
+  coinType ^= COIN_TYPE_DEFAULT
+  return coinType >= 0 && coinType < COIN_TYPE_DEFAULT ? Number(coinType) : 0
 }
 
 export function isEVMCoinType(coinType: bigint) {
-  return !!chainFromCoinType(coinType) || coinType === EVM_BIT
+  return coinType === COIN_TYPE_DEFAULT || chainFromCoinType(coinType) > 0;
 }
 
 export function shortCoin(coinType: bigint) {
@@ -24,7 +23,7 @@ export function getReverseNamespace(coinType: bigint) {
   return `${
     coinType == COIN_TYPE_ETH
       ? 'addr'
-      : coinType == EVM_BIT
+      : coinType == COIN_TYPE_DEFAULT
       ? 'default'
       : coinType.toString(16)
   }.reverse`

--- a/test/resolvers/TestPublicResolver.ts
+++ b/test/resolvers/TestPublicResolver.ts
@@ -1,6 +1,7 @@
+import hre from 'hardhat'
 import { loadFixture } from '@nomicfoundation/hardhat-toolbox-viem/network-helpers.js'
 import { expect } from 'chai'
-import hre from 'hardhat'
+import { shouldSupportInterfaces } from '@ensdomains/hardhat-chai-matchers-viem/behaviour'
 import {
   type Address,
   type Hash,
@@ -21,7 +22,6 @@ import {
   COIN_TYPE_DEFAULT,
   shortCoin,
 } from '../fixtures/ensip19.js'
-import { shouldSupportInterfaces } from '@ensdomains/hardhat-chai-matchers-viem/behaviour'
 
 const targetNode = namehash('eth')
 

--- a/test/resolvers/TestPublicResolver.ts
+++ b/test/resolvers/TestPublicResolver.ts
@@ -16,7 +16,11 @@ import {
 } from 'viem'
 import { createInterfaceId } from '../fixtures/createInterfaceId.js'
 import { dnsEncodeName } from '../fixtures/dnsEncodeName.js'
-import { COIN_TYPE_ETH, EVM_BIT, shortCoin } from '../fixtures/ensip19.js'
+import {
+  COIN_TYPE_ETH,
+  COIN_TYPE_DEFAULT,
+  shortCoin,
+} from '../fixtures/ensip19.js'
 import { shouldSupportInterfaces } from '@ensdomains/hardhat-chai-matchers-viem/behaviour'
 
 const targetNode = namehash('eth')
@@ -132,43 +136,6 @@ describe('PublicResolver', () => {
           }),
         )
         .toBeRevertedWithoutReason()
-    })
-  })
-
-  describe('supportsInterface function', () => {
-    it('supports known interfaces', async () => {
-      const { publicResolver } = await loadFixture(fixture)
-
-      const expectedArtifactSupport = [
-        await hre.artifacts.readArtifact('IAddrResolver'),
-        await hre.artifacts.readArtifact('IAddressResolver'),
-        await hre.artifacts.readArtifact('INameResolver'),
-        await hre.artifacts.readArtifact('IABIResolver'),
-        await hre.artifacts.readArtifact('IPubkeyResolver'),
-        await hre.artifacts.readArtifact('ITextResolver'),
-        await hre.artifacts.readArtifact('IContentHashResolver'),
-        await hre.artifacts.readArtifact('IDNSRecordResolver'),
-        await hre.artifacts.readArtifact('IDNSZoneResolver'),
-        await hre.artifacts.readArtifact('IInterfaceResolver'),
-      ] as const
-
-      const interfaceIds = expectedArtifactSupport.map((a) =>
-        createInterfaceId(a.abi),
-      )
-
-      for (const interfaceId of interfaceIds) {
-        await expect(
-          publicResolver.read.supportsInterface([interfaceId]),
-        ).resolves.toEqual(true)
-      }
-    })
-
-    it('does not support a random interface', async () => {
-      const { publicResolver } = await loadFixture(fixture)
-
-      await expect(
-        publicResolver.read.supportsInterface(['0x3b3b57df']),
-      ).resolves.toEqual(false)
     })
   })
 
@@ -377,7 +344,7 @@ describe('PublicResolver', () => {
       ).resolves.toStrictEqual('0x')
     })
 
-    it('clears address w/setAddr()', async () => {
+    it('zeros address w/setAddr()', async () => {
       const { publicResolver, accounts } = await loadFixture(fixture)
       // set
       await publicResolver.write.setAddr([targetNode, accounts[1].address])
@@ -397,19 +364,19 @@ describe('PublicResolver', () => {
           COIN_TYPE_ETH,
         ]) as Promise<Address>,
         'addr(60)',
-      ).resolves.toStrictEqual('0x')
+      ).resolves.toStrictEqual(zeroAddress)
     })
 
-    it('does fallback for EVM coin types to default coin type', async () => {
+    it('does fallback for EVM coin types to default', async () => {
       const { publicResolver, accounts } = await loadFixture(fixture)
       // set default
       await publicResolver.write.setAddr([
         targetNode,
-        EVM_BIT,
+        COIN_TYPE_DEFAULT,
         accounts[1].address,
       ])
       // expect evm are default
-      for (const coinType of [COIN_TYPE_ETH, EVM_BIT | 1n]) {
+      for (const coinType of [COIN_TYPE_ETH, COIN_TYPE_DEFAULT | 1n]) {
         await expect(
           publicResolver.read.addr([targetNode, coinType]) as Promise<Address>,
           shortCoin(coinType),
@@ -417,12 +384,12 @@ describe('PublicResolver', () => {
       }
     })
 
-    it('does not fallback for non EVM coin types', async () => {
+    it('does not fallback for non-EVM coin types', async () => {
       const { publicResolver, accounts } = await loadFixture(fixture)
       // set default
       await publicResolver.write.setAddr([
         targetNode,
-        EVM_BIT,
+        COIN_TYPE_DEFAULT,
         accounts[1].address,
       ])
       // expect non-evm ignore default
@@ -437,7 +404,7 @@ describe('PublicResolver', () => {
     it('forbids setting an invalid EVM address', async () => {
       const invalidAddr = '0x1234'
       const { publicResolver } = await loadFixture(fixture)
-      for (const coinType of [COIN_TYPE_ETH, EVM_BIT]) {
+      for (const coinType of [COIN_TYPE_ETH, COIN_TYPE_DEFAULT]) {
         await expect(publicResolver)
           .write('setAddr', [targetNode, coinType, invalidAddr])
           .toBeRevertedWithCustomError('InvalidEVMAddress')
@@ -456,7 +423,7 @@ describe('PublicResolver', () => {
       // set default
       await publicResolver.write.setAddr([
         targetNode,
-        EVM_BIT,
+        COIN_TYPE_DEFAULT,
         accounts[1].address,
       ])
       // expect 0
@@ -473,15 +440,15 @@ describe('PublicResolver', () => {
       // set default
       await publicResolver.write.setAddr([
         targetNode,
-        EVM_BIT,
+        COIN_TYPE_DEFAULT,
         accounts[1].address,
       ])
       // has default
       await expect(
-        publicResolver.read.hasAddr([targetNode, EVM_BIT]),
+        publicResolver.read.hasAddr([targetNode, COIN_TYPE_DEFAULT]),
       ).resolves.toStrictEqual(true)
       // does not have any other
-      for (const coinType of [0n, COIN_TYPE_ETH, EVM_BIT | 1n]) {
+      for (const coinType of [0n, COIN_TYPE_ETH, COIN_TYPE_DEFAULT | 1n]) {
         await expect(
           publicResolver.read.hasAddr([targetNode, coinType]),
           shortCoin(coinType),

--- a/test/resolvers/TestPublicResolver.ts
+++ b/test/resolvers/TestPublicResolver.ts
@@ -2,9 +2,9 @@ import { loadFixture } from '@nomicfoundation/hardhat-toolbox-viem/network-helpe
 import { expect } from 'chai'
 import hre from 'hardhat'
 import {
-  Address,
-  Hash,
-  Hex,
+  type Address,
+  type Hash,
+  type Hex,
   decodeFunctionResult,
   encodeFunctionData,
   keccak256,
@@ -16,6 +16,7 @@ import {
 } from 'viem'
 import { createInterfaceId } from '../fixtures/createInterfaceId.js'
 import { dnsEncodeName } from '../fixtures/dnsEncodeName.js'
+import { COIN_TYPE_ETH, EVM_BIT, shortCoin } from '../fixtures/ensip19.js'
 
 const targetNode = namehash('eth')
 
@@ -175,7 +176,7 @@ describe('PublicResolver', () => {
       await expect(publicResolver)
         .transaction(hash)
         .toEmitEvent('AddressChanged')
-        .withArgs(targetNode, 60n, accounts[1].address)
+        .withArgs(targetNode, COIN_TYPE_ETH, accounts[1].address)
 
       await expect(publicResolver)
         .transaction(hash)
@@ -282,13 +283,13 @@ describe('PublicResolver', () => {
       await expect(publicResolver)
         .transaction(hash)
         .toEmitEvent('AddressChanged')
-        .withArgs(targetNode, 60n, accounts[1].address)
+        .withArgs(targetNode, COIN_TYPE_ETH, accounts[1].address)
       await expect(publicResolver)
         .transaction(hash)
         .toEmitEvent('AddrChanged')
         .withArgs(targetNode, accounts[1].address)
       await expect(
-        publicResolver.read.addr([targetNode, 60n]) as Promise<Hex>,
+        publicResolver.read.addr([targetNode, COIN_TYPE_ETH]) as Promise<Hex>,
       ).resolves.toEqual(accounts[1].address.toLowerCase() as Address)
     })
 
@@ -297,14 +298,14 @@ describe('PublicResolver', () => {
 
       const hash = await publicResolver.write.setAddr([
         targetNode,
-        60n,
+        COIN_TYPE_ETH,
         accounts[2].address,
       ])
 
       await expect(publicResolver)
         .transaction(hash)
         .toEmitEvent('AddressChanged')
-        .withArgs(targetNode, 60n, accounts[2].address)
+        .withArgs(targetNode, COIN_TYPE_ETH, accounts[2].address)
       await expect(publicResolver)
         .transaction(hash)
         .toEmitEvent('AddrChanged')
@@ -328,6 +329,90 @@ describe('PublicResolver', () => {
       await expect(
         publicResolver.read.addr([targetNode]) as Promise<Address>,
       ).resolves.toEqualAddress(zeroAddress)
+    })
+
+    it('clears coin type 60', async () => {
+      const { publicResolver, accounts } = await loadFixture(fixture)
+      await publicResolver.write.setAddr([
+        targetNode,
+        COIN_TYPE_ETH,
+        accounts[1].address,
+      ])
+      await expect(
+        publicResolver.read.addr([targetNode]) as Promise<Address>,
+        'confirm set',
+      ).resolves.toEqualAddress(accounts[1].address)
+      await publicResolver.write.setAddr([targetNode, COIN_TYPE_ETH, '0x'])
+      await expect(
+        publicResolver.read.addr([targetNode]) as Promise<Address>,
+        'addr',
+      ).resolves.toEqualAddress(zeroAddress)
+      await expect(
+        publicResolver.read.addr([
+          targetNode,
+          COIN_TYPE_ETH,
+        ]) as Promise<Address>,
+        'addr(60)',
+      ).resolves.toStrictEqual('0x')
+    })
+
+    it('does fallback for EVM coin types to default coin type', async () => {
+      const { publicResolver, accounts } = await loadFixture(fixture)
+      await publicResolver.write.setAddr([
+        targetNode,
+        EVM_BIT,
+        accounts[1].address,
+      ])
+      for (const coinType of [COIN_TYPE_ETH, EVM_BIT | 1n]) {
+        await expect(
+          publicResolver.read.addr([targetNode, coinType]) as Promise<Address>,
+          shortCoin(coinType),
+        ).resolves.toEqualAddress(accounts[1].address)
+      }
+    })
+
+    it('does not fallback for non EVM coin types', async () => {
+      const { publicResolver, accounts } = await loadFixture(fixture)
+      await publicResolver.write.setAddr([
+        targetNode,
+        EVM_BIT,
+        accounts[1].address,
+      ])
+      for (const coinType of [0n, 1n]) {
+        await expect(
+          publicResolver.read.addr([targetNode, coinType]) as Promise<Address>,
+          shortCoin(coinType),
+        ).resolves.toStrictEqual('0x')
+      }
+    })
+
+    it('forbids setting an invalid EVM address', async () => {
+      const invalidAddr = '0x1234'
+      const { publicResolver } = await loadFixture(fixture)
+      for (const coinType of [COIN_TYPE_ETH, EVM_BIT]) {
+        await expect(publicResolver)
+          .write('setAddr', [targetNode, coinType, invalidAddr])
+          .toBeRevertedWithCustomError('InvalidEVMAddress')
+          .withArgs(invalidAddr)
+      }
+    })
+
+    it('supports hasAddr() even if addr() returns default', async () => {
+      const { publicResolver, accounts } = await loadFixture(fixture)
+      await publicResolver.write.setAddr([
+        targetNode,
+        EVM_BIT,
+        accounts[1].address,
+      ])
+      await expect(
+        publicResolver.read.hasAddr([targetNode, EVM_BIT]),
+      ).resolves.toStrictEqual(true)
+      for (const coinType of [0n, COIN_TYPE_ETH, EVM_BIT | 1n]) {
+        await expect(
+          publicResolver.read.hasAddr([targetNode, coinType]),
+          shortCoin(coinType),
+        ).resolves.toStrictEqual(false)
+      }
     })
   })
 
@@ -1144,7 +1229,7 @@ describe('PublicResolver', () => {
       await publicResolver.write.setAddr([targetNode, ensRegistry.address])
 
       const supportsInterfaceArtifact = await hre.artifacts.readArtifact(
-        '@openzeppelin/contracts/interfaces/IERC165.sol:IERC165',
+        'IERC165',
       )
       const supportsInterfaceId = createInterfaceId(
         supportsInterfaceArtifact.abi,
@@ -1164,7 +1249,7 @@ describe('PublicResolver', () => {
       await publicResolver.write.setAddr([targetNode, accounts[0].address])
 
       const supportsInterfaceArtifact = await hre.artifacts.readArtifact(
-        '@openzeppelin/contracts/interfaces/IERC165.sol:IERC165',
+        'IERC165',
       )
       const supportsInterfaceId = createInterfaceId(
         supportsInterfaceArtifact.abi,
@@ -1494,7 +1579,7 @@ describe('PublicResolver', () => {
       await expect(publicResolver)
         .transaction(hash)
         .toEmitEvent('AddressChanged')
-        .withArgs(targetNode, 60n, accounts[1].address)
+        .withArgs(targetNode, COIN_TYPE_ETH, accounts[1].address)
       await expect(publicResolver)
         .transaction(hash)
         .toEmitEvent('TextChanged')

--- a/test/resolvers/TestPublicResolver.ts
+++ b/test/resolvers/TestPublicResolver.ts
@@ -17,6 +17,7 @@ import {
 import { createInterfaceId } from '../fixtures/createInterfaceId.js'
 import { dnsEncodeName } from '../fixtures/dnsEncodeName.js'
 import { COIN_TYPE_ETH, EVM_BIT, shortCoin } from '../fixtures/ensip19.js'
+import { shouldSupportInterfaces } from '@ensdomains/hardhat-chai-matchers-viem/behaviour'
 
 const targetNode = namehash('eth')
 
@@ -87,6 +88,24 @@ async function fixtureWithDnsRecords() {
 }
 
 describe('PublicResolver', () => {
+  shouldSupportInterfaces({
+    contract: () => loadFixture(fixture).then((F) => F.publicResolver),
+    interfaces: [
+      'IERC165',
+      'IAddrResolver',
+      'IAddressResolver',
+      'IHasAddressResolver',
+      'INameResolver',
+      'IABIResolver',
+      'IPubkeyResolver',
+      'ITextResolver',
+      'IContentHashResolver',
+      'IDNSRecordResolver',
+      'IDNSZoneResolver',
+      'IInterfaceResolver',
+    ],
+  })
+
   describe('fallback function', () => {
     it('forbids calls to the fallback function with 0 value', async () => {
       const { publicResolver, walletClients } = await loadFixture(fixture)
@@ -331,8 +350,9 @@ describe('PublicResolver', () => {
       ).resolves.toEqualAddress(zeroAddress)
     })
 
-    it('clears coin type 60', async () => {
+    it('clears address w/setAddr(60)', async () => {
       const { publicResolver, accounts } = await loadFixture(fixture)
+      // set
       await publicResolver.write.setAddr([
         targetNode,
         COIN_TYPE_ETH,
@@ -342,7 +362,31 @@ describe('PublicResolver', () => {
         publicResolver.read.addr([targetNode]) as Promise<Address>,
         'confirm set',
       ).resolves.toEqualAddress(accounts[1].address)
+      // clear
       await publicResolver.write.setAddr([targetNode, COIN_TYPE_ETH, '0x'])
+      await expect(
+        publicResolver.read.addr([targetNode]) as Promise<Address>,
+        'addr',
+      ).resolves.toEqualAddress(zeroAddress)
+      await expect(
+        publicResolver.read.addr([
+          targetNode,
+          COIN_TYPE_ETH,
+        ]) as Promise<Address>,
+        'addr(60)',
+      ).resolves.toStrictEqual('0x')
+    })
+
+    it('clears address w/setAddr()', async () => {
+      const { publicResolver, accounts } = await loadFixture(fixture)
+      // set
+      await publicResolver.write.setAddr([targetNode, accounts[1].address])
+      await expect(
+        publicResolver.read.addr([targetNode]) as Promise<Address>,
+        'confirm set',
+      ).resolves.toEqualAddress(accounts[1].address)
+      // clear
+      await publicResolver.write.setAddr([targetNode, zeroAddress])
       await expect(
         publicResolver.read.addr([targetNode]) as Promise<Address>,
         'addr',
@@ -358,11 +402,13 @@ describe('PublicResolver', () => {
 
     it('does fallback for EVM coin types to default coin type', async () => {
       const { publicResolver, accounts } = await loadFixture(fixture)
+      // set default
       await publicResolver.write.setAddr([
         targetNode,
         EVM_BIT,
         accounts[1].address,
       ])
+      // expect evm are default
       for (const coinType of [COIN_TYPE_ETH, EVM_BIT | 1n]) {
         await expect(
           publicResolver.read.addr([targetNode, coinType]) as Promise<Address>,
@@ -373,11 +419,13 @@ describe('PublicResolver', () => {
 
     it('does not fallback for non EVM coin types', async () => {
       const { publicResolver, accounts } = await loadFixture(fixture)
+      // set default
       await publicResolver.write.setAddr([
         targetNode,
         EVM_BIT,
         accounts[1].address,
       ])
+      // expect non-evm ignore default
       for (const coinType of [0n, 1n]) {
         await expect(
           publicResolver.read.addr([targetNode, coinType]) as Promise<Address>,
@@ -397,16 +445,42 @@ describe('PublicResolver', () => {
       }
     })
 
-    it('supports hasAddr() even if addr() returns default', async () => {
+    it('allows address(0) to prevent fallback', async () => {
       const { publicResolver, accounts } = await loadFixture(fixture)
+      // set explicit 0
+      await publicResolver.write.setAddr([
+        targetNode,
+        COIN_TYPE_ETH,
+        zeroAddress,
+      ])
+      // set default
       await publicResolver.write.setAddr([
         targetNode,
         EVM_BIT,
         accounts[1].address,
       ])
+      // expect 0
+      await expect(
+        publicResolver.read.addr([
+          targetNode,
+          COIN_TYPE_ETH,
+        ]) as Promise<Address>,
+      ).resolves.toStrictEqual(zeroAddress)
+    })
+
+    it('supports hasAddr() even if addr() returns default', async () => {
+      const { publicResolver, accounts } = await loadFixture(fixture)
+      // set default
+      await publicResolver.write.setAddr([
+        targetNode,
+        EVM_BIT,
+        accounts[1].address,
+      ])
+      // has default
       await expect(
         publicResolver.read.hasAddr([targetNode, EVM_BIT]),
       ).resolves.toStrictEqual(true)
+      // does not have any other
       for (const coinType of [0n, COIN_TYPE_ETH, EVM_BIT | 1n]) {
         await expect(
           publicResolver.read.hasAddr([targetNode, coinType]),

--- a/test/universalResolver/TestUniversalResolver.ts
+++ b/test/universalResolver/TestUniversalResolver.ts
@@ -15,7 +15,11 @@ import {
 } from 'viem'
 import { dnsEncodeName } from '../fixtures/dnsEncodeName.js'
 import { serveBatchGateway } from '../fixtures/localBatchGateway.js'
-import { COIN_TYPE_ETH, EVM_BIT, getReverseName } from '../fixtures/ensip19.js'
+import {
+  COIN_TYPE_ETH,
+  COIN_TYPE_DEFAULT,
+  getReverseName,
+} from '../fixtures/ensip19.js'
 import { ownedEnsFixture } from './ownedEnsFixture.js'
 import { expectVar } from '../fixtures/expectVar.js'
 import { makeResolutions, bundleCalls, getParentName } from './utils.js'
@@ -603,7 +607,7 @@ describe('UniversalResolver', () => {
         name: testName,
         addresses: [
           {
-            coinType: EVM_BIT,
+            coinType: COIN_TYPE_DEFAULT,
             encodedAddress: F.owner,
           },
         ],

--- a/test/utils/TestENSIP19.ts
+++ b/test/utils/TestENSIP19.ts
@@ -4,7 +4,7 @@ import { expect } from 'chai'
 import {
   chainFromCoinType,
   COIN_TYPE_ETH,
-  EVM_BIT,
+  COIN_TYPE_DEFAULT,
   getReverseName,
   isEVMCoinType,
   shortCoin,
@@ -23,10 +23,10 @@ const addrs = [
 
 const coinTypes = [
   COIN_TYPE_ETH,
-  EVM_BIT,
+  COIN_TYPE_DEFAULT,
   0n, // btc
   0x123n,
-  EVM_BIT | 1n,
+  COIN_TYPE_DEFAULT | 1n,
   0x1_8000_0123n, // 33 bits
 ]
 


### PR DESCRIPTION
- added default fallback to [AddrResolver.sol](https://github.com/ensdomains/ens-contracts/blob/feature/bet-383-addr-resolver/contracts/resolvers/profiles/AddrResolver.sol)
     - uses same logic as [DedicatedResolver.sol](https://github.com/ensdomains/namechain/blob/feat/bet-371-dedicated-resolver/contracts/src/common/DedicatedResolver.sol)
- added [IHasAddressResolver.sol](https://github.com/ensdomains/ens-contracts/blob/feature/bet-383-addr-resolver/contracts/resolvers/profiles/IHasAddressResolver.sol)
- added corresponding [tests](https://github.com/ensdomains/ens-contracts/blob/feature/bet-383-addr-resolver/test/resolvers/TestPublicResolver.ts)
- changed `EVM_BIT` to `COIN_TYPE_DEFAULT`