### PR TITLE
Improve `UniversalResolver` tests

### DIFF
--- a/test/fixtures/deployDefaultReverseFixture.ts
+++ b/test/fixtures/deployDefaultReverseFixture.ts
@@ -12,10 +12,11 @@ export async function deployDefaultReverseFixture() {
     'DefaultReverseResolver',
     [defaultReverseRegistrar.address],
   )
-  const defaultReverseNamespace = getReverseNamespace(COIN_TYPE_DEFAULT) // could be "reverse"
-  await F.takeControl(defaultReverseNamespace)
+  const defaultReverseNamespace = getReverseNamespace(COIN_TYPE_DEFAULT)
+  const mountedNamespace = 'reverse' // getParentName(defaultReverseNamespace)
+  await F.takeControl(mountedNamespace)
   await F.ensRegistry.write.setResolver([
-    namehash(defaultReverseNamespace),
+    namehash(mountedNamespace),
     defaultReverseResolver.address,
   ])
   return {

--- a/test/reverseResolver/TestChainReverseResolver.ts
+++ b/test/reverseResolver/TestChainReverseResolver.ts
@@ -16,7 +16,7 @@ import {
   getReverseNamespace,
 } from '../fixtures/ensip19.js'
 import { urgArtifact } from '../fixtures/externalArtifacts.js'
-import { KnownProfile, makeResolutions } from '../universalResolver/utils.js'
+import { KnownProfile, makeResolutions } from '../utils/resolutions.js'
 
 const testName = 'test.eth'
 const l2CoinType = COIN_TYPE_DEFAULT | 12345n // any evm chain
@@ -131,7 +131,7 @@ describe('ChainReverseResolver', () => {
       const F = await loadFixture(fixture)
       const kp: KnownProfile = {
         name: getReverseName(F.owner, l2CoinType),
-        primary: { name: '' },
+        primary: { value: '' },
       }
       const [res] = makeResolutions(kp)
       res.expect(
@@ -147,7 +147,7 @@ describe('ChainReverseResolver', () => {
       await F.reverseRegistrar.write.setName([testName])
       const kp: KnownProfile = {
         name: getReverseName(F.owner, l2CoinType),
-        primary: { name: testName },
+        primary: { value: testName },
       }
       const [res] = makeResolutions(kp)
       res.expect(
@@ -163,7 +163,7 @@ describe('ChainReverseResolver', () => {
       await F.defaultReverseRegistrar.write.setName([testName])
       const kp: KnownProfile = {
         name: getReverseName(F.owner, l2CoinType),
-        primary: { name: testName },
+        primary: { value: testName },
       }
       const [res] = makeResolutions(kp)
       res.expect(

--- a/test/reverseResolver/TestDefaultReverseResolver.ts
+++ b/test/reverseResolver/TestDefaultReverseResolver.ts
@@ -13,7 +13,7 @@ import {
   isEVMCoinType,
   shortCoin,
 } from '../fixtures/ensip19.js'
-import { KnownProfile, makeResolutions } from '../universalResolver/utils.js'
+import { KnownProfile, makeResolutions } from '../utils/resolutions.js'
 
 const testName = 'test.eth'
 const coinTypes = [COIN_TYPE_ETH, COIN_TYPE_DEFAULT, 0n, 1n]
@@ -89,7 +89,7 @@ describe('DefaultReverseResolver', () => {
         const F = await loadFixture(fixture)
         const kp: KnownProfile = {
           name: getReverseName(F.owner, coinType),
-          primary: { name: testName },
+          primary: { value: testName },
         }
         const [res] = makeResolutions(kp)
         if (isEVMCoinType(coinType)) {
@@ -121,7 +121,7 @@ describe('DefaultReverseResolver', () => {
         const F = await loadFixture(fixture)
         const kp: KnownProfile = {
           name: `${F.owner.slice(2).toLowerCase()}.${namespace}`,
-          primary: { name: testName },
+          primary: { value: testName },
         }
         const [res] = makeResolutions(kp)
         res.expect(

--- a/test/reverseResolver/TestETHReverseResolver.ts
+++ b/test/reverseResolver/TestETHReverseResolver.ts
@@ -9,7 +9,7 @@ import {
   getReverseName,
   getReverseNamespace,
 } from '../fixtures/ensip19.js'
-import { KnownProfile, makeResolutions } from '../universalResolver/utils.js'
+import { KnownProfile, makeResolutions } from '../utils/resolutions.js'
 import { dnsEncodeName } from '../fixtures/dnsEncodeName.js'
 import { deployDefaultReverseFixture } from '../fixtures/deployDefaultReverseFixture.js'
 
@@ -71,7 +71,7 @@ const sources = {
     set: async (F, name, account) => {
       const [res] = makeResolutions({
         name: getReverseName(account.address),
-        primary: { name },
+        primary: { value: name },
       })
       await F.shapeshift.write.setResponse([res.call, res.answer])
       await F.claimV1(account.address)
@@ -79,7 +79,7 @@ const sources = {
     setOld: async (F, name, account) => {
       const [res] = makeResolutions({
         name: getReverseName(account.address),
-        primary: { name },
+        primary: { value: name },
       })
       await F.shapeshift.write.setOld()
       await F.shapeshift.write.setResponse([res.call, res.answer])
@@ -88,7 +88,7 @@ const sources = {
     empty: async (F, _, account) => {
       const [res] = makeResolutions({
         name: getReverseName(account.address),
-        primary: { name: '' },
+        primary: { value: '' },
       })
       await F.shapeshift.write.setResponse([res.call, res.answer])
       await F.claimV1(account.address)
@@ -206,7 +206,7 @@ describe('ETHReverseResolver', () => {
         }
         const kp: KnownProfile = {
           name: getReverseName(wallet.account.address),
-          primary: { name },
+          primary: { value: name },
         }
         const [res] = makeResolutions(kp)
         await expect(

--- a/test/universalResolver/TestUniversalResolver.remote.ts
+++ b/test/universalResolver/TestUniversalResolver.remote.ts
@@ -6,7 +6,7 @@ import { serveBatchGateway } from '../fixtures/localBatchGateway.js'
 import { shortCoin } from '../fixtures/ensip19.js'
 import { isHardhatFork } from '../fixtures/forked.js'
 import { ENS_REGISTRY, KNOWN_PRIMARIES, KNOWN_RESOLUTIONS } from './mainnet.js'
-import { bundleCalls, makeResolutions } from './utils.js'
+import { bundleCalls, makeResolutions } from '../utils/resolutions.js'
 
 // $ bun run test:remote
 

--- a/test/universalResolver/mainnet.ts
+++ b/test/universalResolver/mainnet.ts
@@ -1,5 +1,5 @@
 import type { Address } from 'viem'
-import type { KnownProfile, KnownReverse } from './utils.js'
+import type { KnownProfile, KnownReverse } from '../utils/resolutions.js'
 import { COIN_TYPE_ETH } from '../fixtures/ensip19.js'
 
 export const ENS_REGISTRY: Address =

--- a/test/utils/TestNameCoder.ts
+++ b/test/utils/TestNameCoder.ts
@@ -4,7 +4,7 @@ import { expect } from 'chai'
 import { namehash, slice, toHex } from 'viem'
 import { dnsEncodeName } from '../fixtures/dnsEncodeName.js'
 import { dnsDecodeName } from '../fixtures/dnsDecodeName.js'
-import { getParentName } from '../universalResolver/utils.js'
+import { getParentName } from './resolutions.js'
 
 async function fixture() {
   return hre.viem.deployContract('TestNameCoder', [])


### PR DESCRIPTION
- added more [tests](https://github.com/ensdomains/ens-contracts/blob/feat/bet-398-ur-tests/test/universalResolver/TestUniversalResolver.ts)
      - test default name
      - test default address
      - use `PublicResolver` for `"onchain immediate"` tests instead of `ShapeshiftResolver`
- changed `deployDefaultReverseFixture()` to use `"reverse"`
- move `universalResolver/resolutions` to `utils/`
     - added `.write`