### PR TITLE
Add `IFeatureSupporter` and `resolve(multicall)` support

### DIFF
--- a/contracts/ccipRead/CCIPBatcher.sol
+++ b/contracts/ccipRead/CCIPBatcher.sol
@@ -16,8 +16,8 @@ contract CCIPBatcher is CCIPReader {
     uint256 constant FLAG_EIP140_AFTER = 1 << 5; // has revert op code
     uint256 constant FLAG_DONE = 1 << 6; // the lookup has finished processing (private)
 
-    uint256 constant FLAGS_ANY_ERROR =
-        FLAG_CALL_ERROR | FLAG_BATCH_ERROR | FLAG_EMPTY_RESPONSE;
+    uint256 constant FLAGS_TARGET_ERROR = FLAG_EMPTY_RESPONSE | FLAG_CALL_ERROR;
+    uint256 constant FLAGS_ANY_ERROR = FLAGS_TARGET_ERROR | FLAG_BATCH_ERROR;
     uint256 constant FLAGS_ANY_EIP140 = FLAG_EIP140_BEFORE | FLAG_EIP140_AFTER;
 
     /// @dev An independent `OffchainLookup` session.
@@ -32,6 +32,21 @@ contract CCIPBatcher is CCIPReader {
     struct Batch {
         Lookup[] lookups;
         string[] gateways;
+    }
+
+    /// @dev Create a `Batch` for a single target with multiple calls.
+    function _createBatch(
+        address target,
+        bytes[] memory calls,
+        string[] memory gateways
+    ) internal pure returns (Batch memory) {
+        Lookup[] memory lookups = new Lookup[](calls.length);
+        for (uint256 i; i < calls.length; i++) {
+            Lookup memory lu = lookups[i];
+            lu.target = target;
+            lu.call = calls[i];
+        }
+        return Batch(lookups, gateways);
     }
 
     /// @dev Use `CCIPReader.ccipRead()` to call this function with a batch.

--- a/contracts/ccipRead/CCIPBatcher.sol
+++ b/contracts/ccipRead/CCIPBatcher.sol
@@ -75,12 +75,12 @@ abstract contract CCIPBatcher is CCIPReader {
             if (!ok && bytes4(v) == OffchainLookup.selector) {
                 lu.flags |= FLAG_OFFCHAIN;
             } else {
-                // unsafe contracts appear the same for throw and unimplemented fallback
-                // decision: interpret both as empty response
-                if (ok || (unsafe && v.length == 0)) {
-                    lu.flags |= FLAG_DONE;
-                } else {
-                    lu.flags |= FLAG_DONE | FLAG_CALL_ERROR;
+                lu.flags |= FLAG_DONE;
+                if (unsafe && v.length == 0) {
+                    // unsafe contracts appear the same for throw and unimplemented fallback
+                    // decision: interpret like an unimplemented function selector response
+                } else if (!ok) {
+                    lu.flags |= FLAG_CALL_ERROR;
                 }
                 if (v.length == 0) {
                     lu.flags |= FLAG_EMPTY_RESPONSE;

--- a/contracts/ccipRead/CCIPBatcher.sol
+++ b/contracts/ccipRead/CCIPBatcher.sol
@@ -35,8 +35,8 @@ contract CCIPBatcher is CCIPReader {
         string[] gateways;
     }
 
-    /// @dev Create a `Batch` for a single target with multiple calls.
-    function _createBatch(
+    /// @dev Create a batch for a single target with multiple calls.
+    function createBatch(
         address target,
         bytes[] memory calls,
         string[] memory gateways
@@ -58,7 +58,7 @@ contract CCIPBatcher is CCIPReader {
         for (uint256 i; i < batch.lookups.length; i++) {
             Lookup memory lu = batch.lookups[i];
             if ((lu.flags & FLAGS_ANY_EIP140) == 0) {
-                uint256 flags = _detectEIP140(lu.target)
+                uint256 flags = detectEIP140(lu.target)
                     ? FLAG_EIP140_AFTER
                     : FLAG_EIP140_BEFORE;
                 for (uint256 j = i; j < batch.lookups.length; j++) {
@@ -68,7 +68,7 @@ contract CCIPBatcher is CCIPReader {
                 }
             }
             bool old = (lu.flags & FLAG_EIP140_AFTER) == 0;
-            (bool ok, bytes memory v) = _safeCall(!old, lu.target, lu.call);
+            (bool ok, bytes memory v) = safeCall(!old, lu.target, lu.call);
             if (ok || (old && v.length == 0)) {
                 lu.flags |= FLAG_DONE;
                 if (v.length == 0) {

--- a/contracts/ccipRead/CCIPBatcher.sol
+++ b/contracts/ccipRead/CCIPBatcher.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.17;
 import {IBatchGateway} from "./IBatchGateway.sol";
 import {CCIPReader, EIP3668, OffchainLookup} from "./CCIPReader.sol";
 
-contract CCIPBatcher is CCIPReader {
+abstract contract CCIPBatcher is CCIPReader {
     /// @notice The batch gateway supplied an incorrect number of responses.
     /// @dev Error selector: `0x4a5c31ea`
     error InvalidBatchGatewayResponse();
@@ -12,14 +12,14 @@ contract CCIPBatcher is CCIPReader {
     uint256 constant FLAG_OFFCHAIN = 1 << 0; // the lookup reverted `OffchainLookup`
     uint256 constant FLAG_CALL_ERROR = 1 << 1; // the initial call or callback reverted
     uint256 constant FLAG_BATCH_ERROR = 1 << 2; // `OffchainLookup` failed on the batch gateway
+    uint256 constant FLAG_EMPTY_RESPONSE = 1 << 3; // the initial call or callback returned `0x`
     uint256 constant FLAG_EIP140_BEFORE = 1 << 4; // does not have revert op code
     uint256 constant FLAG_EIP140_AFTER = 1 << 5; // has revert op code
     uint256 constant FLAG_DONE = 1 << 6; // the lookup has finished processing (private)
 
-    uint256 constant FLAGS_ANY_ERROR = FLAG_CALL_ERROR | FLAG_BATCH_ERROR;
+    uint256 constant FLAGS_ANY_ERROR =
+        FLAG_CALL_ERROR | FLAG_BATCH_ERROR | FLAG_EMPTY_RESPONSE;
     uint256 constant FLAGS_ANY_EIP140 = FLAG_EIP140_BEFORE | FLAG_EIP140_AFTER;
-
-    constructor(uint256 unsafeCallGas) CCIPReader(unsafeCallGas) {}
 
     /// @dev An independent `OffchainLookup` session.
     struct Lookup {
@@ -36,13 +36,16 @@ contract CCIPBatcher is CCIPReader {
     }
 
     /// @dev Create a batch for a single target with multiple calls.
+    /// @param target The target contract.
+    /// @param calls The list of calldata.
+    /// @param gateways The batch gateway URLs.
     function createBatch(
         address target,
         bytes[] memory calls,
         string[] memory gateways
     ) internal pure returns (Batch memory) {
         Lookup[] memory lookups = new Lookup[](calls.length);
-        for (uint256 i; i < calls.length; i++) {
+        for (uint256 i; i < calls.length; ++i) {
             Lookup memory lu = lookups[i];
             lu.target = target;
             lu.call = calls[i];
@@ -50,18 +53,18 @@ contract CCIPBatcher is CCIPReader {
         return Batch(lookups, gateways);
     }
 
-    /// @dev Use `CCIPReader.ccipRead()` to call this function with a batch.
-    ///      The callback `response` will be `abi.encode(batch)`.
+    /// @dev Use `ccipRead()` to call this function with a batch.
+    ///      The callback response will be `abi.encode(batch)`.
     function ccipBatch(
         Batch memory batch
     ) external view returns (Batch memory) {
-        for (uint256 i; i < batch.lookups.length; i++) {
+        for (uint256 i; i < batch.lookups.length; ++i) {
             Lookup memory lu = batch.lookups[i];
             if ((lu.flags & FLAGS_ANY_EIP140) == 0) {
                 uint256 flags = detectEIP140(lu.target)
                     ? FLAG_EIP140_AFTER
                     : FLAG_EIP140_BEFORE;
-                for (uint256 j = i; j < batch.lookups.length; j++) {
+                for (uint256 j = i; j < batch.lookups.length; ++j) {
                     if (batch.lookups[j].target == lu.target) {
                         batch.lookups[j].flags |= flags;
                     }
@@ -69,14 +72,19 @@ contract CCIPBatcher is CCIPReader {
             }
             bool unsafe = (lu.flags & FLAG_EIP140_AFTER) == 0;
             (bool ok, bytes memory v) = safeCall(!unsafe, lu.target, lu.call);
-            // unsafe contracts appear the same for throw and unimplemented fallback
-            // decision: interpret both as empty response
-            if (ok || (unsafe && v.length == 0)) {
-                lu.flags |= FLAG_DONE;
-            } else if (bytes4(v) == OffchainLookup.selector) {
+            if (!ok && bytes4(v) == OffchainLookup.selector) {
                 lu.flags |= FLAG_OFFCHAIN;
             } else {
-                lu.flags |= FLAG_DONE | FLAG_CALL_ERROR;
+                // unsafe contracts appear the same for throw and unimplemented fallback
+                // decision: interpret both as empty response
+                if (ok || (unsafe && v.length == 0)) {
+                    lu.flags |= FLAG_DONE;
+                } else {
+                    lu.flags |= FLAG_DONE | FLAG_CALL_ERROR;
+                }
+                if (v.length == 0) {
+                    lu.flags |= FLAG_EMPTY_RESPONSE;
+                }
             }
             lu.data = v;
         }
@@ -90,7 +98,7 @@ contract CCIPBatcher is CCIPReader {
             batch.lookups.length
         );
         uint256 count;
-        for (uint256 i; i < batch.lookups.length; i++) {
+        for (uint256 i; i < batch.lookups.length; ++i) {
             Lookup memory lu = batch.lookups[i];
             if ((lu.flags & FLAG_DONE) == 0) {
                 EIP3668.Params memory p = decodeOffchainLookup(lu.data);
@@ -133,7 +141,7 @@ contract CCIPBatcher is CCIPReader {
         }
         batch = abi.decode(extraData, (Batch));
         uint256 expected;
-        for (uint256 i; i < batch.lookups.length; i++) {
+        for (uint256 i; i < batch.lookups.length; ++i) {
             Lookup memory lu = batch.lookups[i];
             if ((lu.flags & FLAG_DONE) == 0) {
                 if (expected < responses.length) {
@@ -151,13 +159,17 @@ contract CCIPBatcher is CCIPReader {
                                 p.extraData
                             )
                         );
-                        // decision: promote empty response from the callback => call error
-                        // ie. the initial function was implemented but the callback was not
-                        // note: FLAG_OFFCHAIN will be true
-                        if (ok && v.length > 0) {
+                        if (ok || bytes4(v) != OffchainLookup.selector) {
                             lu.flags |= FLAG_DONE;
-                        } else if (bytes4(v) != OffchainLookup.selector) {
-                            lu.flags |= FLAG_DONE | FLAG_CALL_ERROR;
+                            // decision: promote empty response from the callback => call error
+                            // ie. the initial function was implemented but the callback was not
+                            // this can be detected via FLAG_OFFCHAIN
+                            if (!ok || v.length == 0) {
+                                lu.flags |= FLAG_CALL_ERROR;
+                            }
+                            if (v.length == 0) {
+                                lu.flags |= FLAG_EMPTY_RESPONSE;
+                            }
                         }
                     }
                     lu.data = v;

--- a/contracts/ccipRead/CCIPBatcher.sol
+++ b/contracts/ccipRead/CCIPBatcher.sol
@@ -6,6 +6,7 @@ import {CCIPReader, EIP3668, OffchainLookup} from "./CCIPReader.sol";
 
 contract CCIPBatcher is CCIPReader {
     /// @dev The batch gateway supplied an incorrect number of responses.
+    ///      Error selector: `0x4a5c31ea`
     error InvalidBatchGatewayResponse();
 
     uint256 constant FLAG_OFFCHAIN = 1 << 0; // the lookup reverted `OffchainLookup`
@@ -16,8 +17,8 @@ contract CCIPBatcher is CCIPReader {
     uint256 constant FLAG_EIP140_AFTER = 1 << 5; // has revert op code
     uint256 constant FLAG_DONE = 1 << 6; // the lookup has finished processing (private)
 
-    uint256 constant FLAGS_TARGET_ERROR = FLAG_EMPTY_RESPONSE | FLAG_CALL_ERROR;
-    uint256 constant FLAGS_ANY_ERROR = FLAGS_TARGET_ERROR | FLAG_BATCH_ERROR;
+    uint256 constant FLAGS_ANY_ERROR =
+        FLAG_CALL_ERROR | FLAG_BATCH_ERROR | FLAG_EMPTY_RESPONSE;
     uint256 constant FLAGS_ANY_EIP140 = FLAG_EIP140_BEFORE | FLAG_EIP140_AFTER;
 
     /// @dev An independent `OffchainLookup` session.

--- a/contracts/ccipRead/CCIPBatcher.sol
+++ b/contracts/ccipRead/CCIPBatcher.sol
@@ -19,6 +19,8 @@ contract CCIPBatcher is CCIPReader {
     uint256 constant FLAGS_ANY_ERROR = FLAG_CALL_ERROR | FLAG_BATCH_ERROR;
     uint256 constant FLAGS_ANY_EIP140 = FLAG_EIP140_BEFORE | FLAG_EIP140_AFTER;
 
+    constructor(uint256 unsafeCallGas) CCIPReader(unsafeCallGas) {}
+
     /// @dev An independent `OffchainLookup` session.
     struct Lookup {
         address target; // contract to call

--- a/contracts/ccipRead/CCIPBatcher.sol
+++ b/contracts/ccipRead/CCIPBatcher.sol
@@ -5,20 +5,18 @@ import {IBatchGateway} from "./IBatchGateway.sol";
 import {CCIPReader, EIP3668, OffchainLookup} from "./CCIPReader.sol";
 
 contract CCIPBatcher is CCIPReader {
-    /// @dev The batch gateway supplied an incorrect number of responses.
-    ///      Error selector: `0x4a5c31ea`
+    /// @notice The batch gateway supplied an incorrect number of responses.
+    /// @dev Error selector: `0x4a5c31ea`
     error InvalidBatchGatewayResponse();
 
     uint256 constant FLAG_OFFCHAIN = 1 << 0; // the lookup reverted `OffchainLookup`
     uint256 constant FLAG_CALL_ERROR = 1 << 1; // the initial call or callback reverted
     uint256 constant FLAG_BATCH_ERROR = 1 << 2; // `OffchainLookup` failed on the batch gateway
-    uint256 constant FLAG_EMPTY_RESPONSE = 1 << 3; // the initial call or callback returned `0x`
     uint256 constant FLAG_EIP140_BEFORE = 1 << 4; // does not have revert op code
     uint256 constant FLAG_EIP140_AFTER = 1 << 5; // has revert op code
     uint256 constant FLAG_DONE = 1 << 6; // the lookup has finished processing (private)
 
-    uint256 constant FLAGS_ANY_ERROR =
-        FLAG_CALL_ERROR | FLAG_BATCH_ERROR | FLAG_EMPTY_RESPONSE;
+    uint256 constant FLAGS_ANY_ERROR = FLAG_CALL_ERROR | FLAG_BATCH_ERROR;
     uint256 constant FLAGS_ANY_EIP140 = FLAG_EIP140_BEFORE | FLAG_EIP140_AFTER;
 
     /// @dev An independent `OffchainLookup` session.
@@ -67,14 +65,12 @@ contract CCIPBatcher is CCIPReader {
                     }
                 }
             }
-            bool old = (lu.flags & FLAG_EIP140_AFTER) == 0;
-            (bool ok, bytes memory v) = safeCall(!old, lu.target, lu.call);
-            if (ok || (old && v.length == 0)) {
+            bool unsafe = (lu.flags & FLAG_EIP140_AFTER) == 0;
+            (bool ok, bytes memory v) = safeCall(!unsafe, lu.target, lu.call);
+            // unsafe contracts appear the same for throw and unimplemented fallback
+            // decision: interpret both as empty response
+            if (ok || (unsafe && v.length == 0)) {
                 lu.flags |= FLAG_DONE;
-                if (v.length == 0) {
-                    v = abi.encodePacked(bytes4(lu.call));
-                    lu.flags |= FLAG_EMPTY_RESPONSE;
-                }
             } else if (bytes4(v) == OffchainLookup.selector) {
                 lu.flags |= FLAG_OFFCHAIN;
             } else {
@@ -145,6 +141,7 @@ contract CCIPBatcher is CCIPReader {
                     } else {
                         EIP3668.Params memory p = decodeOffchainLookup(lu.data);
                         bool ok;
+                        // assumption: unsafe contracts don't revert OffchainLookup()
                         (ok, v) = p.sender.staticcall(
                             abi.encodeWithSelector(
                                 p.callbackFunction,
@@ -152,12 +149,11 @@ contract CCIPBatcher is CCIPReader {
                                 p.extraData
                             )
                         );
-                        if (ok) {
+                        // decision: promote empty response from the callback => call error
+                        // ie. the initial function was implemented but the callback was not
+                        // note: FLAG_OFFCHAIN will be true
+                        if (ok && v.length > 0) {
                             lu.flags |= FLAG_DONE;
-                            if (v.length == 0) {
-                                v = abi.encodePacked(p.callbackFunction);
-                                lu.flags |= FLAG_EMPTY_RESPONSE;
-                            }
                         } else if (bytes4(v) != OffchainLookup.selector) {
                             lu.flags |= FLAG_DONE | FLAG_CALL_ERROR;
                         }

--- a/contracts/ccipRead/CCIPReader.sol
+++ b/contracts/ccipRead/CCIPReader.sol
@@ -18,37 +18,46 @@ import {EIP3668, OffchainLookup} from "./EIP3668.sol";
 import {BytesUtils} from "../utils/BytesUtils.sol";
 
 contract CCIPReader {
+
+    /// @dev Special-purpose value for identity callback: `f(x) = x`.
+    bytes4 constant IDENTITY_FUNCTION = bytes4(0);
+
+    /// @dev The gas limit for calling functions on unsafe contracts.
+    uint256 immutable unsafeCallGas;
+
+    constructor(uint256 _unsafeCallGas) {
+        unsafeCallGas = _unsafeCallGas;
+    }
+
     /// @dev A recursive CCIP-Read session.
     struct Context {
         address target;
         bytes4 callbackFunction;
         bytes extraData;
-        bytes4 myCallbackFunction;
+        bytes4 successCallbackFunction;
+        bytes4 failureCallbackFunction;
         bytes myExtraData;
-        bool catchReverts;
     }
-
-    /// @dev Special-purpose value for identity callback: `f(x) = x`.
-    bytes4 constant IDENTITY_FUNCTION = bytes4(0);
 
     /// @dev Same as `ccipRead()` but the callback function is the identity.
     function ccipRead(address target, bytes memory call) internal view {
-        ccipRead(target, call, IDENTITY_FUNCTION, "", false);
+        ccipRead(target, call, IDENTITY_FUNCTION, IDENTITY_FUNCTION, "");
     }
 
     /// @dev Performs a CCIP-Read and handles internal recursion.
     ///      Reverts `OffchainLookup` if necessary.
+    ///      Use `IDENTITY_FUNCTION` as the callback function selector for return/revert behavior.
     /// @param target The contract address.
     /// @param call The calldata to `staticcall()` on `target`.
-    /// @param callbackFunction The function selector of callback.
-    /// @param extraData The contextual data relayed to `callbackFunction`.
-    /// @param catchReverts If true, passes revert data to the callback too.
+    /// @param successCallbackFunction The function selector of callback on success.
+    /// @param failureCallbackFunction The function selector of callback on failure.
+    /// @param extraData The contextual data relayed to callback function.
     function ccipRead(
         address target,
         bytes memory call,
-        bytes4 callbackFunction,
-        bytes memory extraData,
-        bool catchReverts
+        bytes4 successCallbackFunction,
+        bytes4 failureCallbackFunction,
+        bytes memory extraData
     ) internal view {
         // We call the intended function that **could** revert with an `OffchainLookup`
         // We destructure the response into an execution status bool and our return bytes
@@ -74,16 +83,18 @@ contract CCIPReader {
                             target,
                             p.callbackFunction,
                             p.extraData,
-                            callbackFunction,
-                            extraData,
-                            catchReverts
+                            successCallbackFunction,
+                            failureCallbackFunction,
+                            extraData
                         )
                     )
                 );
             }
         }
         // IF we have gotten here, the 'real' target does not revert with an `OffchainLookup` error
-        if ((ok || catchReverts) && callbackFunction != IDENTITY_FUNCTION) {
+        // figure out what callback to call
+        bytes4 callbackFunction = ok ? successCallbackFunction : failureCallbackFunction;
+        if (callbackFunction != IDENTITY_FUNCTION) {
             // The exit point of this architecture is OUR callback in the 'real'
             // We pass through the response to that callback
             (ok, v) = address(this).staticcall(
@@ -121,9 +132,9 @@ contract CCIPReader {
                 response,
                 ctx.extraData
             ),
-            ctx.myCallbackFunction,
-            ctx.myExtraData,
-            ctx.catchReverts
+            ctx.successCallbackFunction,
+            ctx.failureCallbackFunction,
+            ctx.myExtraData
         );
     }
 
@@ -157,6 +168,6 @@ contract CCIPReader {
         address target,
         bytes memory call
     ) internal view returns (bool ok, bytes memory v) {
-        (ok, v) = target.staticcall{gas: safe ? gasleft() : 50000}(call);
+        (ok, v) = target.staticcall{gas: safe ? gasleft() : unsafeCallGas}(call);
     }
 }

--- a/contracts/ccipRead/CCIPReader.sol
+++ b/contracts/ccipRead/CCIPReader.sol
@@ -36,16 +36,6 @@ contract CCIPReader {
         ccipRead(target, call, IDENTITY_FUNCTION, "", false);
     }
 
-    /// @dev Same as `ccipRead()` w/catchReverts = false.
-    function ccipRead(
-        address target,
-        bytes memory call,
-        bytes4 callbackFunction,
-        bytes memory extraData
-    ) internal view {
-        ccipRead(target, call, callbackFunction, extraData, false);
-    }
-
     /// @dev Performs a CCIP-Read and handles internal recursion.
     ///      Reverts `OffchainLookup` if necessary.
     /// @param target The contract address.

--- a/contracts/ccipRead/CCIPReader.sol
+++ b/contracts/ccipRead/CCIPReader.sol
@@ -18,6 +18,8 @@ import {EIP3668, OffchainLookup} from "./EIP3668.sol";
 import {BytesUtils} from "../utils/BytesUtils.sol";
 
 contract CCIPReader {
+    /// @dev Default unsafe call gas (sufficient for legacy ENS resolver profiles).
+    uint256 constant DEFAULT_UNSAFE_CALL_GAS = 50000;
 
     /// @dev Special-purpose value for identity callback: `f(x) = x`.
     bytes4 constant IDENTITY_FUNCTION = bytes4(0);
@@ -93,7 +95,9 @@ contract CCIPReader {
         }
         // IF we have gotten here, the 'real' target does not revert with an `OffchainLookup` error
         // figure out what callback to call
-        bytes4 callbackFunction = ok ? successCallbackFunction : failureCallbackFunction;
+        bytes4 callbackFunction = ok
+            ? successCallbackFunction
+            : failureCallbackFunction;
         if (callbackFunction != IDENTITY_FUNCTION) {
             // The exit point of this architecture is OUR callback in the 'real'
             // We pass through the response to that callback
@@ -168,6 +172,8 @@ contract CCIPReader {
         address target,
         bytes memory call
     ) internal view returns (bool ok, bytes memory v) {
-        (ok, v) = target.staticcall{gas: safe ? gasleft() : unsafeCallGas}(call);
+        (ok, v) = target.staticcall{gas: safe ? gasleft() : unsafeCallGas}(
+            call
+        );
     }
 }

--- a/contracts/ccipRead/CCIPReader.sol
+++ b/contracts/ccipRead/CCIPReader.sol
@@ -25,6 +25,7 @@ contract CCIPReader {
         bytes extraData;
         bytes4 myCallbackFunction;
         bytes myExtraData;
+        bool catchReverts;
     }
 
     /// @dev Special-purpose value for identity callback: `f(x) = x`.
@@ -32,7 +33,17 @@ contract CCIPReader {
 
     /// @dev Same as `ccipRead()` but the callback function is the identity.
     function ccipRead(address target, bytes memory call) internal view {
-        ccipRead(target, call, IDENTITY_FUNCTION, "");
+        ccipRead(target, call, IDENTITY_FUNCTION, "", false);
+    }
+
+    /// @dev Same as `ccipRead()` w/catchReverts = false.
+    function ccipRead(
+        address target,
+        bytes memory call,
+        bytes4 callbackFunction,
+        bytes memory extraData
+    ) internal view {
+        ccipRead(target, call, callbackFunction, extraData, false);
     }
 
     /// @dev Performs a CCIP-Read and handles internal recursion.
@@ -41,11 +52,13 @@ contract CCIPReader {
     /// @param call The calldata to `staticcall()` on `target`.
     /// @param callbackFunction The function selector of callback.
     /// @param extraData The contextual data relayed to `callbackFunction`.
+    /// @param catchReverts Pass reverts to the callback.
     function ccipRead(
         address target,
         bytes memory call,
         bytes4 callbackFunction,
-        bytes memory extraData
+        bytes memory extraData,
+        bool catchReverts
     ) internal view {
         // We call the intended function that **could** revert with an `OffchainLookup`
         // We destructure the response into an execution status bool and our return bytes
@@ -72,14 +85,15 @@ contract CCIPReader {
                             p.callbackFunction,
                             p.extraData,
                             callbackFunction,
-                            extraData
+                            extraData,
+                            catchReverts
                         )
                     )
                 );
             }
         }
         // IF we have gotten here, the 'real' target does not revert with an `OffchainLookup` error
-        if (ok && callbackFunction != IDENTITY_FUNCTION) {
+        if ((ok || catchReverts) && callbackFunction != IDENTITY_FUNCTION) {
             // The exit point of this architecture is  OUR callback in the 'real'
             // We pass through the response to that callback
             (ok, v) = address(this).staticcall(
@@ -118,7 +132,8 @@ contract CCIPReader {
                 ctx.extraData
             ),
             ctx.myCallbackFunction,
-            ctx.myExtraData
+            ctx.myExtraData,
+            ctx.catchReverts
         );
     }
 

--- a/contracts/ccipRead/CCIPReader.sol
+++ b/contracts/ccipRead/CCIPReader.sol
@@ -42,7 +42,7 @@ contract CCIPReader {
     /// @param call The calldata to `staticcall()` on `target`.
     /// @param callbackFunction The function selector of callback.
     /// @param extraData The contextual data relayed to `callbackFunction`.
-    /// @param catchReverts Pass reverts to the callback.
+    /// @param catchReverts If true, passes revert data to the callback too.
     function ccipRead(
         address target,
         bytes memory call,
@@ -52,8 +52,8 @@ contract CCIPReader {
     ) internal view {
         // We call the intended function that **could** revert with an `OffchainLookup`
         // We destructure the response into an execution status bool and our return bytes
-        (bool ok, bytes memory v) = _safeCall(
-            _detectEIP140(target),
+        (bool ok, bytes memory v) = safeCall(
+            detectEIP140(target),
             target,
             call
         );
@@ -84,7 +84,7 @@ contract CCIPReader {
         }
         // IF we have gotten here, the 'real' target does not revert with an `OffchainLookup` error
         if ((ok || catchReverts) && callbackFunction != IDENTITY_FUNCTION) {
-            // The exit point of this architecture is  OUR callback in the 'real'
+            // The exit point of this architecture is OUR callback in the 'real'
             // We pass through the response to that callback
             (ok, v) = address(this).staticcall(
                 abi.encodeWithSelector(callbackFunction, v, extraData)
@@ -140,7 +140,7 @@ contract CCIPReader {
     //       Assumption: only newer contracts revert `OffchainLookup`.
     /// @param target The contract to test.
     /// @return safe True if safe to call.
-    function _detectEIP140(address target) internal view returns (bool safe) {
+    function detectEIP140(address target) internal view returns (bool safe) {
         if (target == address(this)) return true;
         // https://github.com/ethereum/EIPs/blob/master/EIPS/eip-140.md
         assembly {
@@ -152,7 +152,7 @@ contract CCIPReader {
     }
 
     /// @dev Same as `staticcall()` but prevents OOG when not `safe`.
-    function _safeCall(
+    function safeCall(
         bool safe,
         address target,
         bytes memory call

--- a/contracts/resolvers/ResolverFeatures.sol
+++ b/contracts/resolvers/ResolverFeatures.sol
@@ -3,11 +3,11 @@ pragma solidity ^0.8.0;
 
 library ResolverFeatures {
     /// @notice Implements `resolve(multicall([...]))`.
-    /// @dev Feature: `0xcc086793`
+    /// @dev Feature: `0x96b62db8`
     bytes4 constant RESOLVE_MULTICALL =
-        bytes4(keccak256("ens.resolver.extended.multicall"));
+        bytes4(keccak256("eth.ens.resolver.extended.multicall"));
 
     /// @notice Returns the same records independent of name or node.
-    /// @dev Feature: `0xfaa33450`
-    bytes4 constant SINGULAR = bytes4(keccak256("ens.resolver.singular"));
+    /// @dev Feature: `0x86fb8da8`
+    bytes4 constant SINGULAR = bytes4(keccak256("eth.ens.resolver.singular"));
 }

--- a/contracts/resolvers/ResolverFeatures.sol
+++ b/contracts/resolvers/ResolverFeatures.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+library ResolverFeatures {
+    /// @notice Implements `resolve(multicall([...]))`.
+    /// @dev Feature: `0xcc086793`
+    bytes4 constant RESOLVE_MULTICALL =
+        bytes4(keccak256("ens.resolver.extended.multicall"));
+
+    /// @notice Returns the same records independent of name or node.
+    /// @dev Feature: `0xfaa33450`
+    bytes4 constant SINGULAR = bytes4(keccak256("ens.resolver.singular"));
+}

--- a/contracts/reverseResolver/AbstractReverseResolver.sol
+++ b/contracts/reverseResolver/AbstractReverseResolver.sol
@@ -58,7 +58,7 @@ abstract contract AbstractReverseResolver is
     /// @notice Resolves the following profiles according to ENSIP-10:
     ///         - `name()` if `name` is an ENSIP-19 reverse name of an EVM address for `coinType`.
     ///         - `addr(*) = registrar` if `name` is an ENSIP-19 reverse namespace for `coinType`.
-    ///         Callers should enable EIP-3668.
+    ///         Caller should enable EIP-3668.
     /// @dev This function may execute over multiple steps.
     /// @param name The reverse name to resolve, in normalised and DNS-encoded form.
     /// @param data The resolution data, as specified in ENSIP-10.

--- a/contracts/reverseResolver/ChainReverseResolver.sol
+++ b/contracts/reverseResolver/ChainReverseResolver.sol
@@ -69,7 +69,6 @@ contract ChainReverseResolver is
     }
 
     /// @inheritdoc AbstractReverseResolver
-    /// @dev This function executes over multiple steps (step 1 of 2).
     function _resolveName(
         address addr
     ) internal view override returns (string memory) {
@@ -80,13 +79,13 @@ contract ChainReverseResolver is
         fetch(
             gatewayVerifier,
             req,
-            this.resolveNameCallback.selector,
+            this.resolveNameCallback.selector, // ==> step 2
             abi.encode(addr),
             gatewayURLs
         );
     }
 
-    /// @dev CCIP-Read callback for `_resolveName()` (step 2 of 2).
+    /// @dev CCIP-Read callback for `_resolveName()`.
     /// @param values The outputs for `GatewayRequest` (1 name).
     /// @param extraData The contextual data passed from `_resolveName()`.
     /// @return result The abi-encoded name for the given address.
@@ -113,7 +112,7 @@ contract ChainReverseResolver is
     }
 
     /// @dev Resolve the next page of addresses to names.
-    ///      This function executes over multiple steps (step 1 of 2).
+    ///      This function executes over multiple steps.
     function _resolveNames(
         address[] memory addrs,
         string[] memory names,
@@ -133,13 +132,13 @@ contract ChainReverseResolver is
         fetch(
             gatewayVerifier,
             req,
-            this.resolveNamesCallback.selector,
+            this.resolveNamesCallback.selector, // ==> step 2
             abi.encode(addrs, names, start, perPage),
             gatewayURLs
         );
     }
 
-    /// @dev CCIP-Read callback for `_resolveNames()` (step 2 of 2).
+    /// @dev CCIP-Read callback for `_resolveNames()`.
     ///      Recursive if there are still addresses to resolve.
     /// @param values The outputs for `GatewayRequest` (N names).
     /// @param extraData The contextual data passed from `_resolveNames()`.
@@ -163,6 +162,6 @@ contract ChainReverseResolver is
             }
             names[start + i] = name;
         }
-        _resolveNames(addrs, names, start + values.length, perPage);
+        _resolveNames(addrs, names, start + values.length, perPage); // ==> goto step 1 again
     }
 }

--- a/contracts/reverseResolver/INameReverser.sol
+++ b/contracts/reverseResolver/INameReverser.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.0;
 
 interface INameReverser {
     /// @notice Resolve multiple EVM addresses to names.
-    ///         Callers should enable EIP-3668.
+    ///         Caller should enable EIP-3668.
     /// @dev This function may execute over multiple steps.
     /// @param addrs The addresses to resolve.
     /// @param perPage The maximum number of addresses to resolve per call.

--- a/contracts/universalResolver/AbstractUniversalResolver.sol
+++ b/contracts/universalResolver/AbstractUniversalResolver.sol
@@ -41,7 +41,7 @@ abstract contract AbstractUniversalResolver is
             super.supportsInterface(interfaceId);
     }
 
-    /// @notice Set the default batch gateways, see: `resolve()` and `reverse()`.
+    /// @notice Set the default batch gateways.
     /// @param gateways The batch gateway URLs.
     function setBatchGateways(string[] memory gateways) external onlyOwner {
         _gateways = gateways;
@@ -120,12 +120,13 @@ abstract contract AbstractUniversalResolver is
     ) public view returns (bytes memory result, address resolver) {
         result;
         resolver;
+        ResolverInfo memory info = requireResolver(name);
         _callResolver(
-            requireResolver(name),
+            info,
             data,
             gateways,
             this.resolveCallback.selector,
-            ""
+            abi.encode(info.resolver)
         );
     }
 
@@ -141,23 +142,28 @@ abstract contract AbstractUniversalResolver is
         info.node = NameCoder.namehash(name, 0);
         info.resolver = resolver;
         _checkResolver(info);
-        _callResolver(info, data, gateways, this.resolveCallback.selector, "");
+        _callResolver(
+            info,
+            data,
+            gateways,
+            this.resolveCallback.selector,
+            abi.encode(resolver)
+        );
     }
 
     /// @dev CCIP-Read callback for `resolveWithGateways()` (step 2 of 2).
-    /// @param info The resolver that was called.
     /// @param response The response from the resolver.
+    /// @param extraData The contextual data passed from `resolveWith*()`.
     function resolveCallback(
-        ResolverInfo calldata info,
         bytes calldata response,
-        bytes calldata
+        bytes calldata extraData
     ) external pure returns (bytes memory, address) {
-        return (response, info.resolver);
+        return (response, abi.decode(extraData, (address)));
     }
 
     /// @notice Same as `reverseWithGateways()` but uses default batch gateways.
     function reverse(
-        bytes memory lookupAddress,
+        bytes calldata lookupAddress,
         uint256 coinType
     ) external view returns (string memory, address, address) {
         return reverseWithGateways(lookupAddress, coinType, _gateways);
@@ -167,6 +173,7 @@ abstract contract AbstractUniversalResolver is
         bytes lookupAddress;
         uint256 coinType;
         string[] gateways;
+        address resolver;
     }
 
     /// @notice Performs ENS reverse resolution for the supplied address and coin type.
@@ -179,7 +186,7 @@ abstract contract AbstractUniversalResolver is
     /// @return resolver The resolver address for primary name.
     /// @return reverseResolver The resolver address for the reverse name.
     function reverseWithGateways(
-        bytes memory lookupAddress,
+        bytes calldata lookupAddress,
         uint256 coinType,
         string[] memory gateways
     )
@@ -203,23 +210,23 @@ abstract contract AbstractUniversalResolver is
             abi.encodeCall(INameResolver.name, (info.node)),
             gateways,
             this.reverseNameCallback.selector,
-            abi.encode(ReverseArgs(lookupAddress, coinType, gateways))
+            abi.encode(
+                ReverseArgs(lookupAddress, coinType, gateways, info.resolver)
+            )
         );
     }
 
     /// @dev CCIP-Read callback for `reverseWithGateways()` (step 2 of 3).
-    /// @param infoRev The resolver for the reverse name that was called.
-    /// @param response The abi-encoded `name()` response.
+    /// @param response The abi-encoded `name()` response from the reverse resolver.
     /// @param extraData The contextual data passed from `reverseWithGateways()`.
     function reverseNameCallback(
-        ResolverInfo calldata infoRev,
         bytes calldata response,
-        bytes memory extraData // this cannot be calldata due to "stack too deep"
+        bytes calldata extraData
     ) external view returns (string memory primary, address, address) {
         ReverseArgs memory args = abi.decode(extraData, (ReverseArgs));
         primary = abi.decode(response, (string));
         if (bytes(primary).length == 0) {
-            return ("", address(0), infoRev.resolver);
+            return ("", address(0), args.resolver);
         }
         ResolverInfo memory info = requireResolver(NameCoder.encode(primary));
         _callResolver(
@@ -232,28 +239,30 @@ abstract contract AbstractUniversalResolver is
                 ),
             args.gateways,
             this.reverseAddressCallback.selector,
-            abi.encode(args, primary, infoRev.resolver)
+            abi.encode(args, primary, info.resolver, args.resolver)
         );
     }
 
     /// @dev CCIP-Read callback for `reverseNameCallback()` (step 3 of 3).
     ///      Reverts `ReverseAddressMismatch`.
-    /// @param info The resolver for the primary name that was called.
-    /// @param response The abi-encoded `addr()` response.
+    /// @param response The abi-encoded `addr()` response from the forward resolver.
     /// @param extraData The contextual data passed from `reverseNameCallback()`.
     function reverseAddressCallback(
-        ResolverInfo calldata info,
         bytes calldata response,
         bytes calldata extraData
     )
         external
         pure
-        returns (string memory primary, address, address reverseResolver)
+        returns (
+            string memory primary,
+            address resolver,
+            address reverseResolver
+        )
     {
         ReverseArgs memory args;
-        (args, primary, reverseResolver) = abi.decode(
+        (args, primary, resolver, reverseResolver) = abi.decode(
             extraData,
-            (ReverseArgs, string, address)
+            (ReverseArgs, string, address, address)
         );
         bytes memory primaryAddress;
         if (args.coinType == COIN_TYPE_ETH) {
@@ -265,11 +274,10 @@ abstract contract AbstractUniversalResolver is
         if (!BytesUtils.equals(args.lookupAddress, primaryAddress)) {
             revert ReverseAddressMismatch(primary, primaryAddress);
         }
-        return (primary, info.resolver, reverseResolver);
     }
 
     /// @dev Efficiently call a resolver.
-    ///      If features are supported, and not a multicall or extended + multicall + `RESOLVE_MULTICALL`, performs a direct call.
+    ///      If features are supported, and not a multicall or extended w/`RESOLVE_MULTICALL`, performs a direct call.
     ///      Otherwise, uses the batch gateway.
     /// @param info The resolver to call.
     /// @param call The calldata.
@@ -304,7 +312,12 @@ abstract contract AbstractUniversalResolver is
                     )
                     : call,
                 this.resolveDirectCallback.selector,
-                abi.encode(info, bytes4(call), callbackFunction, extraData),
+                abi.encode(
+                    info.extended,
+                    bytes4(call),
+                    callbackFunction,
+                    extraData
+                ),
                 true
             );
         } else {
@@ -331,10 +344,10 @@ abstract contract AbstractUniversalResolver is
                 address(this),
                 abi.encodeCall(
                     this.ccipBatch,
-                    (_createBatch(info.resolver, calls, gateways))
+                    (createBatch(info.resolver, calls, gateways))
                 ),
                 this.resolveBatchCallback.selector,
-                abi.encode(info, multi, callbackFunction, extraData),
+                abi.encode(info.extended, multi, callbackFunction, extraData),
                 false
             );
         }
@@ -346,11 +359,11 @@ abstract contract AbstractUniversalResolver is
         bytes calldata extraData
     ) external view {
         (
-            ResolverInfo memory info,
+            bool extended,
             bytes4 callSelector,
             bytes4 callbackFunction,
             bytes memory extraData_
-        ) = abi.decode(extraData, (ResolverInfo, bytes4, bytes4, bytes));
+        ) = abi.decode(extraData, (bool, bytes4, bytes4, bytes));
         if (response.length == 0) {
             response = abi.encodeWithSelector(
                 UnsupportedResolverProfile.selector,
@@ -360,12 +373,12 @@ abstract contract AbstractUniversalResolver is
         if ((response.length & 31) != 0) {
             revert ResolverError(response);
         }
-        if (info.extended) {
+        if (extended) {
             response = abi.decode(response, (bytes)); // unwrap resolve()
         }
         ccipRead(
             address(this),
-            abi.encodeWithSelector(callbackFunction, info, response, extraData_)
+            abi.encodeWithSelector(callbackFunction, response, extraData_)
         );
     }
 
@@ -376,16 +389,16 @@ abstract contract AbstractUniversalResolver is
     ) external view {
         Lookup[] memory lookups = abi.decode(response, (Batch)).lookups;
         (
-            ResolverInfo memory info,
+            bool extended,
             bool multi,
             bytes4 callbackFunction,
             bytes memory extraData_
-        ) = abi.decode(extraData, (ResolverInfo, bool, bytes4, bytes));
+        ) = abi.decode(extraData, (bool, bool, bytes4, bytes));
         bytes[] memory m = new bytes[](lookups.length);
         for (uint256 i; i < lookups.length; i++) {
             Lookup memory lu = lookups[i];
             bytes memory v = lu.data;
-            if ((lu.flags & FLAGS_ANY_ERROR) == 0 && info.extended) {
+            if ((lu.flags & FLAGS_ANY_ERROR) == 0 && extended) {
                 v = abi.decode(v, (bytes)); // unwrap resolve()
             } else if ((lu.flags & FLAG_EMPTY_RESPONSE) != 0) {
                 v = abi.encodeWithSelector(
@@ -415,7 +428,7 @@ abstract contract AbstractUniversalResolver is
         }
         ccipRead(
             address(this),
-            abi.encodeWithSelector(callbackFunction, info, answer, extraData_)
+            abi.encodeWithSelector(callbackFunction, answer, extraData_)
         );
     }
 }

--- a/contracts/universalResolver/AbstractUniversalResolver.sol
+++ b/contracts/universalResolver/AbstractUniversalResolver.sol
@@ -28,7 +28,7 @@ abstract contract AbstractUniversalResolver is
 {
     string[] _gateways;
 
-    constructor(string[] memory gateways) {
+    constructor(string[] memory gateways) CCIPBatcher(50000) {
         _gateways = gateways;
     }
 
@@ -311,13 +311,13 @@ abstract contract AbstractUniversalResolver is
                     )
                     : call,
                 this.resolveDirectCallback.selector,
+                this.resolveDirectCallbackError.selector,
                 abi.encode(
                     info.extended,
                     bytes4(call),
                     callbackFunction,
                     extraData
-                ),
-                true
+                )
             );
         } else {
             bytes[] memory calls;
@@ -332,7 +332,7 @@ abstract contract AbstractUniversalResolver is
                 calls[0] = call;
             }
             if (info.extended) {
-                for (uint256 i; i < calls.length; i++) {
+                for (uint256 i; i < calls.length; ++i) {
                     calls[i] = abi.encodeCall(
                         IExtendedResolver.resolve,
                         (info.name, calls[i])
@@ -346,13 +346,13 @@ abstract contract AbstractUniversalResolver is
                     (createBatch(info.resolver, calls, gateways))
                 ),
                 this.resolveBatchCallback.selector,
-                abi.encode(info.extended, multi, callbackFunction, extraData),
-                false
+                IDENTITY_FUNCTION,
+                abi.encode(info.extended, multi, callbackFunction, extraData)
             );
         }
     }
 
-    /// @dev CCIP-Read callback for `_callResolver()` from calling the resolver directly.
+    /// @dev CCIP-Read callback for `_callResolver()` from calling the resolver successfully.
     function resolveDirectCallback(
         bytes memory response,
         bytes calldata extraData
@@ -365,8 +365,6 @@ abstract contract AbstractUniversalResolver is
         ) = abi.decode(extraData, (bool, bytes4, bytes4, bytes));
         if (response.length == 0) {
             revert UnsupportedResolverProfile(callSelector);
-        } else if ((response.length & 31) != 0) {
-            revert ResolverError(response);
         }
         if (extended) {
             response = abi.decode(response, (bytes)); // unwrap resolve()
@@ -377,7 +375,15 @@ abstract contract AbstractUniversalResolver is
         );
     }
 
-    /// @dev CCIP-Read callback for `_callResolver()` from calling the batch gateway.
+    /// @dev CCIP-Read callback for `_callResolver()` from calling the resolver unsuccessfully.
+    function resolveDirectCallbackError(
+        bytes calldata response,
+        bytes calldata
+    ) external pure {
+        _propagateResolverError(response);
+    }
+
+    /// @dev CCIP-Read callback for `_callResolver()` from calling the batch gateway successfully.
     function resolveBatchCallback(
         bytes calldata response,
         bytes calldata extraData
@@ -392,7 +398,7 @@ abstract contract AbstractUniversalResolver is
         bytes memory answer;
         if (multi) {
             bytes[] memory m = new bytes[](lookups.length);
-            for (uint256 i; i < lookups.length; i++) {
+            for (uint256 i; i < lookups.length; ++i) {
                 Lookup memory lu = lookups[i];
                 bytes memory v = lu.data;
                 if (extended && (lu.flags & FLAGS_ANY_ERROR) == 0) {
@@ -404,19 +410,14 @@ abstract contract AbstractUniversalResolver is
         } else {
             Lookup memory lu = lookups[0];
             answer = lu.data;
-            if (
-                (lu.flags & FLAG_CALL_ERROR) != 0 && // wrap any error from the resolver
-                bytes4(answer) != UnsupportedResolverProfile.selector // except this
-            ) {
-                revert ResolverError(answer);
-            }
-            if (answer.length == 0) {
-                revert UnsupportedResolverProfile(bytes4(lu.call));
-            }
-            if ((answer.length & 31) != 0) {
+            if ((lu.flags & FLAG_BATCH_ERROR) != 0) {
                 assembly {
-                    revert(add(answer, 32), mload(answer))
+                    revert(add(answer, 32), mload(answer)) // propagate batch gateway errors
                 }
+            } else if ((lu.flags & FLAG_CALL_ERROR) != 0) {
+                _propagateResolverError(answer);
+            } else if (answer.length == 0) {
+                revert UnsupportedResolverProfile(bytes4(lu.call));
             }
             if (extended) {
                 answer = abi.decode(answer, (bytes)); // unwrap resolve()
@@ -426,5 +427,17 @@ abstract contract AbstractUniversalResolver is
             address(this),
             abi.encodeWithSelector(callbackFunction, answer, extraData_)
         );
+    }
+
+    /// @dev Propagate the revert from the resolver.
+    /// @param v The error data.
+    function _propagateResolverError(bytes memory v) internal pure {
+        if (bytes4(v) == UnsupportedResolverProfile.selector) {
+            assembly {
+                revert(add(v, 32), mload(v))
+            }
+        } else {
+            revert ResolverError(v);
+        }
     }
 }

--- a/contracts/universalResolver/AbstractUniversalResolver.sol
+++ b/contracts/universalResolver/AbstractUniversalResolver.sol
@@ -364,12 +364,8 @@ abstract contract AbstractUniversalResolver is
             bytes memory extraData_
         ) = abi.decode(extraData, (bool, bytes4, bytes4, bytes));
         if (response.length == 0) {
-            response = abi.encodeWithSelector(
-                UnsupportedResolverProfile.selector,
-                callSelector
-            );
-        }
-        if ((response.length & 31) != 0) {
+            revert UnsupportedResolverProfile(callSelector);
+        } else if ((response.length & 31) != 0) {
             revert ResolverError(response);
         }
         if (extended) {
@@ -413,13 +409,11 @@ abstract contract AbstractUniversalResolver is
         } else {
             answer = m[0];
             if (
-                (lookups[0].flags & (FLAG_EMPTY_RESPONSE | FLAG_CALL_ERROR)) !=
-                0 && // resolver-originating error should be wrapped
-                bytes4(answer) != UnsupportedResolverProfile.selector // except this error
+                (lookups[0].flags & FLAG_CALL_ERROR) != 0 && // wrap any error from the resolver
+                bytes4(answer) != UnsupportedResolverProfile.selector // except this
             ) {
                 revert ResolverError(answer);
-            }
-            if (answer.length & 31 != 0) {
+            } else if (answer.length & 31 != 0) {
                 assembly {
                     revert(add(answer, 32), mload(answer))
                 }

--- a/contracts/universalResolver/AbstractUniversalResolver.sol
+++ b/contracts/universalResolver/AbstractUniversalResolver.sol
@@ -15,6 +15,8 @@ import {IMulticallable} from "../resolvers/IMulticallable.sol";
 import {NameCoder} from "../utils/NameCoder.sol";
 import {BytesUtils} from "../utils/BytesUtils.sol";
 import {ENSIP19, COIN_TYPE_ETH, COIN_TYPE_DEFAULT} from "../utils/ENSIP19.sol";
+import {isFeatureSupported} from "../utils/IFeatureSupporter.sol";
+import {ResolverFeatures} from "../resolvers/ResolverFeatures.sol";
 
 abstract contract AbstractUniversalResolver is
     IUniversalResolver,
@@ -265,22 +267,89 @@ abstract contract AbstractUniversalResolver is
         bytes4 callbackFunction,
         bytes memory extraData
     ) internal view {
-        Batch memory batch = Batch(new Lookup[](calls.length), gateways);
-        for (uint256 i; i < calls.length; i++) {
-            Lookup memory lu = batch.lookups[i];
-            lu.target = info.resolver;
-            lu.call = info.extended
-                ? abi.encodeCall(
+        if (
+            info.extended &&
+            isFeatureSupported(
+                info.resolver,
+                ResolverFeatures.RESOLVE_MULTICALL
+            )
+        ) {
+            ccipRead(
+                address(info.resolver),
+                abi.encodeCall(
                     IExtendedResolver.resolve,
-                    (info.name, calls[i])
-                )
-                : calls[i];
+                    (
+                        info.name,
+                        abi.encodeCall(IMulticallable.multicall, (calls))
+                    )
+                ),
+                this.resolveMulticallCallback.selector,
+                abi.encode(info, callbackFunction, extraData, calls)
+            );
+        } else {
+            Batch memory batch = Batch(new Lookup[](calls.length), gateways);
+            for (uint256 i; i < calls.length; i++) {
+                Lookup memory lu = batch.lookups[i];
+                lu.target = info.resolver;
+                lu.call = info.extended
+                    ? abi.encodeCall(
+                        IExtendedResolver.resolve,
+                        (info.name, calls[i])
+                    )
+                    : calls[i];
+            }
+            ccipRead(
+                address(this),
+                abi.encodeCall(this.ccipBatch, (batch)),
+                this.resolveBatchCallback.selector,
+                abi.encode(info, callbackFunction, extraData)
+            );
+        }
+    }
+
+    /// @dev CCIP-Read callback for `_resolveBatch()` when feature `RESOLVE_MULTICALL` is supported.
+    /// @param response The response data from the resolver.
+    /// @param extraData The contextual data from `_resolveBatch()`.
+    function resolveMulticallCallback(
+        bytes calldata response,
+        bytes calldata extraData
+    ) external view {
+        (
+            ResolverInfo memory info,
+            bytes4 callbackFunction_,
+            bytes memory extraData_,
+            bytes[] memory calls
+        ) = abi.decode(extraData, (ResolverInfo, bytes4, bytes, bytes[]));
+        bytes memory v = abi.decode(response, (bytes)); // unwrap resolve()
+        if (v.length == 0) {
+            revert UnsupportedResolverProfile(
+                IMulticallable.multicall.selector
+            );
+        }
+        if ((v.length & 31) != 0) revert ResolverError(v);
+        bytes[] memory answers = abi.decode(v, (bytes[]));
+        if (answers.length != calls.length) {
+            revert ResolverError(
+                abi.encodeWithSelector(0x08c379a0, "Length mismatch") // Error(string)
+            );
+        }
+        Lookup[] memory lookups = new Lookup[](calls.length);
+        for (uint256 i; i < calls.length; i++) {
+            Lookup memory lu = lookups[i];
+            v = answers[i];
+            lu.call = calls[i];
+            lu.flags = FLAG_DONE;
+            if (v.length == 0) {
+                lu.flags |= FLAG_EMPTY_RESPONSE;
+                lu.data = lu.call;
+            } else {
+                if ((v.length & 31) != 0) lu.flags |= FLAG_CALL_ERROR;
+                lu.data = v;
+            }
         }
         ccipRead(
             address(this),
-            abi.encodeCall(this.ccipBatch, (batch)),
-            this.resolveBatchCallback.selector,
-            abi.encode(info, callbackFunction, extraData)
+            abi.encodeWithSelector(callbackFunction_, info, lookups, extraData_)
         );
     }
 

--- a/contracts/universalResolver/AbstractUniversalResolver.sol
+++ b/contracts/universalResolver/AbstractUniversalResolver.sol
@@ -389,34 +389,39 @@ abstract contract AbstractUniversalResolver is
             bytes4 callbackFunction,
             bytes memory extraData_
         ) = abi.decode(extraData, (bool, bool, bytes4, bytes));
-        bytes[] memory m = new bytes[](lookups.length);
-        for (uint256 i; i < lookups.length; i++) {
-            Lookup memory lu = lookups[i];
-            bytes memory v = lu.data;
-            if ((lu.flags & FLAGS_ANY_ERROR) == 0 && extended) {
-                v = abi.decode(v, (bytes)); // unwrap resolve()
-            } else if ((lu.flags & FLAG_EMPTY_RESPONSE) != 0) {
-                v = abi.encodeWithSelector(
-                    UnsupportedResolverProfile.selector,
-                    bytes4(v)
-                );
-            }
-            m[i] = v;
-        }
         bytes memory answer;
         if (multi) {
+            bytes[] memory m = new bytes[](lookups.length);
+            for (uint256 i; i < lookups.length; i++) {
+                Lookup memory lu = lookups[i];
+                if ((lu.flags & FLAG_EMPTY_RESPONSE) != 0) {
+                    continue;
+                }
+                bytes memory v = lu.data;
+                if (extended && (lu.flags & FLAGS_ANY_ERROR) == 0) {
+                    v = abi.decode(v, (bytes)); // unwrap resolve()
+                }
+                m[i] = v;
+            }
             answer = abi.encode(m);
         } else {
-            answer = m[0];
-            if (
-                (lookups[0].flags & FLAG_CALL_ERROR) != 0 && // wrap any error from the resolver
+            Lookup memory lu = lookups[0];
+            answer = lu.data;
+            if ((lu.flags & FLAG_EMPTY_RESPONSE) != 0) {
+                revert UnsupportedResolverProfile(bytes4(answer));
+            } else if (
+                (lu.flags & FLAG_CALL_ERROR) != 0 && // wrap any error from the resolver
                 bytes4(answer) != UnsupportedResolverProfile.selector // except this
             ) {
                 revert ResolverError(answer);
-            } else if (answer.length & 31 != 0) {
+            }
+            if ((answer.length & 31) != 0) {
                 assembly {
                     revert(add(answer, 32), mload(answer))
                 }
+            }
+            if (extended) {
+                answer = abi.decode(answer, (bytes)); // unwrap resolve()
             }
         }
         ccipRead(

--- a/contracts/universalResolver/AbstractUniversalResolver.sol
+++ b/contracts/universalResolver/AbstractUniversalResolver.sol
@@ -206,7 +206,7 @@ abstract contract AbstractUniversalResolver is
     /// @dev CCIP-Read callback for `reverseNameCallback()` (step 3 of 3).
     ///      Reverts `ReverseAddressMismatch`.
     /// @param info The resolver for the primary name that was called.
-    /// @param response The lookups corresponding to the calls: `[addr()]`.
+    /// @param response The response from the resolver.
     /// @param extraData The contextual data passed from `reverseNameCallback()`.
     /// @return primary The resolved primary name.
     /// @return resolver The resolver address for primary name.
@@ -242,7 +242,9 @@ abstract contract AbstractUniversalResolver is
         resolver = info.resolver;
     }
 
-    /// @dev Perform multiple resolver calls in parallel using batch gateway.
+    /// @dev Efficiently call a resolver.
+    ///      If extended and `RESOLVE_MULTICALL` feature is supported, does a direct call.
+    ///      Otherwise, uses the batch gateway.
     /// @param info The resolver to call.
     /// @param call The calldata.
     /// @param gateways The list of batch gateway URLs to use.
@@ -267,12 +269,13 @@ abstract contract AbstractUniversalResolver is
                 address(info.resolver),
                 abi.encodeCall(IExtendedResolver.resolve, (info.name, call)),
                 this.resolveExtendedDirectCallback.selector,
-                abi.encode(info, call, callbackFunction, extraData),
+                abi.encode(info, bytes4(call), callbackFunction, extraData),
                 true
             );
         } else {
             bytes[] memory calls;
-            if (bytes4(call) == IMulticallable.multicall.selector) {
+            bool multi = bytes4(call) == IMulticallable.multicall.selector;
+            if (multi) {
                 calls = abi.decode(
                     BytesUtils.substring(call, 4, call.length - 4),
                     (bytes[])
@@ -296,7 +299,7 @@ abstract contract AbstractUniversalResolver is
                     (_createBatch(info.resolver, calls, gateways))
                 ),
                 this.resolveBatchCallback.selector,
-                abi.encode(info, call, callbackFunction, extraData)
+                abi.encode(info, multi, callbackFunction, extraData)
             );
         }
     }
@@ -308,14 +311,14 @@ abstract contract AbstractUniversalResolver is
     ) external view {
         (
             ResolverInfo memory info,
-            bytes memory call,
-            bytes4 callbackFunction_,
+            bytes4 callSelector,
+            bytes4 callbackFunction,
             bytes memory extraData_
-        ) = abi.decode(extraData, (ResolverInfo, bytes, bytes4, bytes));
+        ) = abi.decode(extraData, (ResolverInfo, bytes4, bytes4, bytes));
         if (response.length == 0) {
             response = abi.encodeWithSelector(
                 UnsupportedResolverProfile.selector,
-                bytes4(call)
+                callSelector
             );
         }
         if ((response.length & 31) != 0) {
@@ -324,27 +327,22 @@ abstract contract AbstractUniversalResolver is
         response = abi.decode(response, (bytes)); // unwrap resolve()
         ccipRead(
             address(this),
-            abi.encodeWithSelector(
-                callbackFunction_,
-                info,
-                response,
-                extraData_
-            )
+            abi.encodeWithSelector(callbackFunction, info, response, extraData_)
         );
     }
 
     /// @dev CCIP-Read callback for `_callResolver()` from calling the batch gateway.
     function resolveBatchCallback(
-        bytes memory response,
+        bytes calldata response,
         bytes calldata extraData
     ) external view {
         Lookup[] memory lookups = abi.decode(response, (Batch)).lookups;
         (
             ResolverInfo memory info,
-            bytes memory call,
-            bytes4 callbackFunction_,
+            bool multi,
+            bytes4 callbackFunction,
             bytes memory extraData_
-        ) = abi.decode(extraData, (ResolverInfo, bytes, bytes4, bytes));
+        ) = abi.decode(extraData, (ResolverInfo, bool, bytes4, bytes));
         bytes[] memory m = new bytes[](lookups.length);
         for (uint256 i; i < lookups.length; i++) {
             Lookup memory lu = lookups[i];
@@ -359,30 +357,23 @@ abstract contract AbstractUniversalResolver is
             }
             m[i] = v;
         }
-        if (bytes4(call) == IMulticallable.multicall.selector) {
-            response = abi.encode(m);
+        bytes memory answer;
+        if (multi) {
+            answer = abi.encode(m);
         } else {
-            response = m[0];
+            answer = m[0];
             if ((lookups[0].flags & FLAGS_TARGET_ERROR) != 0) {
-                response = abi.encodeWithSelector(
-                    ResolverError.selector,
-                    response
-                );
+                answer = abi.encodeWithSelector(ResolverError.selector, answer);
             }
-            if (response.length & 31 != 0) {
+            if (answer.length & 31 != 0) {
                 assembly {
-                    revert(add(response, 32), mload(response))
+                    revert(add(answer, 32), mload(answer))
                 }
             }
         }
         ccipRead(
             address(this),
-            abi.encodeWithSelector(
-                callbackFunction_,
-                info,
-                response,
-                extraData_
-            )
+            abi.encodeWithSelector(callbackFunction, info, answer, extraData_)
         );
     }
 }

--- a/contracts/universalResolver/AbstractUniversalResolver.sol
+++ b/contracts/universalResolver/AbstractUniversalResolver.sol
@@ -58,11 +58,7 @@ abstract contract AbstractUniversalResolver is
     /// @inheritdoc IUniversalResolver
     function findResolver(
         bytes memory name
-    )
-        public
-        view
-        virtual
-        returns (address resolver, bytes32 node, uint256 offset);
+    ) public view virtual returns (address, bytes32, uint256);
 
     /// @dev A valid resolver and its relevant properties.
     struct ResolverInfo {
@@ -112,15 +108,20 @@ abstract contract AbstractUniversalResolver is
     }
 
     /// @notice Performs ENS resolution process for the supplied name and resolution data.
-    /// @notice Callers should enable EIP-3668.
+    ///         Callers should enable EIP-3668.
     /// @dev This function executes over multiple steps (step 1 of 2).
+    /// @param name The name to resolve, in normalised and DNS-encoded form.
+    /// @param data The resolution data, as specified in ENSIP-10.
+    /// @param gateways The list of batch gateway URLs to use.
     /// @return result The encoded response for the requested call.
     /// @return resolver The address of the resolver that supplied `result`.
     function resolveWithGateways(
         bytes calldata name,
         bytes calldata data,
         string[] memory gateways
-    ) public view returns (bytes memory result, address /*resolver*/) {
+    ) public view returns (bytes memory result, address resolver) {
+        result;
+        resolver;
         _callResolver(
             requireResolver(name),
             data,
@@ -171,16 +172,30 @@ abstract contract AbstractUniversalResolver is
     }
 
     /// @notice Performs ENS reverse resolution for the supplied address and coin type.
-    /// @notice Callers should enable EIP-3668.
+    ///         Callers should enable EIP-3668.
     /// @dev This function executes over multiple steps (step 1 of 3).
     /// @param lookupAddress The input address.
     /// @param coinType The coin type.
     /// @param gateways The list of batch gateway URLs to use.
+    /// @return primary The resolved primary name.
+    /// @return resolver The resolver address for primary name.
+    /// @return reverseResolver The resolver address for the reverse name.
     function reverseWithGateways(
         bytes memory lookupAddress,
         uint256 coinType,
         string[] memory gateways
-    ) public view returns (string memory, address /* resolver */, address) {
+    )
+        public
+        view
+        returns (
+            string memory primary,
+            address resolver,
+            address reverseResolver
+        )
+    {
+        primary;
+        resolver;
+        reverseResolver;
         // https://docs.ens.domains/ensip/19
         ResolverInfo memory info = requireResolver(
             NameCoder.encode(ENSIP19.reverseName(lookupAddress, coinType)) // reverts EmptyAddress
@@ -226,11 +241,8 @@ abstract contract AbstractUniversalResolver is
     /// @dev CCIP-Read callback for `reverseNameCallback()` (step 3 of 3).
     ///      Reverts `ReverseAddressMismatch`.
     /// @param info The resolver for the primary name that was called.
-    /// @param response The response from the resolver.
+    /// @param response The abi-encoded `addr()` response.
     /// @param extraData The contextual data passed from `reverseNameCallback()`.
-    /// @return primary The resolved primary name.
-    /// @return resolver The resolver address for primary name.
-    /// @return reverseResolver The resolver address for the reverse name.
     function reverseAddressCallback(
         ResolverInfo calldata info,
         bytes calldata response,
@@ -238,11 +250,7 @@ abstract contract AbstractUniversalResolver is
     )
         external
         pure
-        returns (
-            string memory primary,
-            address resolver,
-            address reverseResolver
-        )
+        returns (string memory primary, address, address reverseResolver)
     {
         ReverseArgs memory args;
         (args, primary, reverseResolver) = abi.decode(
@@ -259,7 +267,7 @@ abstract contract AbstractUniversalResolver is
         if (!BytesUtils.equals(args.lookupAddress, primaryAddress)) {
             revert ReverseAddressMismatch(primary, primaryAddress);
         }
-        resolver = info.resolver;
+        return (primary, info.resolver, reverseResolver);
     }
 
     /// @dev Efficiently call a resolver.
@@ -385,10 +393,10 @@ abstract contract AbstractUniversalResolver is
             answer = m[0];
             if (
                 (lookups[0].flags & (FLAG_EMPTY_RESPONSE | FLAG_CALL_ERROR)) !=
-                0 && // resolver-originating error
-                bytes4(answer) != UnsupportedResolverProfile.selector // dont wrap
+                0 && // resolver-originating error should be wrapped
+                bytes4(answer) != UnsupportedResolverProfile.selector // exception
             ) {
-                answer = abi.encodeWithSelector(ResolverError.selector, answer);
+                revert ResolverError(answer);
             }
             if (answer.length & 31 != 0) {
                 assembly {

--- a/contracts/universalResolver/AbstractUniversalResolver.sol
+++ b/contracts/universalResolver/AbstractUniversalResolver.sol
@@ -6,7 +6,7 @@ import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import {ERC165Checker} from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
 
 import {IUniversalResolver} from "./IUniversalResolver.sol";
-import {CCIPBatcher} from "../ccipRead/CCIPBatcher.sol";
+import {CCIPBatcher, CCIPReader} from "../ccipRead/CCIPBatcher.sol";
 import {NameCoder} from "../utils/NameCoder.sol";
 import {BytesUtils} from "../utils/BytesUtils.sol";
 import {ENSIP19, COIN_TYPE_ETH, COIN_TYPE_DEFAULT} from "../utils/ENSIP19.sol";
@@ -28,7 +28,7 @@ abstract contract AbstractUniversalResolver is
 {
     string[] _gateways;
 
-    constructor(string[] memory gateways) CCIPBatcher(DEFAULT_UNSAFE_CALL_GAS) {
+    constructor(string[] memory gateways) CCIPReader(DEFAULT_UNSAFE_CALL_GAS) {
         _gateways = gateways;
     }
 

--- a/contracts/universalResolver/AbstractUniversalResolver.sol
+++ b/contracts/universalResolver/AbstractUniversalResolver.sol
@@ -329,9 +329,7 @@ abstract contract AbstractUniversalResolver is
         if ((v.length & 31) != 0) revert ResolverError(v);
         bytes[] memory answers = abi.decode(v, (bytes[]));
         if (answers.length != calls.length) {
-            revert ResolverError(
-                abi.encodeWithSelector(0x08c379a0, "Length mismatch") // Error(string)
-            );
+            revert InvalidMulticallResponse();
         }
         Lookup[] memory lookups = new Lookup[](calls.length);
         for (uint256 i; i < calls.length; i++) {

--- a/contracts/universalResolver/AbstractUniversalResolver.sol
+++ b/contracts/universalResolver/AbstractUniversalResolver.sol
@@ -28,10 +28,10 @@ abstract contract AbstractUniversalResolver is
     Ownable,
     ERC165
 {
-    string[] public batchGateways;
+    string[] _gateways;
 
     constructor(string[] memory gateways) {
-        batchGateways = gateways;
+        _gateways = gateways;
     }
 
     /// @inheritdoc ERC165
@@ -43,10 +43,16 @@ abstract contract AbstractUniversalResolver is
             super.supportsInterface(interfaceId);
     }
 
-    /// @dev Set the default batch gateways, see: `resolve()` and `reverse()`.
+    /// @notice Set the default batch gateways, see: `resolve()` and `reverse()`.
     /// @param gateways The list of batch gateway URLs to use as default.
     function setBatchGateways(string[] memory gateways) external onlyOwner {
-        batchGateways = gateways;
+        _gateways = gateways;
+    }
+
+    /// @notice Get the default batch gateways.
+    /// @return The batch gateway URLs.
+    function batchGateways() external view returns (string[] memory) {
+        return _gateways;
     }
 
     /// @inheritdoc IUniversalResolver
@@ -97,7 +103,7 @@ abstract contract AbstractUniversalResolver is
         bytes calldata name,
         bytes calldata data
     ) external view returns (bytes memory /*result*/, address /*resolver*/) {
-        return resolveWithGateways(name, data, batchGateways);
+        return resolveWithGateways(name, data, _gateways);
     }
 
     /// @notice Performs ENS name resolution for the supplied name and resolution data.
@@ -135,7 +141,7 @@ abstract contract AbstractUniversalResolver is
         bytes memory lookupAddress,
         uint256 coinType
     ) external view returns (string memory, address, address) {
-        return reverseWithGateways(lookupAddress, coinType, batchGateways);
+        return reverseWithGateways(lookupAddress, coinType, _gateways);
     }
 
     struct ReverseArgs {

--- a/contracts/universalResolver/AbstractUniversalResolver.sol
+++ b/contracts/universalResolver/AbstractUniversalResolver.sol
@@ -394,9 +394,6 @@ abstract contract AbstractUniversalResolver is
             bytes[] memory m = new bytes[](lookups.length);
             for (uint256 i; i < lookups.length; i++) {
                 Lookup memory lu = lookups[i];
-                if ((lu.flags & FLAG_EMPTY_RESPONSE) != 0) {
-                    continue;
-                }
                 bytes memory v = lu.data;
                 if (extended && (lu.flags & FLAGS_ANY_ERROR) == 0) {
                     v = abi.decode(v, (bytes)); // unwrap resolve()
@@ -407,13 +404,14 @@ abstract contract AbstractUniversalResolver is
         } else {
             Lookup memory lu = lookups[0];
             answer = lu.data;
-            if ((lu.flags & FLAG_EMPTY_RESPONSE) != 0) {
-                revert UnsupportedResolverProfile(bytes4(answer));
-            } else if (
+            if (
                 (lu.flags & FLAG_CALL_ERROR) != 0 && // wrap any error from the resolver
                 bytes4(answer) != UnsupportedResolverProfile.selector // except this
             ) {
                 revert ResolverError(answer);
+            }
+            if (answer.length == 0) {
+                revert UnsupportedResolverProfile(bytes4(lu.call));
             }
             if ((answer.length & 31) != 0) {
                 assembly {

--- a/contracts/universalResolver/AbstractUniversalResolver.sol
+++ b/contracts/universalResolver/AbstractUniversalResolver.sol
@@ -363,7 +363,10 @@ abstract contract AbstractUniversalResolver is
             answer = abi.encode(m);
         } else {
             answer = m[0];
-            if ((lookups[0].flags & FLAGS_TARGET_ERROR) != 0) {
+            if (
+                (lookups[0].flags & FLAGS_TARGET_ERROR) != 0 &&
+                bytes4(answer) != UnsupportedResolverProfile.selector // dont wrap
+            ) {
                 answer = abi.encodeWithSelector(ResolverError.selector, answer);
             }
             if (answer.length & 31 != 0) {

--- a/contracts/universalResolver/AbstractUniversalResolver.sol
+++ b/contracts/universalResolver/AbstractUniversalResolver.sol
@@ -170,10 +170,10 @@ abstract contract AbstractUniversalResolver is
     }
 
     struct ReverseArgs {
-        bytes lookupAddress;
-        uint256 coinType;
-        string[] gateways;
-        address resolver;
+        bytes lookupAddress; // parsed input address
+        uint256 coinType; // parsed coinType
+        string[] gateways; // supplied gateways
+        address resolver; // valid reverse resolver
     }
 
     /// @notice Performs ENS reverse resolution for the supplied address and coin type.

--- a/contracts/universalResolver/AbstractUniversalResolver.sol
+++ b/contracts/universalResolver/AbstractUniversalResolver.sol
@@ -10,6 +10,8 @@ import {CCIPBatcher} from "../ccipRead/CCIPBatcher.sol";
 import {NameCoder} from "../utils/NameCoder.sol";
 import {BytesUtils} from "../utils/BytesUtils.sol";
 import {ENSIP19, COIN_TYPE_ETH, COIN_TYPE_DEFAULT} from "../utils/ENSIP19.sol";
+import {IFeatureSupporter} from "../utils/IFeatureSupporter.sol";
+import {ResolverFeatures} from "../resolvers/ResolverFeatures.sol";
 
 // resolver profiles
 import {IExtendedResolver} from "../resolvers/profiles/IExtendedResolver.sol";
@@ -17,10 +19,6 @@ import {INameResolver} from "../resolvers/profiles/INameResolver.sol";
 import {IAddrResolver} from "../resolvers/profiles/IAddrResolver.sol";
 import {IAddressResolver} from "../resolvers/profiles/IAddressResolver.sol";
 import {IMulticallable} from "../resolvers/IMulticallable.sol";
-
-// resolver features
-import {isFeatureSupported} from "../utils/IFeatureSupporter.sol";
-import {ResolverFeatures} from "../resolvers/ResolverFeatures.sol";
 
 abstract contract AbstractUniversalResolver is
     IUniversalResolver,
@@ -44,7 +42,7 @@ abstract contract AbstractUniversalResolver is
     }
 
     /// @notice Set the default batch gateways, see: `resolve()` and `reverse()`.
-    /// @param gateways The list of batch gateway URLs to use as default.
+    /// @param gateways The batch gateway URLs.
     function setBatchGateways(string[] memory gateways) external onlyOwner {
         _gateways = gateways;
     }
@@ -271,7 +269,7 @@ abstract contract AbstractUniversalResolver is
     }
 
     /// @dev Efficiently call a resolver.
-    ///      If extended and `RESOLVE_MULTICALL` feature is supported, does a direct call.
+    ///      If features are supported, and not a multicall or extended + multicall + `RESOLVE_MULTICALL`, performs a direct call.
     ///      Otherwise, uses the batch gateway.
     /// @param info The resolver to call.
     /// @param call The calldata.
@@ -287,16 +285,25 @@ abstract contract AbstractUniversalResolver is
         bytes memory extraData
     ) internal view {
         if (
-            info.extended &&
-            isFeatureSupported(
+            ERC165Checker.supportsERC165InterfaceUnchecked(
                 info.resolver,
-                ResolverFeatures.RESOLVE_MULTICALL
-            )
+                type(IFeatureSupporter).interfaceId
+            ) &&
+            (bytes4(call) != IMulticallable.multicall.selector ||
+                (info.extended &&
+                    IFeatureSupporter(info.resolver).supportsFeature(
+                        ResolverFeatures.RESOLVE_MULTICALL
+                    )))
         ) {
             ccipRead(
                 address(info.resolver),
-                abi.encodeCall(IExtendedResolver.resolve, (info.name, call)),
-                this.resolveExtendedDirectCallback.selector,
+                info.extended
+                    ? abi.encodeCall(
+                        IExtendedResolver.resolve,
+                        (info.name, call)
+                    )
+                    : call,
+                this.resolveDirectCallback.selector,
                 abi.encode(info, bytes4(call), callbackFunction, extraData),
                 true
             );
@@ -334,7 +341,7 @@ abstract contract AbstractUniversalResolver is
     }
 
     /// @dev CCIP-Read callback for `_callResolver()` from calling the resolver directly.
-    function resolveExtendedDirectCallback(
+    function resolveDirectCallback(
         bytes memory response,
         bytes calldata extraData
     ) external view {
@@ -353,7 +360,9 @@ abstract contract AbstractUniversalResolver is
         if ((response.length & 31) != 0) {
             revert ResolverError(response);
         }
-        response = abi.decode(response, (bytes)); // unwrap resolve()
+        if (info.extended) {
+            response = abi.decode(response, (bytes)); // unwrap resolve()
+        }
         ccipRead(
             address(this),
             abi.encodeWithSelector(callbackFunction, info, response, extraData_)

--- a/contracts/universalResolver/AbstractUniversalResolver.sol
+++ b/contracts/universalResolver/AbstractUniversalResolver.sol
@@ -7,14 +7,18 @@ import {ERC165Checker} from "@openzeppelin/contracts/utils/introspection/ERC165C
 
 import {IUniversalResolver} from "./IUniversalResolver.sol";
 import {CCIPBatcher} from "../ccipRead/CCIPBatcher.sol";
+import {NameCoder} from "../utils/NameCoder.sol";
+import {BytesUtils} from "../utils/BytesUtils.sol";
+import {ENSIP19, COIN_TYPE_ETH, COIN_TYPE_DEFAULT} from "../utils/ENSIP19.sol";
+
+// resolver profiles
 import {IExtendedResolver} from "../resolvers/profiles/IExtendedResolver.sol";
 import {INameResolver} from "../resolvers/profiles/INameResolver.sol";
 import {IAddrResolver} from "../resolvers/profiles/IAddrResolver.sol";
 import {IAddressResolver} from "../resolvers/profiles/IAddressResolver.sol";
 import {IMulticallable} from "../resolvers/IMulticallable.sol";
-import {NameCoder} from "../utils/NameCoder.sol";
-import {BytesUtils} from "../utils/BytesUtils.sol";
-import {ENSIP19, COIN_TYPE_ETH, COIN_TYPE_DEFAULT} from "../utils/ENSIP19.sol";
+
+// resolver features
 import {isFeatureSupported} from "../utils/IFeatureSupporter.sol";
 import {ResolverFeatures} from "../resolvers/ResolverFeatures.sol";
 
@@ -106,48 +110,31 @@ abstract contract AbstractUniversalResolver is
         bytes calldata data,
         string[] memory gateways
     ) public view returns (bytes memory /*result*/, address /*resolver*/) {
-        bool multi = bytes4(data) == IMulticallable.multicall.selector;
-        _resolveBatch(
+        _callResolver(
             requireResolver(name),
-            multi ? abi.decode(data[4:], (bytes[])) : _oneCall(data),
+            data,
             gateways,
             this.resolveCallback.selector,
-            abi.encode(multi)
+            ""
         );
     }
 
     /// @dev CCIP-Read callback for `resolveWithGateways()` (step 2 of 2).
     /// @param info The resolver that was called.
-    /// @param lookups The lookups corresponding to the requested call.
-    /// @param extraData The contextual data passed from `resolveWithGateways()`.
-    /// @return result The encoded response for the requested call.
-    /// @return resolver The address of the resolver that supplied `result`.
+    /// @param response The response from the resolver.
     function resolveCallback(
         ResolverInfo calldata info,
-        Lookup[] calldata lookups,
-        bytes calldata extraData
-    ) external pure returns (bytes memory result, address resolver) {
-        bool multi = abi.decode(extraData, (bool));
-        if (multi) {
-            bytes[] memory m = new bytes[](lookups.length);
-            for (uint256 i; i < lookups.length; i++) {
-                Lookup memory lu = lookups[i];
-                if ((lu.flags & FLAG_EMPTY_RESPONSE) == 0) {
-                    m[i] = lookups[i].data;
-                }
-            }
-            result = abi.encode(m);
-        } else {
-            result = _requireResponse(lookups[0]);
-        }
-        resolver = info.resolver;
+        bytes calldata response,
+        bytes calldata
+    ) external pure returns (bytes memory, address) {
+        return (response, info.resolver);
     }
 
     /// @notice Same as `reverseWithGateways()` but uses default batch gateways.
     function reverse(
         bytes memory lookupAddress,
         uint256 coinType
-    ) external view returns (string memory, address /* resolver */, address) {
+    ) external view returns (string memory, address, address) {
         return reverseWithGateways(lookupAddress, coinType, batchGateways);
     }
 
@@ -172,9 +159,9 @@ abstract contract AbstractUniversalResolver is
         ResolverInfo memory info = requireResolver(
             NameCoder.encode(ENSIP19.reverseName(lookupAddress, coinType)) // reverts EmptyAddress
         );
-        _resolveBatch(
+        _callResolver(
             info,
-            _oneCall(abi.encodeCall(INameResolver.name, (info.node))),
+            abi.encodeCall(INameResolver.name, (info.node)),
             gateways,
             this.reverseNameCallback.selector,
             abi.encode(ReverseArgs(lookupAddress, coinType, gateways))
@@ -183,46 +170,44 @@ abstract contract AbstractUniversalResolver is
 
     /// @dev CCIP-Read callback for `reverseWithGateways()` (step 2 of 3).
     /// @param infoRev The resolver for the reverse name that was called.
-    /// @param lookups The lookups corresponding to the calls: `[name()]`.
+    /// @param response The abi-encoded `name()` response.
     /// @param extraData The contextual data passed from `reverseWithGateways()`.
     function reverseNameCallback(
         ResolverInfo calldata infoRev,
-        Lookup[] calldata lookups,
+        bytes calldata response,
         bytes memory extraData // this cannot be calldata due to "stack too deep"
     ) external view returns (string memory primary, address, address) {
         ReverseArgs memory args = abi.decode(extraData, (ReverseArgs));
-        primary = abi.decode(_requireResponse(lookups[0]), (string));
+        primary = abi.decode(response, (string));
         if (bytes(primary).length == 0) {
             return ("", address(0), infoRev.resolver);
         }
         ResolverInfo memory info = requireResolver(NameCoder.encode(primary));
-        _resolveBatch(
+        _callResolver(
             info,
-            _oneCall(
-                args.coinType == COIN_TYPE_ETH
-                    ? abi.encodeCall(IAddrResolver.addr, (info.node))
-                    : abi.encodeCall(
-                        IAddressResolver.addr,
-                        (info.node, args.coinType)
-                    )
-            ),
+            args.coinType == COIN_TYPE_ETH
+                ? abi.encodeCall(IAddrResolver.addr, (info.node))
+                : abi.encodeCall(
+                    IAddressResolver.addr,
+                    (info.node, args.coinType)
+                ),
             args.gateways,
             this.reverseAddressCallback.selector,
-            abi.encode(args.lookupAddress, primary, infoRev.resolver)
+            abi.encode(args, primary, infoRev.resolver)
         );
     }
 
     /// @dev CCIP-Read callback for `reverseNameCallback()` (step 3 of 3).
     ///      Reverts `ReverseAddressMismatch`.
     /// @param info The resolver for the primary name that was called.
-    /// @param lookups The lookups corresponding to the calls: `[addr()]`.
+    /// @param response The lookups corresponding to the calls: `[addr()]`.
     /// @param extraData The contextual data passed from `reverseNameCallback()`.
     /// @return primary The resolved primary name.
     /// @return resolver The resolver address for primary name.
     /// @return reverseResolver The resolver address for the reverse name.
     function reverseAddressCallback(
         ResolverInfo calldata info,
-        Lookup[] calldata lookups,
+        bytes calldata response,
         bytes calldata extraData
     )
         external
@@ -233,21 +218,19 @@ abstract contract AbstractUniversalResolver is
             address reverseResolver
         )
     {
-        bytes memory reverseAddress;
-        (reverseAddress, primary, reverseResolver) = abi.decode(
+        ReverseArgs memory args;
+        (args, primary, reverseResolver) = abi.decode(
             extraData,
-            (bytes, string, address)
+            (ReverseArgs, string, address)
         );
-        bytes memory v = _requireResponse(lookups[0]);
         bytes memory primaryAddress;
-        bytes4 selector = bytes4(lookups[0].call);
-        if (selector == IAddrResolver.addr.selector) {
-            address addr = abi.decode(v, (address));
+        if (args.coinType == COIN_TYPE_ETH) {
+            address addr = abi.decode(response, (address));
             primaryAddress = abi.encodePacked(addr);
-        } else if (selector == IAddressResolver.addr.selector) {
-            primaryAddress = abi.decode(v, (bytes));
+        } else {
+            primaryAddress = abi.decode(response, (bytes));
         }
-        if (!BytesUtils.equals(reverseAddress, primaryAddress)) {
+        if (!BytesUtils.equals(args.lookupAddress, primaryAddress)) {
             revert ReverseAddressMismatch(primary, primaryAddress);
         }
         resolver = info.resolver;
@@ -255,14 +238,14 @@ abstract contract AbstractUniversalResolver is
 
     /// @dev Perform multiple resolver calls in parallel using batch gateway.
     /// @param info The resolver to call.
-    /// @param calls The list of resolver calldata, eg. `[addr(), text()]`.
+    /// @param call The calldata.
     /// @param gateways The list of batch gateway URLs to use.
     /// @param callbackFunction The function selector to call after resolution.
     /// @param extraData The contextual data passed to `callbackFunction`.
     /// @dev The return type of this function is polymorphic depending on the caller.
-    function _resolveBatch(
+    function _callResolver(
         ResolverInfo memory info,
-        bytes[] memory calls,
+        bytes memory call,
         string[] memory gateways,
         bytes4 callbackFunction,
         bytes memory extraData
@@ -276,100 +259,113 @@ abstract contract AbstractUniversalResolver is
         ) {
             ccipRead(
                 address(info.resolver),
-                abi.encodeCall(
-                    IExtendedResolver.resolve,
-                    (
-                        info.name,
-                        abi.encodeCall(IMulticallable.multicall, (calls))
-                    )
-                ),
-                this.resolveMulticallCallback.selector,
-                abi.encode(info, callbackFunction, extraData, calls)
+                abi.encodeCall(IExtendedResolver.resolve, (info.name, call)),
+                this.resolveExtendedDirectCallback.selector,
+                abi.encode(info, call, callbackFunction, extraData),
+                true
             );
         } else {
-            Batch memory batch = Batch(new Lookup[](calls.length), gateways);
-            for (uint256 i; i < calls.length; i++) {
-                Lookup memory lu = batch.lookups[i];
-                lu.target = info.resolver;
-                lu.call = info.extended
-                    ? abi.encodeCall(
+            bytes[] memory calls;
+            if (bytes4(call) == IMulticallable.multicall.selector) {
+                calls = abi.decode(
+                    BytesUtils.substring(call, 4, call.length - 4),
+                    (bytes[])
+                );
+            } else {
+                calls = new bytes[](1);
+                calls[0] = call;
+            }
+            if (info.extended) {
+                for (uint256 i; i < calls.length; i++) {
+                    calls[i] = abi.encodeCall(
                         IExtendedResolver.resolve,
                         (info.name, calls[i])
-                    )
-                    : calls[i];
+                    );
+                }
             }
             ccipRead(
                 address(this),
-                abi.encodeCall(this.ccipBatch, (batch)),
+                abi.encodeCall(
+                    this.ccipBatch,
+                    (_createBatch(info.resolver, calls, gateways))
+                ),
                 this.resolveBatchCallback.selector,
-                abi.encode(info, callbackFunction, extraData)
+                abi.encode(info, call, callbackFunction, extraData)
             );
         }
     }
 
-    /// @dev CCIP-Read callback for `_resolveBatch()` when feature `RESOLVE_MULTICALL` is supported.
-    /// @param response The response data from the resolver.
-    /// @param extraData The contextual data from `_resolveBatch()`.
-    function resolveMulticallCallback(
-        bytes calldata response,
+    /// @dev CCIP-Read callback for `_callResolver()` from calling the resolver directly.
+    function resolveExtendedDirectCallback(
+        bytes memory response,
         bytes calldata extraData
     ) external view {
         (
             ResolverInfo memory info,
+            bytes memory call,
             bytes4 callbackFunction_,
-            bytes memory extraData_,
-            bytes[] memory calls
-        ) = abi.decode(extraData, (ResolverInfo, bytes4, bytes, bytes[]));
-        bytes memory v = abi.decode(response, (bytes)); // unwrap resolve()
-        if (v.length == 0) {
-            revert UnsupportedResolverProfile(
-                IMulticallable.multicall.selector
+            bytes memory extraData_
+        ) = abi.decode(extraData, (ResolverInfo, bytes, bytes4, bytes));
+        if (response.length == 0) {
+            response = abi.encodeWithSelector(
+                UnsupportedResolverProfile.selector,
+                bytes4(call)
             );
         }
-        if ((v.length & 31) != 0) revert ResolverError(v);
-        bytes[] memory answers = abi.decode(v, (bytes[]));
-        if (answers.length != calls.length) {
-            revert InvalidMulticallResponse();
+        if ((response.length & 31) != 0) {
+            revert ResolverError(response);
         }
-        Lookup[] memory lookups = new Lookup[](calls.length);
-        for (uint256 i; i < calls.length; i++) {
-            Lookup memory lu = lookups[i];
-            v = answers[i];
-            lu.call = calls[i];
-            lu.flags = FLAG_DONE;
-            if (v.length == 0) {
-                lu.flags |= FLAG_EMPTY_RESPONSE;
-                lu.data = lu.call;
-            } else {
-                if ((v.length & 31) != 0) lu.flags |= FLAG_CALL_ERROR;
-                lu.data = v;
-            }
-        }
+        response = abi.decode(response, (bytes)); // unwrap resolve()
         ccipRead(
             address(this),
-            abi.encodeWithSelector(callbackFunction_, info, lookups, extraData_)
+            abi.encodeWithSelector(
+                callbackFunction_,
+                info,
+                response,
+                extraData_
+            )
         );
     }
 
-    /// @dev CCIP-Read callback for `_resolveBatch()`.
-    /// @param response The response data from `CCIPBatcher`.
-    /// @param extraData The contextual data from `_resolveBatch()`.
+    /// @dev CCIP-Read callback for `_callResolver()` from calling the batch gateway.
     function resolveBatchCallback(
-        bytes calldata response,
+        bytes memory response,
         bytes calldata extraData
     ) external view {
-        Batch memory batch = abi.decode(response, (Batch));
+        Lookup[] memory lookups = abi.decode(response, (Batch)).lookups;
         (
             ResolverInfo memory info,
+            bytes memory call,
             bytes4 callbackFunction_,
             bytes memory extraData_
-        ) = abi.decode(extraData, (ResolverInfo, bytes4, bytes));
-        if (info.extended) {
-            for (uint256 i; i < batch.lookups.length; i++) {
-                Lookup memory lu = batch.lookups[i];
-                lu.call = _unwrapResolve(lu.call);
-                if ((lu.flags & FLAGS_ANY_ERROR) == 0) {
-                    lu.data = abi.decode(lu.data, (bytes));
+        ) = abi.decode(extraData, (ResolverInfo, bytes, bytes4, bytes));
+        bytes[] memory m = new bytes[](lookups.length);
+        for (uint256 i; i < lookups.length; i++) {
+            Lookup memory lu = lookups[i];
+            bytes memory v = lu.data;
+            if ((lu.flags & FLAGS_ANY_ERROR) == 0 && info.extended) {
+                v = abi.decode(v, (bytes)); // unwrap resolve()
+            } else if ((lu.flags & FLAG_EMPTY_RESPONSE) != 0) {
+                v = abi.encodeWithSelector(
+                    UnsupportedResolverProfile.selector,
+                    bytes4(v)
+                );
+            }
+            m[i] = v;
+        }
+        if (bytes4(call) == IMulticallable.multicall.selector) {
+            response = abi.encode(m);
+        } else {
+            response = m[0];
+            if ((lookups[0].flags & FLAGS_TARGET_ERROR) != 0) {
+                response = abi.encodeWithSelector(
+                    ResolverError.selector,
+                    response
+                );
+            }
+            if (response.length & 31 != 0) {
+                assembly {
+                    revert(add(response, 32), mload(response))
                 }
             }
         }
@@ -378,58 +374,9 @@ abstract contract AbstractUniversalResolver is
             abi.encodeWithSelector(
                 callbackFunction_,
                 info,
-                batch.lookups,
+                response,
                 extraData_
             )
         );
-    }
-
-    /// @dev Extract `data` from `resolve(bytes, bytes data)` calldata.
-    /// @param v The `resolve(bytes, bytes data)` calldata.
-    /// @return data The inner `bytes data` argument.
-    function _unwrapResolve(
-        bytes memory v
-    ) internal pure returns (bytes memory data) {
-        // resolve(bytes name, bytes data):      | <== offset starts here
-        // => uint256(length) + bytes4(selector) | offset(name) + offset(data)
-        //           32       +        4         |      32
-        assembly {
-            data := add(v, 36) // location of offset start
-            data := add(data, mload(add(data, 32))) // += offset(data)
-        }
-    }
-
-    /// @dev Extract `data` from a lookup or revert an appropriate error.
-    ///      Reverts if the `data` is not a successful response.
-    /// @param lu The lookup to extract from.
-    /// @return v The successful response (always 32+ bytes).
-    function _requireResponse(
-        Lookup memory lu
-    ) internal pure returns (bytes memory v) {
-        v = lu.data;
-        if ((lu.flags & FLAG_BATCH_ERROR) != 0) {
-            assembly {
-                revert(add(v, 32), mload(v)) // HttpError or Error
-            }
-        } else if ((lu.flags & FLAG_CALL_ERROR) != 0) {
-            if (bytes4(v) == UnsupportedResolverProfile.selector) {
-                assembly {
-                    revert(add(v, 32), mload(v))
-                }
-            }
-            revert ResolverError(v); // any error from Resolver
-        } else if ((lu.flags & FLAG_EMPTY_RESPONSE) != 0) {
-            revert UnsupportedResolverProfile(bytes4(v)); // initial call or callback was unimplemented
-        }
-    }
-
-    /// @dev Create an array with one `call`.
-    /// @param call The single calldata.
-    /// @return calls The one-element calldata array, eg. `[call]`.
-    function _oneCall(
-        bytes memory call
-    ) internal pure returns (bytes[] memory calls) {
-        calls = new bytes[](1);
-        calls[0] = call;
     }
 }

--- a/contracts/universalResolver/AbstractUniversalResolver.sol
+++ b/contracts/universalResolver/AbstractUniversalResolver.sol
@@ -299,7 +299,8 @@ abstract contract AbstractUniversalResolver is
                     (_createBatch(info.resolver, calls, gateways))
                 ),
                 this.resolveBatchCallback.selector,
-                abi.encode(info, multi, callbackFunction, extraData)
+                abi.encode(info, multi, callbackFunction, extraData),
+                false
             );
         }
     }

--- a/contracts/universalResolver/AbstractUniversalResolver.sol
+++ b/contracts/universalResolver/AbstractUniversalResolver.sol
@@ -64,7 +64,7 @@ abstract contract AbstractUniversalResolver is
         virtual
         returns (address resolver, bytes32 node, uint256 offset);
 
-    // @dev A valid resolver and its relevant properties.
+    /// @dev A valid resolver and its relevant properties.
     struct ResolverInfo {
         bytes name; // dns-encoded name (safe to decode)
         uint256 offset; // byte offset into name used for resolver
@@ -81,8 +81,14 @@ abstract contract AbstractUniversalResolver is
     ) public view returns (ResolverInfo memory info) {
         // https://docs.ens.domains/ensip/10
         (info.resolver, info.node, info.offset) = findResolver(name);
+        info.name = name;
+        _checkResolver(info);
+    }
+
+    /// @dev Asserts that the resolver information is valid.
+    function _checkResolver(ResolverInfo memory info) internal view {
         if (info.resolver == address(0)) {
-            revert ResolverNotFound(name);
+            revert ResolverNotFound(info.name);
         } else if (
             ERC165Checker.supportsERC165InterfaceUnchecked(
                 info.resolver,
@@ -91,22 +97,21 @@ abstract contract AbstractUniversalResolver is
         ) {
             info.extended = true;
         } else if (info.offset != 0) {
-            revert ResolverNotFound(name); // immediate resolver requires exact match
+            revert ResolverNotFound(info.name); // immediate resolver requires exact match
         } else if (info.resolver.code.length == 0) {
-            revert ResolverNotContract(name, info.resolver);
+            revert ResolverNotContract(info.name, info.resolver);
         }
-        info.name = name;
     }
 
     /// @notice Same as `resolveWithGateways()` but uses default batch gateways.
     function resolve(
         bytes calldata name,
         bytes calldata data
-    ) external view returns (bytes memory /*result*/, address /*resolver*/) {
+    ) external view returns (bytes memory, address) {
         return resolveWithGateways(name, data, _gateways);
     }
 
-    /// @notice Performs ENS name resolution for the supplied name and resolution data.
+    /// @notice Performs ENS resolution process for the supplied name and resolution data.
     /// @notice Callers should enable EIP-3668.
     /// @dev This function executes over multiple steps (step 1 of 2).
     /// @return result The encoded response for the requested call.
@@ -115,7 +120,7 @@ abstract contract AbstractUniversalResolver is
         bytes calldata name,
         bytes calldata data,
         string[] memory gateways
-    ) public view returns (bytes memory /*result*/, address /*resolver*/) {
+    ) public view returns (bytes memory result, address /*resolver*/) {
         _callResolver(
             requireResolver(name),
             data,
@@ -123,6 +128,21 @@ abstract contract AbstractUniversalResolver is
             this.resolveCallback.selector,
             ""
         );
+    }
+
+    /// @notice Same as `resolveWithGateways()` but uses the supplied resolver.
+    function resolveWithResolver(
+        address resolver,
+        bytes calldata name,
+        bytes calldata data,
+        string[] memory gateways
+    ) external view returns (bytes memory, address) {
+        ResolverInfo memory info;
+        info.name = name;
+        info.node = NameCoder.namehash(name, 0);
+        info.resolver = resolver;
+        _checkResolver(info);
+        _callResolver(info, data, gateways, this.resolveCallback.selector, "");
     }
 
     /// @dev CCIP-Read callback for `resolveWithGateways()` (step 2 of 2).

--- a/contracts/universalResolver/AbstractUniversalResolver.sol
+++ b/contracts/universalResolver/AbstractUniversalResolver.sol
@@ -364,7 +364,8 @@ abstract contract AbstractUniversalResolver is
         } else {
             answer = m[0];
             if (
-                (lookups[0].flags & FLAGS_TARGET_ERROR) != 0 &&
+                (lookups[0].flags & (FLAG_EMPTY_RESPONSE | FLAG_CALL_ERROR)) !=
+                0 && // resolver-originating error
                 bytes4(answer) != UnsupportedResolverProfile.selector // dont wrap
             ) {
                 answer = abi.encodeWithSelector(ResolverError.selector, answer);

--- a/contracts/universalResolver/AbstractUniversalResolver.sol
+++ b/contracts/universalResolver/AbstractUniversalResolver.sol
@@ -28,7 +28,7 @@ abstract contract AbstractUniversalResolver is
 {
     string[] _gateways;
 
-    constructor(string[] memory gateways) CCIPBatcher(50000) {
+    constructor(string[] memory gateways) CCIPBatcher(DEFAULT_UNSAFE_CALL_GAS) {
         _gateways = gateways;
     }
 

--- a/contracts/universalResolver/AbstractUniversalResolver.sol
+++ b/contracts/universalResolver/AbstractUniversalResolver.sol
@@ -106,8 +106,8 @@ abstract contract AbstractUniversalResolver is
     }
 
     /// @notice Performs ENS resolution process for the supplied name and resolution data.
-    ///         Callers should enable EIP-3668.
-    /// @dev This function executes over multiple steps (step 1 of 2).
+    ///         Caller should enable EIP-3668.
+    /// @dev This function executes over multiple steps.
     /// @param name The name to resolve, in normalised and DNS-encoded form.
     /// @param data The resolution data, as specified in ENSIP-10.
     /// @param gateways The list of batch gateway URLs to use.
@@ -125,7 +125,7 @@ abstract contract AbstractUniversalResolver is
             info,
             data,
             gateways,
-            this.resolveCallback.selector,
+            this.resolveCallback.selector, // ==> step 2
             abi.encode(info.resolver)
         );
     }
@@ -146,12 +146,12 @@ abstract contract AbstractUniversalResolver is
             info,
             data,
             gateways,
-            this.resolveCallback.selector,
+            this.resolveCallback.selector, // ==> step 2
             abi.encode(resolver)
         );
     }
 
-    /// @dev CCIP-Read callback for `resolveWithGateways()` (step 2 of 2).
+    /// @dev CCIP-Read callback for `resolveWithGateways()`.
     /// @param response The response from the resolver.
     /// @param extraData The contextual data passed from `resolveWith*()`.
     function resolveCallback(
@@ -177,8 +177,8 @@ abstract contract AbstractUniversalResolver is
     }
 
     /// @notice Performs ENS reverse resolution for the supplied address and coin type.
-    ///         Callers should enable EIP-3668.
-    /// @dev This function executes over multiple steps (step 1 of 3).
+    ///         Caller should enable EIP-3668.
+    /// @dev This function executes over multiple steps.
     /// @param lookupAddress The input address.
     /// @param coinType The coin type.
     /// @param gateways The list of batch gateway URLs to use.
@@ -209,14 +209,14 @@ abstract contract AbstractUniversalResolver is
             info,
             abi.encodeCall(INameResolver.name, (info.node)),
             gateways,
-            this.reverseNameCallback.selector,
+            this.reverseNameCallback.selector, // ==> step 2
             abi.encode(
                 ReverseArgs(lookupAddress, coinType, gateways, info.resolver)
             )
         );
     }
 
-    /// @dev CCIP-Read callback for `reverseWithGateways()` (step 2 of 3).
+    /// @dev CCIP-Read callback for `reverseWithGateways()`.
     /// @param response The abi-encoded `name()` response from the reverse resolver.
     /// @param extraData The contextual data passed from `reverseWithGateways()`.
     function reverseNameCallback(
@@ -238,12 +238,12 @@ abstract contract AbstractUniversalResolver is
                     (info.node, args.coinType)
                 ),
             args.gateways,
-            this.reverseAddressCallback.selector,
+            this.reverseAddressCallback.selector, // ==> step 3
             abi.encode(args, primary, info.resolver, args.resolver)
         );
     }
 
-    /// @dev CCIP-Read callback for `reverseNameCallback()` (step 3 of 3).
+    /// @dev CCIP-Read callback for `reverseNameCallback()`.
     ///      Reverts `ReverseAddressMismatch`.
     /// @param response The abi-encoded `addr()` response from the forward resolver.
     /// @param extraData The contextual data passed from `reverseNameCallback()`.
@@ -284,7 +284,6 @@ abstract contract AbstractUniversalResolver is
     /// @param gateways The list of batch gateway URLs to use.
     /// @param callbackFunction The function selector to call after resolution.
     /// @param extraData The contextual data passed to `callbackFunction`.
-    /// @dev The return type of this function is polymorphic depending on the caller.
     function _callResolver(
         ResolverInfo memory info,
         bytes memory call,
@@ -416,7 +415,7 @@ abstract contract AbstractUniversalResolver is
             if (
                 (lookups[0].flags & (FLAG_EMPTY_RESPONSE | FLAG_CALL_ERROR)) !=
                 0 && // resolver-originating error should be wrapped
-                bytes4(answer) != UnsupportedResolverProfile.selector // exception
+                bytes4(answer) != UnsupportedResolverProfile.selector // except this error
             ) {
                 revert ResolverError(answer);
             }

--- a/contracts/universalResolver/IUniversalResolver.sol
+++ b/contracts/universalResolver/IUniversalResolver.sol
@@ -39,7 +39,7 @@ interface IUniversalResolver {
     ) external view returns (address resolver, bytes32 node, uint256 offset);
 
     /// @notice Performs ENS name resolution for the supplied name and resolution data.
-    /// @notice Callers should enable EIP-3668.
+    /// @notice Caller should enable EIP-3668.
     /// @param name The name to resolve, in normalised and DNS-encoded form.
     /// @param data The resolution data, as specified in ENSIP-10.
     ///             For a multicall, the data should be encoded as `multicall(bytes[])`.
@@ -52,7 +52,7 @@ interface IUniversalResolver {
     ) external view returns (bytes memory result, address resolver);
 
     /// @notice Performs ENS reverse resolution for the supplied address and coin type.
-    /// @notice Callers should enable EIP-3668.
+    /// @notice Caller should enable EIP-3668.
     /// @param lookupAddress The address to reverse resolve, in encoded form.
     /// @param coinType The coin type to use for the reverse resolution.
     ///                 For ETH, this is 60.

--- a/contracts/universalResolver/IUniversalResolver.sol
+++ b/contracts/universalResolver/IUniversalResolver.sol
@@ -28,6 +28,10 @@ interface IUniversalResolver {
     /// @dev Error selector: `0x01800152`
     error HttpError(uint16 status, string message);
 
+    /// @notice The resolver supplied an incorrect number of responses.
+    /// @dev Error selector: `0xe5a61c3c`
+    error InvalidMulticallResponse();
+
     /// @dev Find the resolver address for `name`.
     ///      Does not perform any validity checks.
     /// @param name The name to search.

--- a/contracts/universalResolver/IUniversalResolver.sol
+++ b/contracts/universalResolver/IUniversalResolver.sol
@@ -28,10 +28,6 @@ interface IUniversalResolver {
     /// @dev Error selector: `0x01800152`
     error HttpError(uint16 status, string message);
 
-    /// @notice The resolver supplied an incorrect number of responses.
-    /// @dev Error selector: `0xe5a61c3c`
-    error InvalidMulticallResponse();
-
     /// @dev Find the resolver address for `name`.
     ///      Does not perform any validity checks.
     /// @param name The name to search.
@@ -46,7 +42,7 @@ interface IUniversalResolver {
     /// @notice Callers should enable EIP-3668.
     /// @param name The name to resolve, in normalised and DNS-encoded form.
     /// @param data The resolution data, as specified in ENSIP-10.
-    ///             For a multicall, the data should be encoded as `(bytes[])`.
+    ///             For a multicall, the data should be encoded as `multicall(bytes[])`.
     /// @return result The result of the resolution.
     ///                For a multicall, the result is encoded as `(bytes[])`.
     /// @return resolver The resolver that was used to resolve the name.

--- a/contracts/universalResolver/mocks/DummyShapeshiftResolver.sol
+++ b/contracts/universalResolver/mocks/DummyShapeshiftResolver.sol
@@ -7,30 +7,35 @@ import {IExtendedResolver} from "../../resolvers/profiles/IExtendedResolver.sol"
 import {IMulticallable} from "../../resolvers/IMulticallable.sol";
 import {OffchainLookup} from "../../ccipRead/EIP3668.sol";
 
-// this resolver can perform all resolver permutations
-// when this contract triggers OffchainLookup(), it uses a data-url, so no server is required
-// the actual response is set using `setResponse()`
+/// @dev This resolver can perform all resolver permutations.
+///      When this contract triggers OffchainLookup(), it uses a data-url, so no server is required.
+///      The actual response is set using `setResponse()`.
+contract DummyShapeshiftResolver is
+    IExtendedResolver,
+    IERC165,
+    IFeatureSupporter
+{
+    // https://github.com/ensdomains/ensips/pull/18
+    error UnsupportedResolverProfile(bytes4 call);
 
-// https://github.com/ensdomains/ensips/pull/18
-error UnsupportedResolverProfile(bytes4 call);
-
-contract DummyShapeshiftResolver is IExtendedResolver, IERC165, IFeatureSupporter {
     mapping(bytes => bytes) public responses;
     mapping(bytes4 => bool) public features;
+    uint256 public featureCount;
     bool public isERC165 = true; // default
     bool public isExtended;
     bool public isOffchain;
     bool public revertUnsupported;
     bool public revertEmpty;
-    //bool public isWrapperSafe;
-    //bool public isResolveMulticallable;
 
     function setResponse(bytes memory req, bytes memory res) external {
         responses[req] = res;
     }
 
     function setFeature(bytes4 feature, bool on) external {
-        features[feature] = on;
+        if (features[feature] != on) {
+            features[feature] = on;
+            featureCount = on ? featureCount + 1 : featureCount - 1;
+        }
     }
 
     function setOld() external {
@@ -81,7 +86,8 @@ contract DummyShapeshiftResolver is IExtendedResolver, IERC165, IFeatureSupporte
         }
         return
             type(IERC165).interfaceId == x ||
-            (type(IExtendedResolver).interfaceId == x && isExtended);
+            (type(IExtendedResolver).interfaceId == x && isExtended) ||
+            (type(IFeatureSupporter).interfaceId == x && featureCount > 0);
     }
 
     function supportsFeature(bytes4 x) external view returns (bool) {

--- a/contracts/universalResolver/mocks/DummyShapeshiftResolver.sol
+++ b/contracts/universalResolver/mocks/DummyShapeshiftResolver.sol
@@ -2,9 +2,10 @@
 pragma solidity ^0.8.0;
 
 import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import {IFeatureSupporter} from "../../utils/IFeatureSupporter.sol";
 import {IExtendedResolver} from "../../resolvers/profiles/IExtendedResolver.sol";
+import {IMulticallable} from "../../resolvers/IMulticallable.sol";
 import {OffchainLookup} from "../../ccipRead/EIP3668.sol";
-//import {IResolveMulticall} from "../../resolvers/IResolveMulticall.sol";
 
 // this resolver can perform all resolver permutations
 // when this contract triggers OffchainLookup(), it uses a data-url, so no server is required
@@ -13,8 +14,9 @@ import {OffchainLookup} from "../../ccipRead/EIP3668.sol";
 // https://github.com/ensdomains/ensips/pull/18
 error UnsupportedResolverProfile(bytes4 call);
 
-contract DummyShapeshiftResolver is IExtendedResolver, IERC165 {
+contract DummyShapeshiftResolver is IExtendedResolver, IERC165, IFeatureSupporter {
     mapping(bytes => bytes) public responses;
+    mapping(bytes4 => bool) public features;
     bool public isERC165 = true; // default
     bool public isExtended;
     bool public isOffchain;
@@ -25,6 +27,10 @@ contract DummyShapeshiftResolver is IExtendedResolver, IERC165 {
 
     function setResponse(bytes memory req, bytes memory res) external {
         responses[req] = res;
+    }
+
+    function setFeature(bytes4 feature, bool on) external {
+        features[feature] = on;
     }
 
     function setOld() external {
@@ -76,6 +82,10 @@ contract DummyShapeshiftResolver is IExtendedResolver, IERC165 {
         return
             type(IERC165).interfaceId == x ||
             (type(IExtendedResolver).interfaceId == x && isExtended);
+    }
+
+    function supportsFeature(bytes4 x) external view returns (bool) {
+        return features[x];
     }
 
     function resolve(

--- a/contracts/utils/HexUtils.sol
+++ b/contracts/utils/HexUtils.sol
@@ -15,6 +15,7 @@ library HexUtils {
         uint256 pos,
         uint256 end
     ) internal pure returns (bytes32 word, bool valid) {
+        if (end < pos) return ('', false); // invalid range
         uint256 nibbles = end - pos;
         if (nibbles > 64 || end > hexString.length) {
             return (bytes32(0), false); // too large or out of bounds
@@ -42,7 +43,7 @@ library HexUtils {
         uint256 pos,
         uint256 end
     ) internal pure returns (address addr, bool valid) {
-        if (end - pos != 40) return (address(0), false); // wrong length
+        if (pos + 40 != end) return (address(0), false); // wrong length
         bytes32 word;
         (word, valid) = hexStringToBytes32(hexString, pos, end);
         addr = address(uint160(uint256(word)));
@@ -59,6 +60,7 @@ library HexUtils {
         uint256 pos,
         uint256 end
     ) internal pure returns (bytes memory v, bool valid) {
+        if (end < pos) return ('', false); // invalid range
         uint256 nibbles = end - pos;
         v = new bytes((1 + nibbles) >> 1); // round up
         uint256 src;

--- a/contracts/utils/HexUtils.sol
+++ b/contracts/utils/HexUtils.sol
@@ -15,7 +15,7 @@ library HexUtils {
         uint256 pos,
         uint256 end
     ) internal pure returns (bytes32 word, bool valid) {
-        if (end < pos) return ('', false); // invalid range
+        if (end < pos) return ("", false); // invalid range
         uint256 nibbles = end - pos;
         if (nibbles > 64 || end > hexString.length) {
             return (bytes32(0), false); // too large or out of bounds
@@ -60,7 +60,7 @@ library HexUtils {
         uint256 pos,
         uint256 end
     ) internal pure returns (bytes memory v, bool valid) {
-        if (end < pos) return ('', false); // invalid range
+        if (end < pos) return ("", false); // invalid range
         uint256 nibbles = end - pos;
         v = new bytes((1 + nibbles) >> 1); // round up
         uint256 src;

--- a/contracts/utils/IFeatureSupporter.sol
+++ b/contracts/utils/IFeatureSupporter.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/// @notice Interface for expressing contract features not visible from the ABI.
+/// @dev Interface selector: `0x582de3e7`
+interface IFeatureSupporter {
+    /// @notice Check if a feature is supported.
+    /// @param feature The feature.
+    /// @return True if the feature is supported by the contract.
+    function supportsFeature(bytes4 feature) external view returns (bool);
+}
+
+/// @notice Determine if a feature is implemented by the contract.
+/// @param target The contract.
+/// @param feature The feature.
+/// @return True if the feature is supported.
+function isFeatureSupported(address target, bytes4 feature) view returns (bool) {
+    bytes memory v = abi.encodeCall(
+        IFeatureSupporter.supportsFeature,
+        (feature)
+    );
+    bool success;
+    uint256 returnSize;
+    uint256 returnValue;
+    assembly {
+        success := staticcall(30000, target, add(v, 32), mload(v), 0, 32)
+        returnSize := returndatasize()
+        returnValue := mload(0)
+    }
+    return success && returnSize >= 32 && returnValue > 0;
+}

--- a/contracts/utils/IFeatureSupporter.sol
+++ b/contracts/utils/IFeatureSupporter.sol
@@ -9,23 +9,3 @@ interface IFeatureSupporter {
     /// @return True if the feature is supported by the contract.
     function supportsFeature(bytes4 feature) external view returns (bool);
 }
-
-/// @notice Determine if a feature is implemented by the contract.
-/// @param target The contract.
-/// @param feature The feature.
-/// @return True if the feature is supported.
-function isFeatureSupported(address target, bytes4 feature) view returns (bool) {
-    bytes memory v = abi.encodeCall(
-        IFeatureSupporter.supportsFeature,
-        (feature)
-    );
-    bool success;
-    uint256 returnSize;
-    uint256 returnValue;
-    assembly {
-        success := staticcall(30000, target, add(v, 32), mload(v), 0, 32)
-        returnSize := returndatasize()
-        returnValue := mload(0)
-    }
-    return success && returnSize >= 32 && returnValue > 0;
-}

--- a/test/universalResolver/TestUniversalResolver.ts
+++ b/test/universalResolver/TestUniversalResolver.ts
@@ -4,6 +4,7 @@ import { expect } from 'chai'
 import hre from 'hardhat'
 import {
   encodeErrorResult,
+  Hex,
   HttpRequestError,
   keccak256,
   namehash,
@@ -74,7 +75,14 @@ async function fixture() {
   }
 }
 
-const dummyCalldata = '0x12345678'
+function unsupportedProfileData(selector: Hex) {
+  return encodeErrorResult({
+    abi: parseAbi(['error UnsupportedResolverProfile(bytes4)']),
+    args: [selector],
+  })
+}
+
+const dummyBytes4 = '0x12345678'
 const testName = 'test.eth' // DummyResolver name
 const anotherAddress = '0x8000000000000000000000000000000000000001'
 const resolutions = makeResolutions({
@@ -172,7 +180,7 @@ describe('UniversalResolver', () => {
     it('unset', async () => {
       const F = await loadFixture(fixture)
       await expect(F.universalResolver)
-        .read('resolve', [dnsEncodeName(testName), dummyCalldata])
+        .read('resolve', [dnsEncodeName(testName), dummyBytes4])
         .toBeRevertedWithCustomError('ResolverNotFound')
         .withArgs(dnsEncodeName(testName))
     })
@@ -185,7 +193,7 @@ describe('UniversalResolver', () => {
         F.owner,
       ])
       await expect(F.universalResolver)
-        .read('resolve', [dnsEncodeName(testName), dummyCalldata])
+        .read('resolve', [dnsEncodeName(testName), dummyBytes4])
         .toBeRevertedWithCustomError('ResolverNotFound')
         .withArgs(dnsEncodeName(testName))
     })
@@ -195,7 +203,7 @@ describe('UniversalResolver', () => {
       await F.takeControl(testName)
       await F.ensRegistry.write.setResolver([namehash(testName), F.owner])
       await expect(F.universalResolver)
-        .read('resolve', [dnsEncodeName(testName), dummyCalldata])
+        .read('resolve', [dnsEncodeName(testName), dummyBytes4])
         .toBeRevertedWithCustomError('ResolverNotContract')
         .withArgs(dnsEncodeName(testName), F.owner)
     })
@@ -208,9 +216,9 @@ describe('UniversalResolver', () => {
         F.shapeshift1.address,
       ])
       await expect(F.universalResolver)
-        .read('resolve', [dnsEncodeName(testName), dummyCalldata])
-        .toBeRevertedWithCustomError('UnsupportedResolverProfile')
-        .withArgs(dummyCalldata)
+        .read('resolve', [dnsEncodeName(testName), dummyBytes4])
+        .toBeRevertedWithCustomError('ResolverError')
+        .withArgs(unsupportedProfileData(dummyBytes4))
     })
 
     it('empty revert', async () => {
@@ -222,7 +230,7 @@ describe('UniversalResolver', () => {
       ])
       await F.shapeshift1.write.setRevertEmpty([true])
       await expect(F.universalResolver)
-        .read('resolve', [dnsEncodeName(testName), dummyCalldata])
+        .read('resolve', [dnsEncodeName(testName), dummyBytes4])
         .toBeRevertedWithCustomError('ResolverError')
         .withArgs('0x')
     })
@@ -234,11 +242,11 @@ describe('UniversalResolver', () => {
         namehash(testName),
         F.shapeshift1.address,
       ])
-      await F.shapeshift1.write.setResponse([dummyCalldata, dummyCalldata])
+      await F.shapeshift1.write.setResponse([dummyBytes4, dummyBytes4])
       await expect(F.universalResolver)
-        .read('resolve', [dnsEncodeName(testName), dummyCalldata])
+        .read('resolve', [dnsEncodeName(testName), dummyBytes4])
         .toBeRevertedWithCustomError('ResolverError')
-        .withArgs(dummyCalldata)
+        .withArgs(dummyBytes4)
     })
 
     it('batch gateway revert', async () => {
@@ -252,12 +260,12 @@ describe('UniversalResolver', () => {
         namehash(testName),
         F.shapeshift1.address,
       ])
-      await F.shapeshift1.write.setResponse([dummyCalldata, dummyCalldata])
+      await F.shapeshift1.write.setResponse([dummyBytes4, dummyBytes4])
       await F.shapeshift1.write.setOffchain([true])
       await expect(F.universalResolver)
         .read('resolveWithGateways', [
           dnsEncodeName(testName),
-          dummyCalldata,
+          dummyBytes4,
           [bg.localBatchGatewayUrl],
         ])
         .toBeRevertedWithCustomError('HttpError')
@@ -273,9 +281,9 @@ describe('UniversalResolver', () => {
       ])
       await F.shapeshift1.write.setRevertUnsupportedResolverProfile([true])
       await expect(F.universalResolver)
-        .read('resolve', [dnsEncodeName(testName), dummyCalldata])
-        .toBeRevertedWithCustomError('UnsupportedResolverProfile')
-        .withArgs(dummyCalldata)
+        .read('resolve', [dnsEncodeName(testName), dummyBytes4])
+        .toBeRevertedWithCustomError('ResolverError')
+        .withArgs(unsupportedProfileData(dummyBytes4))
     })
 
     it('old', async () => {
@@ -294,7 +302,6 @@ describe('UniversalResolver', () => {
         res.call,
       ])
       expectVar({ resolver }).toEqualAddress(F.oldResolver.address)
-      expectVar({ answer }).toStrictEqual(res.answer)
       res.expect(answer)
     })
 
@@ -309,7 +316,12 @@ describe('UniversalResolver', () => {
         makeResolutions({
           name: testName,
           primary: { value: testName },
-          errors: [{ call: dummyCalldata, answer: '0x' }],
+          errors: [
+            {
+              call: dummyBytes4,
+              answer: unsupportedProfileData(dummyBytes4),
+            },
+          ],
         }),
       )
       const [answer, resolver] = await F.universalResolver.read.resolve([
@@ -317,7 +329,6 @@ describe('UniversalResolver', () => {
         bundle.call,
       ])
       expectVar({ resolver }).toEqualAddress(F.oldResolver.address)
-      expectVar({ answer }).toStrictEqual(bundle.answer)
       bundle.expect(answer)
     })
 
@@ -338,7 +349,6 @@ describe('UniversalResolver', () => {
         res.call,
       ])
       expectVar({ resolver }).toEqualAddress(F.publicResolver.address)
-      expectVar({ answer }).toStrictEqual(res.answer)
       res.expect(answer)
     })
 
@@ -362,7 +372,6 @@ describe('UniversalResolver', () => {
         res.call,
       ])
       expectVar({ resolver }).toEqualAddress(F.publicResolver.address)
-      expectVar({ answer }).toStrictEqual(res.answer)
       res.expect(answer)
     })
 
@@ -382,7 +391,6 @@ describe('UniversalResolver', () => {
         bundle.call,
       ])
       expectVar({ resolver }).toEqualAddress(F.publicResolver.address)
-      expectVar({ answer }).toStrictEqual(bundle.answer)
       bundle.expect(answer)
     })
 
@@ -401,7 +409,6 @@ describe('UniversalResolver', () => {
         res.call,
       ])
       expectVar({ resolver }).toEqualAddress(F.shapeshift1.address)
-      expectVar({ answer }).toStrictEqual(res.answer)
       res.expect(answer)
     })
 
@@ -422,7 +429,6 @@ describe('UniversalResolver', () => {
         bundle.call,
       ])
       expectVar({ resolver }).toEqualAddress(F.shapeshift1.address)
-      expectVar({ answer }).toStrictEqual(bundle.answer)
       bundle.expect(answer)
     })
 
@@ -441,7 +447,6 @@ describe('UniversalResolver', () => {
         res.call,
       ])
       expectVar({ resolver }).toEqualAddress(F.shapeshift1.address)
-      expectVar({ answer }).toStrictEqual(res.answer)
       res.expect(answer)
     })
 
@@ -462,7 +467,6 @@ describe('UniversalResolver', () => {
         bundle.call,
       ])
       expectVar({ resolver }).toEqualAddress(F.shapeshift1.address)
-      expectVar({ answer }).toStrictEqual(bundle.answer)
       bundle.expect(answer)
     })
 
@@ -482,7 +486,6 @@ describe('UniversalResolver', () => {
         res.call,
       ])
       expectVar({ resolver }).toEqualAddress(F.shapeshift1.address)
-      expectVar({ answer }).toStrictEqual(res.answer)
       res.expect(answer)
     })
 
@@ -504,7 +507,6 @@ describe('UniversalResolver', () => {
         bundle.call,
       ])
       expectVar({ resolver }).toEqualAddress(F.shapeshift1.address)
-      expectVar({ answer }).toStrictEqual(bundle.answer)
       bundle.expect(answer)
     })
 
@@ -520,11 +522,8 @@ describe('UniversalResolver', () => {
         primary: { value: testName },
         errors: [
           {
-            call: dummyCalldata,
-            answer: encodeErrorResult({
-              abi: parseAbi(['error UnsupportedResolverProfile(bytes4)']),
-              args: [dummyCalldata],
-            }),
+            call: dummyBytes4,
+            answer: unsupportedProfileData(dummyBytes4),
           },
         ],
       })
@@ -539,11 +538,76 @@ describe('UniversalResolver', () => {
         bundle.call,
       ])
       expectVar({ resolver }).toEqualAddress(F.shapeshift1.address)
-      expectVar({ answer }).toStrictEqual(bundle.answer)
+      bundle.expect(answer)
+    })
+  })
+
+  describe('resolve() w/feature detection', () => {
+    it('disabled feature + no gateway', async () => {
+      const F = await loadFixture(fixture)
+      await F.takeControl(testName)
+      await F.ensRegistry.write.setResolver([
+        namehash(getParentName(testName)),
+        F.shapeshift1.address,
+      ])
+      await F.shapeshift1.write.setExtended([true])
+      await F.shapeshift1.write.setOffchain([true])
+      await F.universalResolver.write.setBatchGateways([[]])
+      await expect(
+        F.universalResolver.read.resolve([
+          dnsEncodeName(testName),
+          dummyBytes4,
+        ]),
+      ).rejects.toThrow(/Offchain Gateway/)
+    })
+
+    it('onchain extended w/multicall', async () => {
+      const F = await loadFixture(fixture)
+      await F.takeControl(testName)
+      await F.ensRegistry.write.setResolver([
+        namehash(getParentName(testName)),
+        F.shapeshift1.address,
+      ])
+      await F.shapeshift1.write.setFeature([
+        FEATURES.RESOLVER.RESOLVE_MULTICALL,
+        true,
+      ])
+      const bundle = bundleCalls(resolutions)
+      await F.shapeshift1.write.setResponse([bundle.call, bundle.answer])
+      await F.shapeshift1.write.setExtended([true])
+      const [answer, resolver] = await F.universalResolver.read.resolve([
+        dnsEncodeName(testName),
+        bundle.call,
+      ])
+      expectVar({ resolver }).toEqualAddress(F.shapeshift1.address)
       bundle.expect(answer)
     })
 
-    it('offchain extended w/resolve(multicall)', async () => {
+    it('offchain extended', async () => {
+      const F = await loadFixture(fixture)
+      await F.takeControl(testName)
+      await F.ensRegistry.write.setResolver([
+        namehash(getParentName(testName)),
+        F.shapeshift1.address,
+      ])
+      await F.shapeshift1.write.setFeature([
+        FEATURES.RESOLVER.RESOLVE_MULTICALL,
+        true,
+      ])
+      const [res] = resolutions
+      await F.shapeshift1.write.setResponse([res.call, res.answer])
+      await F.shapeshift1.write.setExtended([true])
+      await F.shapeshift1.write.setOffchain([true])
+      await F.universalResolver.write.setBatchGateways([[]])
+      const [answer, resolver] = await F.universalResolver.read.resolve([
+        dnsEncodeName(testName),
+        res.call,
+      ])
+      expectVar({ resolver }).toEqualAddress(F.shapeshift1.address)
+      res.expect(answer)
+    })
+
+    it('offchain extended w/multicall', async () => {
       const F = await loadFixture(fixture)
       await F.takeControl(testName)
       await F.ensRegistry.write.setResolver([
@@ -564,7 +628,6 @@ describe('UniversalResolver', () => {
         bundle.call,
       ])
       expectVar({ resolver }).toEqualAddress(F.shapeshift1.address)
-      expectVar({ answer }).toStrictEqual(bundle.answer)
       bundle.expect(answer)
     })
   })
@@ -632,8 +695,8 @@ describe('UniversalResolver', () => {
       ])
       await expect(F.universalResolver)
         .read('reverse', [F.owner, COIN_TYPE_ETH])
-        .toBeRevertedWithCustomError('UnsupportedResolverProfile')
-        .withArgs(toFunctionSelector('name(bytes32)'))
+        .toBeRevertedWithCustomError('ResolverError')
+        .withArgs(unsupportedProfileData(toFunctionSelector('name(bytes32)')))
     })
 
     it('old name() + PR addr()', async () => {
@@ -715,8 +778,8 @@ describe('UniversalResolver', () => {
       ])
       await expect(F.universalResolver)
         .read('reverse', [F.owner, COIN_TYPE_ETH])
-        .toBeRevertedWithCustomError('UnsupportedResolverProfile')
-        .withArgs(toFunctionSelector('addr(bytes32)'))
+        .toBeRevertedWithCustomError('ResolverError')
+        .withArgs(unsupportedProfileData(toFunctionSelector('addr(bytes32)')))
     })
 
     it('PR name() + onchain immediate unimplemented addr()', async () => {
@@ -734,8 +797,8 @@ describe('UniversalResolver', () => {
       ])
       await expect(F.universalResolver)
         .read('reverse', [F.owner, COIN_TYPE_ETH])
-        .toBeRevertedWithCustomError('UnsupportedResolverProfile')
-        .withArgs(toFunctionSelector('addr(bytes32)'))
+        .toBeRevertedWithCustomError('ResolverError')
+        .withArgs(unsupportedProfileData(toFunctionSelector('addr(bytes32)')))
     })
 
     for (const coinType of [COIN_TYPE_ETH, COIN_TYPE_DEFAULT + 2n]) {

--- a/test/universalResolver/TestUniversalResolver.ts
+++ b/test/universalResolver/TestUniversalResolver.ts
@@ -4,11 +4,9 @@ import { expect } from 'chai'
 import hre from 'hardhat'
 import {
   encodeErrorResult,
-  Hex,
   HttpRequestError,
   keccak256,
   namehash,
-  parseAbi,
   toBytes,
   toFunctionSelector,
   toHex,
@@ -73,13 +71,6 @@ async function fixture() {
     shapeshift1,
     shapeshift2,
   }
-}
-
-function unsupportedProfileData(selector: Hex) {
-  return encodeErrorResult({
-    abi: parseAbi(['error UnsupportedResolverProfile(bytes4)']),
-    args: [selector],
-  })
 }
 
 const dummyBytes4 = '0x12345678'
@@ -217,8 +208,8 @@ describe('UniversalResolver', () => {
       ])
       await expect(F.universalResolver)
         .read('resolve', [dnsEncodeName(testName), dummyBytes4])
-        .toBeRevertedWithCustomError('ResolverError')
-        .withArgs(unsupportedProfileData(dummyBytes4))
+        .toBeRevertedWithCustomError('UnsupportedResolverProfile')
+        .withArgs(dummyBytes4)
     })
 
     it('empty revert', async () => {
@@ -282,8 +273,8 @@ describe('UniversalResolver', () => {
       await F.shapeshift1.write.setRevertUnsupportedResolverProfile([true])
       await expect(F.universalResolver)
         .read('resolve', [dnsEncodeName(testName), dummyBytes4])
-        .toBeRevertedWithCustomError('ResolverError')
-        .withArgs(unsupportedProfileData(dummyBytes4))
+        .toBeRevertedWithCustomError('UnsupportedResolverProfile')
+        .withArgs(dummyBytes4)
     })
 
     it('old', async () => {
@@ -319,7 +310,11 @@ describe('UniversalResolver', () => {
           errors: [
             {
               call: dummyBytes4,
-              answer: unsupportedProfileData(dummyBytes4),
+              answer: encodeErrorResult({
+                abi: F.universalResolver.abi,
+                errorName: 'UnsupportedResolverProfile',
+                args: [dummyBytes4],
+              }),
             },
           ],
         }),
@@ -523,7 +518,11 @@ describe('UniversalResolver', () => {
         errors: [
           {
             call: dummyBytes4,
-            answer: unsupportedProfileData(dummyBytes4),
+            answer: encodeErrorResult({
+              abi: F.universalResolver.abi,
+              errorName: 'UnsupportedResolverProfile',
+              args: [dummyBytes4],
+            }),
           },
         ],
       })
@@ -695,8 +694,8 @@ describe('UniversalResolver', () => {
       ])
       await expect(F.universalResolver)
         .read('reverse', [F.owner, COIN_TYPE_ETH])
-        .toBeRevertedWithCustomError('ResolverError')
-        .withArgs(unsupportedProfileData(toFunctionSelector('name(bytes32)')))
+        .toBeRevertedWithCustomError('UnsupportedResolverProfile')
+        .withArgs(toFunctionSelector('name(bytes32)'))
     })
 
     it('old name() + PR addr()', async () => {
@@ -778,8 +777,8 @@ describe('UniversalResolver', () => {
       ])
       await expect(F.universalResolver)
         .read('reverse', [F.owner, COIN_TYPE_ETH])
-        .toBeRevertedWithCustomError('ResolverError')
-        .withArgs(unsupportedProfileData(toFunctionSelector('addr(bytes32)')))
+        .toBeRevertedWithCustomError('UnsupportedResolverProfile')
+        .withArgs(toFunctionSelector('addr(bytes32)'))
     })
 
     it('PR name() + onchain immediate unimplemented addr()', async () => {
@@ -797,8 +796,8 @@ describe('UniversalResolver', () => {
       ])
       await expect(F.universalResolver)
         .read('reverse', [F.owner, COIN_TYPE_ETH])
-        .toBeRevertedWithCustomError('ResolverError')
-        .withArgs(unsupportedProfileData(toFunctionSelector('addr(bytes32)')))
+        .toBeRevertedWithCustomError('UnsupportedResolverProfile')
+        .withArgs(toFunctionSelector('addr(bytes32)'))
     })
 
     for (const coinType of [COIN_TYPE_ETH, COIN_TYPE_DEFAULT + 2n]) {

--- a/test/universalResolver/TestUniversalResolver.ts
+++ b/test/universalResolver/TestUniversalResolver.ts
@@ -307,16 +307,7 @@ describe('UniversalResolver', () => {
         makeResolutions({
           name: testName,
           primary: { value: testName },
-          errors: [
-            {
-              call: dummyBytes4,
-              answer: encodeErrorResult({
-                abi: F.universalResolver.abi,
-                errorName: 'UnsupportedResolverProfile',
-                args: [dummyBytes4],
-              }),
-            },
-          ],
+          errors: [{ call: dummyBytes4, answer: '0x' }],
         }),
       )
       const [answer, resolver] = await F.universalResolver.read.resolve([
@@ -361,7 +352,7 @@ describe('UniversalResolver', () => {
           { coinType: COIN_TYPE_ETH, value: anotherAddress },
         ],
       })
-      await F.publicResolver.write.multicall([[res0.write]]) // only set default
+      await F.publicResolver.write.multicall([[res0.write]]) // just default
       const [answer, resolver] = await F.universalResolver.read.resolve([
         dnsEncodeName(testName),
         res.call,
@@ -597,7 +588,7 @@ describe('UniversalResolver', () => {
       await F.shapeshift1.write.setResponse([res.call, res.answer])
       await F.shapeshift1.write.setExtended([true])
       await F.shapeshift1.write.setOffchain([true])
-      await F.universalResolver.write.setBatchGateways([[]])
+      await F.universalResolver.write.setBatchGateways([[]]) // disable
       const [answer, resolver] = await F.universalResolver.read.resolve([
         dnsEncodeName(testName),
         res.call,
@@ -617,11 +608,41 @@ describe('UniversalResolver', () => {
         FEATURES.RESOLVER.RESOLVE_MULTICALL,
         true,
       ])
-      await F.universalResolver.write.setBatchGateways([[]])
       const bundle = bundleCalls(resolutions)
       await F.shapeshift1.write.setResponse([bundle.call, bundle.answer])
       await F.shapeshift1.write.setExtended([true])
       await F.shapeshift1.write.setOffchain([true])
+      await F.universalResolver.write.setBatchGateways([[]]) // disable
+      const [answer, resolver] = await F.universalResolver.read.resolve([
+        dnsEncodeName(testName),
+        bundle.call,
+      ])
+      expectVar({ resolver }).toEqualAddress(F.shapeshift1.address)
+      bundle.expect(answer)
+    })
+
+    it('offchain extended w/multicall (1 revert)', async () => {
+      const F = await loadFixture(fixture)
+      await F.takeControl(testName)
+      await F.ensRegistry.write.setResolver([
+        namehash(getParentName(testName)),
+        F.shapeshift1.address,
+      ])
+      await F.shapeshift1.write.setFeature([
+        FEATURES.RESOLVER.RESOLVE_MULTICALL,
+        true,
+      ])
+      const bundle = bundleCalls(
+        makeResolutions({
+          name: testName,
+          primary: { value: testName },
+          errors: [{ call: dummyBytes4, answer: '0x' }],
+        }),
+      )
+      await F.shapeshift1.write.setResponse([bundle.call, bundle.answer])
+      await F.shapeshift1.write.setExtended([true])
+      await F.shapeshift1.write.setOffchain([true])
+      await F.universalResolver.write.setBatchGateways([[]]) // disable
       const [answer, resolver] = await F.universalResolver.read.resolve([
         dnsEncodeName(testName),
         bundle.call,

--- a/test/universalResolver/TestUniversalResolver.ts
+++ b/test/universalResolver/TestUniversalResolver.ts
@@ -28,6 +28,7 @@ import {
   getParentName,
   makeResolutions,
 } from '../utils/resolutions.js'
+import { FEATURES } from '../utils/features.js'
 
 async function fixture() {
   const F = await deployDefaultReverseFixture()
@@ -531,6 +532,31 @@ describe('UniversalResolver', () => {
       for (const res of calls) {
         await F.shapeshift1.write.setResponse([res.call, res.answer])
       }
+      await F.shapeshift1.write.setExtended([true])
+      await F.shapeshift1.write.setOffchain([true])
+      const [answer, resolver] = await F.universalResolver.read.resolve([
+        dnsEncodeName(testName),
+        bundle.call,
+      ])
+      expectVar({ resolver }).toEqualAddress(F.shapeshift1.address)
+      expectVar({ answer }).toStrictEqual(bundle.answer)
+      bundle.expect(answer)
+    })
+
+    it('offchain extended w/resolve(multicall)', async () => {
+      const F = await loadFixture(fixture)
+      await F.takeControl(testName)
+      await F.ensRegistry.write.setResolver([
+        namehash(getParentName(testName)),
+        F.shapeshift1.address,
+      ])
+      await F.shapeshift1.write.setFeature([
+        FEATURES.RESOLVER.RESOLVE_MULTICALL,
+        true,
+      ])
+      await F.universalResolver.write.setBatchGateways([[]])
+      const bundle = bundleCalls(resolutions)
+      await F.shapeshift1.write.setResponse([bundle.call, bundle.answer])
       await F.shapeshift1.write.setExtended([true])
       await F.shapeshift1.write.setOffchain([true])
       const [answer, resolver] = await F.universalResolver.read.resolve([

--- a/test/universalResolver/TestUniversalResolver.ts
+++ b/test/universalResolver/TestUniversalResolver.ts
@@ -396,7 +396,7 @@ describe('UniversalResolver', () => {
         namehash(getParentName(testName)),
         F.shapeshift1.address,
       ])
-      const res = resolutions[0]
+      const [res] = resolutions
       await F.shapeshift1.write.setResponse([res.call, res.answer])
       await F.shapeshift1.write.setExtended([true])
       const [answer, resolver] = await F.universalResolver.read.resolve([
@@ -434,7 +434,7 @@ describe('UniversalResolver', () => {
         namehash(testName),
         F.shapeshift1.address,
       ])
-      const res = resolutions[0]
+      const [res] = resolutions
       await F.shapeshift1.write.setResponse([res.call, res.answer])
       await F.shapeshift1.write.setOffchain([true])
       const [answer, resolver] = await F.universalResolver.read.resolve([
@@ -472,7 +472,7 @@ describe('UniversalResolver', () => {
         namehash(getParentName(testName)),
         F.shapeshift1.address,
       ])
-      const res = resolutions[0]
+      const [res] = resolutions
       await F.shapeshift1.write.setResponse([res.call, res.answer])
       await F.shapeshift1.write.setExtended([true])
       await F.shapeshift1.write.setOffchain([true])
@@ -629,6 +629,42 @@ describe('UniversalResolver', () => {
       expectVar({ resolver }).toEqualAddress(F.shapeshift1.address)
       bundle.expect(answer)
     })
+  })
+
+  it('resolveWithGateways()', async () => {
+    const F = await loadFixture(fixture)
+    await F.takeControl(testName)
+    await F.ensRegistry.write.setResolver([
+      namehash(testName),
+      F.shapeshift1.address,
+    ])
+    const [res] = resolutions
+    await F.shapeshift1.write.setResponse([res.call, res.answer])
+    await F.shapeshift1.write.setExtended([true])
+    const [answer, resolver] =
+      await F.universalResolver.read.resolveWithGateways([
+        dnsEncodeName(testName),
+        res.call,
+        await F.universalResolver.read.batchGateways(),
+      ])
+    expectVar({ resolver }).toEqualAddress(F.shapeshift1.address)
+    res.expect(answer)
+  })
+
+  it('resolveWithResolver()', async () => {
+    const F = await loadFixture(fixture)
+    const [res] = resolutions
+    await F.shapeshift1.write.setResponse([res.call, res.answer])
+    await F.shapeshift1.write.setExtended([true])
+    const [answer, resolver] =
+      await F.universalResolver.read.resolveWithResolver([
+        F.shapeshift1.address,
+        dnsEncodeName(testName),
+        res.call,
+        await F.universalResolver.read.batchGateways(),
+      ])
+    expectVar({ resolver }).toEqualAddress(F.shapeshift1.address)
+    res.expect(answer)
   })
 
   describe('reverse()', () => {

--- a/test/universalResolver/mainnet.ts
+++ b/test/universalResolver/mainnet.ts
@@ -1,4 +1,4 @@
-import type { Address } from 'viem'
+import { type Address, encodeErrorResult, parseAbi} from 'viem'
 import type { KnownProfile, KnownReverse } from '../utils/resolutions.js'
 import { COIN_TYPE_ETH } from '../fixtures/ensip19.js'
 
@@ -19,7 +19,10 @@ export const KNOWN_RESOLUTIONS: KnownProfile[] = [
     errors: [
       {
         call: '0x12345678',
-        answer: '0x',
+        answer: encodeErrorResult({
+          abi: parseAbi(['error UnsupportedResolverProfile(bytes4)']),
+          args: ['0x12345678'],
+        }),
       },
     ],
   },

--- a/test/universalResolver/mainnet.ts
+++ b/test/universalResolver/mainnet.ts
@@ -1,4 +1,4 @@
-import { type Address, encodeErrorResult, parseAbi} from 'viem'
+import type { Address } from 'viem'
 import type { KnownProfile, KnownReverse } from '../utils/resolutions.js'
 import { COIN_TYPE_ETH } from '../fixtures/ensip19.js'
 
@@ -19,10 +19,7 @@ export const KNOWN_RESOLUTIONS: KnownProfile[] = [
     errors: [
       {
         call: '0x12345678',
-        answer: encodeErrorResult({
-          abi: parseAbi(['error UnsupportedResolverProfile(bytes4)']),
-          args: ['0x12345678'],
-        }),
+        answer: '0x',
       },
     ],
   },

--- a/test/utils/TestFeatures.ts
+++ b/test/utils/TestFeatures.ts
@@ -1,0 +1,33 @@
+import hre from 'hardhat'
+import { loadFixture } from '@nomicfoundation/hardhat-toolbox-viem/network-helpers.js'
+import { expect } from 'chai'
+import { readFileSync } from 'node:fs'
+import { FEATURES, makeFeature } from './features.js'
+
+async function fixture() {
+  return hre.viem.deployContract('DummyShapeshiftResolver')
+}
+
+describe('ResolverFeatures', () => {
+  const code = readFileSync(
+    new URL('../../contracts/resolvers/ResolverFeatures.sol', import.meta.url),
+    'utf8',
+  )
+  for (const [_, name, featureName] of code.matchAll(
+    /constant (\S+) =\s+bytes4\(keccak256\("([^"]+)"\)\);/gm,
+  )) {
+    it(name, async () => {
+      expect(name in FEATURES.RESOLVER, 'missing').toStrictEqual(true)
+      const feature = makeFeature(featureName)
+      expect(feature, 'hash').toStrictEqual(
+        FEATURES.RESOLVER[name as keyof typeof FEATURES.RESOLVER],
+      )
+      const F = await loadFixture(fixture)
+      await F.write.setFeature([feature, true])
+      await expect(
+        F.read.supportsFeature([feature]),
+        'supports',
+      ).resolves.toStrictEqual(true)
+    })
+  }
+})

--- a/test/utils/TestFeatures.ts
+++ b/test/utils/TestFeatures.ts
@@ -16,9 +16,9 @@ describe('ResolverFeatures', () => {
   for (const [_, name, featureName] of code.matchAll(
     /constant (\S+) =\s+bytes4\(keccak256\("([^"]+)"\)\);/gm,
   )) {
-    it(name, async () => {
+    const feature = makeFeature(featureName)
+    it(`${name} = "${featureName}" = ${feature}`, async () => {
       expect(name in FEATURES.RESOLVER, 'missing').toStrictEqual(true)
-      const feature = makeFeature(featureName)
       expect(feature, 'hash').toStrictEqual(
         FEATURES.RESOLVER[name as keyof typeof FEATURES.RESOLVER],
       )

--- a/test/utils/TestHexUtils.ts
+++ b/test/utils/TestHexUtils.ts
@@ -25,6 +25,13 @@ describe('HexUtils', () => {
         ).resolves.toStrictEqual([hex, true])
       })
     }
+    it('invalid range', async () => {
+      const F = await loadFixture(fixture)
+      await expect(F.read.hexToBytes(['0x', 1n, 0n])).resolves.toStrictEqual([
+        '0x',
+        false,
+      ])
+    })
   })
 
   describe('hexStringToBytes32()', () => {
@@ -101,6 +108,13 @@ describe('HexUtils', () => {
         ]),
       ).resolves.toMatchObject([zeroHash, false])
     })
+
+    it('invalid range', async () => {
+      const F = await loadFixture(fixture)
+      await expect(
+        F.read.hexStringToBytes32(['0x', 1n, 0n]),
+      ).resolves.toStrictEqual([zeroHash, false])
+    })
   })
 
   describe('hexToAddress()', async () => {
@@ -144,6 +158,13 @@ describe('HexUtils', () => {
           41n,
         ]),
       ).resolves.toMatchObject([zeroAddress, false])
+    })
+
+    it('invalid range', async () => {
+      const F = await loadFixture(fixture)
+      await expect(
+        F.read.hexToAddress([stringToHex('0x12'), 2n, 0n]),
+      ).resolves.toStrictEqual([zeroAddress, false])
     })
   })
 

--- a/test/utils/features.ts
+++ b/test/utils/features.ts
@@ -1,0 +1,13 @@
+import { keccak256, slice, stringToHex } from 'viem'
+
+export function makeFeature(s: string) {
+  return slice(keccak256(stringToHex(s)), 0, 4)
+}
+
+// see: src/common/ResolverFeatures.sol
+export const FEATURES = {
+  RESOLVER: {
+    RESOLVE_MULTICALL: makeFeature('ens.resolver.extended.multicall'),
+    SINGULAR: makeFeature('ens.resolver.singular'),
+  },
+} as const

--- a/test/utils/features.ts
+++ b/test/utils/features.ts
@@ -4,10 +4,9 @@ export function makeFeature(s: string) {
   return slice(keccak256(stringToHex(s)), 0, 4)
 }
 
-// see: src/common/ResolverFeatures.sol
 export const FEATURES = {
   RESOLVER: {
-    RESOLVE_MULTICALL: makeFeature('ens.resolver.extended.multicall'),
-    SINGULAR: makeFeature('ens.resolver.singular'),
+    RESOLVE_MULTICALL: makeFeature('eth.ens.resolver.extended.multicall'),
+    SINGULAR: makeFeature('eth.ens.resolver.singular'),
   },
 } as const

--- a/test/utils/resolutions.ts
+++ b/test/utils/resolutions.ts
@@ -116,9 +116,9 @@ export function bundleCalls(resolutions: KnownResolution[]): KnownBundle {
         abi: RESOLVE_MULTICALL,
         data,
       }),
-    expect(answer) {
-      const answers = this.unbundle(answer)
-      expect(answers).toHaveLength(resolutions.length)
+    expect(data) {
+      const answers = this.unbundle(data)
+      expect(answers, 'answers.length').toHaveLength(resolutions.length)
       resolutions.forEach((x, i) => x.expect(answers[i]))
     },
     write: encodeFunctionData({


### PR DESCRIPTION
- refactored `AbstractUniversalResolver`
    - passes tests unmodified
    - `batchGateways()` — returns `string[]`
    - `resolveWithResolver()` — exposed registry-agnostic `resolve()` machinery
    - performs direct calls when [features are supported](https://github.com/ensdomains/ens-contracts/blob/temp/ur-features/contracts/universalResolver/AbstractUniversalResolver.sol#L279-L321)
    - added `resolve(multicall)` support
    - added more [tests](https://github.com/ensdomains/ens-contracts/blob/temp/ur-features/test/universalResolver/TestUniversalResolver.ts#L535-L689)
    
---

- copied [IFeatureSupporter.sol](https://github.com/ensdomains/ens-contracts/blob/temp/ur-features/contracts/utils/IFeatureSupporter.sol) and [ResolverFeatures.sol](https://github.com/ensdomains/ens-contracts/blob/temp/ur-features/contracts/resolvers/ResolverFeatures.sol) from `namechain/`
- added [TestFeatures.ts](https://github.com/ensdomains/ens-contracts/blob/temp/ur-features/test/utils/TestFeatures.ts)

---

- added [`createBatch()`](https://github.com/ensdomains/ens-contracts/blob/temp/ur-features/contracts/ccipRead/CCIPBatcher.sol#L38-L51) helper to `CCIPBatcher`
- added [`revertCallbackSelector`](https://github.com/ensdomains/ens-contracts/blob/temp/ur-features/contracts/ccipRead/CCIPReader.sol#L61) option to `CCIPReader`
- allow `CCIPReader.safeCall()` gas limit to be customized in constructor
- disambiguate unimplemented call from unimplemented callback in `CCIPReader` processing
- avoid invalid range revert in `HexUtils`