### PR TITLE
Added controllers in L2 reverse registrar

### DIFF
--- a/contracts/reverseRegistrar/L2ReverseRegistrar.sol
+++ b/contracts/reverseRegistrar/L2ReverseRegistrar.sol
@@ -15,13 +15,23 @@ import {SignatureUtils} from "./SignatureUtils.sol";
 contract L2ReverseRegistrar is
     IL2ReverseRegistrar,
     ERC165,
-    StandaloneReverseRegistrar
+    StandaloneReverseRegistrar,
+    Ownable
 {
     using SignatureUtils for bytes;
     using MessageHashUtils for bytes32;
 
     /// @notice The coin type for the chain this contract is deployed to.
     uint256 public immutable coinType;
+
+    /// @notice A map of addresses that are authorised to set names for any address.
+    mapping(address => bool) public controllers;
+
+    /// @notice Emitted when a controller is added.
+    event ControllerAdded(address indexed controller);
+
+    /// @notice Emitted when a controller is removed.
+    event ControllerRemoved(address indexed controller);
 
     /// @notice Thrown when the specified address is not the owner of the contract
     error NotOwnerOfContract();
@@ -36,7 +46,11 @@ contract L2ReverseRegistrar is
     ///
     /// @param addr The address to check.
     modifier authorised(address addr) {
-        if (addr != msg.sender && !_ownsContract(addr, msg.sender)) {
+        if (
+            addr != msg.sender &&
+            !_ownsContract(addr, msg.sender) &&
+            !controllers[msg.sender]
+        ) {
             revert Unauthorised();
         }
         _;
@@ -53,8 +67,23 @@ contract L2ReverseRegistrar is
     /// @notice Initialises the contract by setting the coin type.
     ///
     /// @param coinType_ The cointype converted from the chainId of the chain this contract is deployed to.
-    constructor(uint256 coinType_) {
+    /// @param owner_ The owner of the contract
+    constructor(uint256 coinType_, address owner_) Ownable(owner_) {
         coinType = coinType_;
+    }
+
+    /// @notice Authorises a controller, who can set names for any address.
+    /// @param controller The address to add as a controller.
+    function addController(address controller) external onlyOwner {
+        controllers[controller] = true;
+        emit ControllerAdded(controller);
+    }
+
+    /// @notice Revoke controller permission for an address.
+    /// @param controller The address to remove as a controller.
+    function removeController(address controller) external onlyOwner {
+        controllers[controller] = false;
+        emit ControllerRemoved(controller);
     }
 
     /// @inheritdoc IL2ReverseRegistrar

--- a/contracts/reverseRegistrar/L2ReverseRegistrarWithMigration.sol
+++ b/contracts/reverseRegistrar/L2ReverseRegistrarWithMigration.sol
@@ -9,7 +9,7 @@ import {INameResolver} from "../resolvers/profiles/INameResolver.sol";
 import {AddressUtils} from "../utils/AddressUtils.sol";
 
 /// @notice An L2 Reverse Registrar that allows migrating from a prior resolver.
-contract L2ReverseRegistrarWithMigration is L2ReverseRegistrar, Ownable {
+contract L2ReverseRegistrarWithMigration is L2ReverseRegistrar {
     using AddressUtils for address;
 
     /// @notice The old reverse resolver to migrate from
@@ -29,7 +29,7 @@ contract L2ReverseRegistrarWithMigration is L2ReverseRegistrar, Ownable {
         address owner_,
         bytes32 parentNode_,
         INameResolver oldReverseResolver_
-    ) L2ReverseRegistrar(coinType_) Ownable(owner_) {
+    ) L2ReverseRegistrar(coinType_, owner_) {
         parentNode = parentNode_;
         oldReverseResolver = oldReverseResolver_;
     }

--- a/test/reverseRegistrar/TestL2ReverseRegistrar.ts
+++ b/test/reverseRegistrar/TestL2ReverseRegistrar.ts
@@ -28,7 +28,11 @@ async function fixture() {
 
   const l2ReverseRegistrar = await hre.viem.deployContract(
     'L2ReverseRegistrar',
-    [coinType],
+    [coinType, accounts[0].address],
+  )
+  const mockNonOwnableSc = await hre.viem.deployContract(
+    'LegacyResolver',
+    [],
   )
   const mockSmartContractAccount = await hre.viem.deployContract(
     'MockSmartContractWallet',
@@ -46,6 +50,7 @@ async function fixture() {
 
   return {
     l2ReverseRegistrar,
+    mockNonOwnableSc,
     mockSmartContractAccount,
     mockErc6492WalletFactory,
     mockOwnableSca,
@@ -797,6 +802,7 @@ describe('L2ReverseRegistrar', () => {
 
     it('reverts if the target address does not implement Ownable', async () => {
       const {
+        mockNonOwnableSc,
         l2ReverseRegistrar,
         name,
         functionSelector,
@@ -808,7 +814,7 @@ describe('L2ReverseRegistrar', () => {
       const messageHash = createMessageHashForOwnable({
         contractAddress: l2ReverseRegistrar.address,
         functionSelector,
-        targetOwnableAddress: l2ReverseRegistrar.address,
+        targetOwnableAddress: mockNonOwnableSc.address,
         ownerAddress: accounts[0].address,
         signatureExpiry,
         name,
@@ -822,7 +828,7 @@ describe('L2ReverseRegistrar', () => {
         .write(
           'setNameForOwnableWithSignature',
           [
-            l2ReverseRegistrar.address,
+            mockNonOwnableSc.address,
             accounts[0].address,
             signatureExpiry,
             name,

--- a/test/reverseRegistrar/TestL2ReverseRegistrar.ts
+++ b/test/reverseRegistrar/TestL2ReverseRegistrar.ts
@@ -145,6 +145,123 @@ describe('L2ReverseRegistrar', () => {
     expect(l2ReverseRegistrar.address).not.toBeUndefined()
   })
 
+  describe('Ownable', () => {
+    it('should set deployer as owner', async () => {
+      const { l2ReverseRegistrar, accounts } = await loadFixture(fixture)
+      
+      await expect(
+        l2ReverseRegistrar.read.owner()
+      ).resolves.toBe(getAddress(accounts[0].address))
+    })
+  })
+  
+  describe('Controllers', () => {
+    it('should allow owner to add a controller', async () => {
+      const { l2ReverseRegistrar, accounts } = await loadFixture(fixture)
+      
+      await expect(l2ReverseRegistrar)
+        .write('addController', [accounts[1].address])
+        .toEmitEvent('ControllerAdded')
+        .withArgs(getAddress(accounts[1].address))
+        
+      await expect(
+        l2ReverseRegistrar.read.controllers([accounts[1].address])
+      ).resolves.toBe(true)
+    })
+    
+    it('should prevent non-owner from adding a controller', async () => {
+      const { l2ReverseRegistrar, accounts } = await loadFixture(fixture)
+      
+      await expect(l2ReverseRegistrar)
+        .write('addController', [accounts[2].address], { account: accounts[1] })
+        .toBeRevertedWithCustomError('OwnableUnauthorizedAccount')
+        
+      await expect(
+        l2ReverseRegistrar.read.controllers([accounts[2].address])
+      ).resolves.toBe(false)
+    })
+    
+    it('should allow owner to remove a controller', async () => {
+      const { l2ReverseRegistrar, accounts } = await loadFixture(fixture)
+      
+      // First add a controller
+      await l2ReverseRegistrar.write.addController([accounts[1].address])
+      
+      // Then remove it
+      await expect(l2ReverseRegistrar)
+        .write('removeController', [accounts[1].address])
+        .toEmitEvent('ControllerRemoved')
+        .withArgs(getAddress(accounts[1].address))
+        
+      await expect(
+        l2ReverseRegistrar.read.controllers([accounts[1].address])
+      ).resolves.toBe(false)
+    })
+    
+    it('should prevent non-owner from removing a controller', async () => {
+      const { l2ReverseRegistrar, accounts } = await loadFixture(fixture)
+      
+      // First add a controller
+      await l2ReverseRegistrar.write.addController([accounts[1].address])
+      
+      // Attempt removal by non-owner
+      await expect(l2ReverseRegistrar)
+        .write('removeController', [accounts[1].address], { account: accounts[2] })
+        .toBeRevertedWithCustomError('OwnableUnauthorizedAccount')
+        
+      // Controller should still exist
+      await expect(
+        l2ReverseRegistrar.read.controllers([accounts[1].address])
+      ).resolves.toBe(true)
+    })
+  })
+  
+  describe('Authorised modifier', () => {
+    async function authorisedFixture() {
+      const initial = await loadFixture(fixture)
+      const name = 'test-auth.eth'
+      
+      // Add a controller
+      await initial.l2ReverseRegistrar.write.addController([initial.accounts[1].address])
+      
+      return {
+        ...initial,
+        name,
+      }
+    }
+    
+    it('should allow owner of contract to set name for ownable contract', async () => {
+      const { l2ReverseRegistrar, name, mockOwnableEoa } = 
+        await loadFixture(authorisedFixture)
+      
+      await expect(l2ReverseRegistrar)
+        .write('setNameForAddr', [mockOwnableEoa.address, name])
+        .toEmitEvent('NameForAddrChanged')
+        .withArgs(getAddress(mockOwnableEoa.address), name)
+    })
+    
+    it('should allow controller to set name for any address', async () => {
+      const { l2ReverseRegistrar, name, accounts } = 
+        await loadFixture(authorisedFixture)
+      
+      // Controller (account[1]) sets name for account[2]
+      await expect(l2ReverseRegistrar)
+        .write('setNameForAddr', [accounts[2].address, name], { account: accounts[1] })
+        .toEmitEvent('NameForAddrChanged')
+        .withArgs(getAddress(accounts[2].address), name)
+    })
+    
+    it('should prevent unauthorized account from setting name for another address', async () => {
+      const { l2ReverseRegistrar, name, accounts } = 
+        await loadFixture(authorisedFixture)
+      
+      // Non-controller account[2] tries to set name for account[3]
+      await expect(l2ReverseRegistrar)
+        .write('setNameForAddr', [accounts[3].address, name], { account: accounts[2] })
+        .toBeRevertedWithCustomError('Unauthorised')
+    })
+  })
+
   describe('setName', () => {
     async function setNameFixture() {
       const initial = await loadFixture(fixture)

--- a/test/reverseResolver/TestChainReverseResolver.ts
+++ b/test/reverseResolver/TestChainReverseResolver.ts
@@ -39,6 +39,7 @@ async function fixture() {
   })
   const reverseRegistrar = await hre.viem.deployContract('L2ReverseRegistrar', [
     l2CoinType,
+    F.owner,
   ])
   const reverseResolver = await hre.viem.deployContract(
     'ChainReverseResolver',


### PR DESCRIPTION
Before ENSIP-19 is merged to mainnet, we’d like to propose a small edit.

We suggest adding support for controllers in the `L2ReverseRegistrar` contract. This change would allow us to inject additional logic for determining which smart contracts are eligible to set a primary ENS name.

Currently, only contracts that implement `Ownable` can set a primary name, due to the ownership check which is hardcoded for contracts. By introducing controllers, we can expand support and enable more contracts to qualify for a primary name.

These controllers could support various use cases (still open for discussion), such as:
	•	Allowing only a specific set of contracts to be named
	•	Allowing verified deployers to set primary names
	•	Supporting contracts deployed via Account Abstraction (AA), etc.

Our goal is to ensure that before ENSIP-19 is finalized, we retain the flexibility to define additional rules—so more contracts, both existing and future, can be supported with primary ENS names.