### PR TITLE
`NameCoder` Helpers

### DIFF
--- a/contracts/universalResolver/RegistryUtils.sol
+++ b/contracts/universalResolver/RegistryUtils.sol
@@ -29,7 +29,7 @@ library RegistryUtils {
                 bytes32 parentNode,
                 uint256 parentOffset
             ) = findResolver(registry, name, next);
-            node = keccak256(abi.encode(parentNode, labelHash)); // assembly saves ~100 gas
+            node = NameCoder.namehash(parentNode, labelHash);
             resolver = registry.resolver(node);
             return
                 resolver != address(0)

--- a/contracts/utils/NameCoder.sol
+++ b/contracts/utils/NameCoder.sol
@@ -265,24 +265,40 @@ library NameCoder {
     /// @param name The name to search.
     /// @param nodeSuffix The node to match.
     /// @return matched True if `name` ends with the suffix.
-    /// @return node The namehash of `name`.
-    /// @return suffixOffset The offset into `name` that namehashes to the `nodeSuffix`.
+    /// @return node The namehash of `name[offset:]`.
+    /// @return prevOffset The offset into `name` of the label before the suffix, or `matchOffset` if no match or prior label.
+    /// @return matchOffset The offset into `name` that namehashes to the `nodeSuffix`, or 0 if no match.
     function matchSuffix(
         bytes memory name,
         uint256 offset,
         bytes32 nodeSuffix
-    ) internal pure returns (bool matched, bytes32 node, uint256 suffixOffset) {
+    )
+        internal
+        pure
+        returns (
+            bool matched,
+            bytes32 node,
+            uint256 prevOffset,
+            uint256 matchOffset
+        )
+    {
         (bytes32 labelHash, uint256 next) = readLabel(name, offset);
         if (labelHash != bytes32(0)) {
-            (matched, node, suffixOffset) = matchSuffix(name, next, nodeSuffix);
+            (matched, node, prevOffset, matchOffset) = matchSuffix(
+                name,
+                next,
+                nodeSuffix
+            );
             if (node == nodeSuffix) {
                 matched = true;
-                suffixOffset = next;
+                prevOffset = offset;
+                matchOffset = next;
             }
             node = namehash(node, labelHash);
         }
         if (node == nodeSuffix) {
             matched = true;
+            prevOffset = matchOffset = offset;
         }
     }
 }

--- a/contracts/utils/NameCoder.sol
+++ b/contracts/utils/NameCoder.sol
@@ -248,4 +248,33 @@ library NameCoder {
             next = start + 1 + size; // advance
         }
     }
+
+    /// @dev Find the offset of `name` that namehashes to `nodeSuffix`.
+    /// @param name The name to search.
+    /// @param nodeSuffix The node to match.
+    /// @return matched True if `name` ends with the suffix.
+    /// @return node The namehash of `name`.
+    /// @return suffixOffset The offset into `name` that namehashes to the `nodeSuffix` or 0 if no match.
+    function matchSuffix(
+        bytes memory name,
+        uint256 offset,
+        bytes32 nodeSuffix
+    ) internal pure returns (bool matched, bytes32 node, uint256 suffixOffset) {
+        (bytes32 labelHash, uint256 next) = readLabel(name, offset);
+        if (labelHash != bytes32(0)) {
+            (matched, node, suffixOffset) = matchSuffix(name, next, nodeSuffix);
+            if (node == nodeSuffix) {
+                matched = true;
+                suffixOffset = next;
+            }
+            assembly {
+                mstore(0, node)
+                mstore(32, labelHash)
+                node := keccak256(0, 64) // compute namehash()
+            }
+        }
+        if (node == nodeSuffix) {
+            matched = true;
+        }
+    }
 }

--- a/contracts/utils/NameCoder.sol
+++ b/contracts/utils/NameCoder.sol
@@ -22,6 +22,7 @@ import {HexUtils} from "../utils/HexUtils.sol";
 ///
 /// w/o hashed labels: `dns.length == 2 + ens.length` and the mapping is injective.
 ///  w/ hashed labels: `dns.length == 2 + ens.split('.').map(x => x.utf8Length).sum(n => n > 255 ? 66 : n)`.
+///
 library NameCoder {
     /// @dev The DNS-encoded name is malformed.
     ///      Error selector: `0xba4adc23`
@@ -31,53 +32,108 @@ library NameCoder {
     ///      Error selector: `0x9a4c3e3b`
     error DNSEncodingFailed(string ens);
 
-    /// @dev Same as `BytesUtils.readLabel()` but supports hashed labels.
-    ///      Only the last labelHash is zero.
+    /// @dev Read the `size` of the label at `offset` and the offset for the next label.
+    ///      If `size = 0`, it must be the end of `name`.
+    ///      Reverts `DNSDecodingFailed`.
+    /// @param name The DNS-encoded name.
+    /// @param offset The offset into `name` to start reading forwards.
+    function nextLabel(
+        bytes memory name,
+        uint256 offset
+    ) internal pure returns (uint256 size, uint256 nextOffset) {
+        assembly {
+            size := byte(0, mload(add(add(name, 32), offset))) // uint8(name[offset])
+            nextOffset := add(offset, add(1, size)) // offset + 1 + size
+        }
+        if (size == 0 ? nextOffset != name.length : nextOffset >= name.length) {
+            revert DNSDecodingFailed(name);
+        }
+    }
+
+    /// @dev Find the offset of the label before `offset` in `name`.
+    ///      * `prevOffset(name, 0)` reverts.
+    ///      * `prevOffset(name, name.length + 1)` reverts.
+    ///      * `prevOffset(name, name.length) = name.length - 1`.
+    ///      * `prevOffset(name, name.length - 1) = <tld>`.
+    ///      Reverts `DNSDecodingFailed`.
+    /// @param name The DNS-encoded name.
+    /// @param offset The offset into `name` to start reading backwards.
+    /// @return prevOffset The offset of the previous label.
+    function prevLabel(
+        bytes memory name,
+        uint256 offset
+    ) internal pure returns (uint256 prevOffset) {
+        while (true) {
+            (, uint256 nextOffset) = nextLabel(name, prevOffset);
+            if (nextOffset == offset) break;
+            if (nextOffset > offset) {
+                revert DNSDecodingFailed(name);
+            }
+            prevOffset = nextOffset;
+        }
+    }
+
+    /// @dev Compute the `labelHash` of the label at `offset` and the offset for the next label.
     ///      Disallows hashed label of zero (eg. `[0..0]`) to prevent confusion with terminator.
     ///      Reverts `DNSDecodingFailed`.
     /// @param name The DNS-encoded name.
-    /// @param idx The offset into `name` to start reading.
+    /// @param offset The offset into `name` to start reading.
+    /// @param parseHashed If true, supports hashed labels.
     /// @return labelHash The resulting labelhash.
-    /// @return newIdx The offset into `name` of the next label.
+    /// @return wasHashed If true, the label was interpreted as a hashed label.
+    /// @return nextOffset The offset into `name` of the next label.
     function readLabel(
         bytes memory name,
-        uint256 idx
-    ) internal pure returns (bytes32 labelHash, uint256 newIdx) {
-        if (idx >= name.length) revert DNSDecodingFailed(name); // "readLabel: expected length"
-        uint256 len = uint256(uint8(name[idx++]));
-        newIdx = idx + len;
-        if (newIdx > name.length) revert DNSDecodingFailed(name); // "readLabel: expected label"
-        if (len == 66 && name[idx] == "[" && name[newIdx - 1] == "]") {
-            bool valid;
-            (labelHash, valid) = HexUtils.hexStringToBytes32(
+        uint256 offset,
+        bool parseHashed
+    )
+        internal
+        pure
+        returns (bytes32 labelHash, bool wasHashed, uint256 nextOffset)
+    {
+        uint256 size;
+        (size, nextOffset) = nextLabel(name, offset);
+        if (
+            parseHashed &&
+            size == 66 &&
+            name[offset + 1] == "[" &&
+            name[nextOffset - 1] == "]"
+        ) {
+            (labelHash, wasHashed) = HexUtils.hexStringToBytes32(
                 name,
-                idx + 1,
-                newIdx - 1
+                offset + 2,
+                nextOffset - 1
             ); // will not revert
-            if (!valid || labelHash == bytes32(0)) {
+            if (!wasHashed || labelHash == bytes32(0)) {
                 revert DNSDecodingFailed(name); // "readLabel: malformed" or null literal
             }
-        } else if (len > 0) {
+        } else if (size > 0) {
             assembly {
-                labelHash := keccak256(add(add(name, idx), 32), len)
+                labelHash := keccak256(add(add(name, offset), 33), size)
             }
         }
+    }
+
+    /// @dev Same as `BytesUtils.readLabel()` but supports hashed labels.
+    function readLabel(
+        bytes memory name,
+        uint256 offset
+    ) internal pure returns (bytes32 labelHash, uint256 nextOffset) {
+        (labelHash, , nextOffset) = readLabel(name, offset, true);
     }
 
     /// @dev Same as `BytesUtils.namehash()` but supports hashed labels.
     ///      Reverts `DNSDecodingFailed`.
     /// @param name The DNS-encoded name.
-    /// @param idx The offset into name start hashing.
+    /// @param offset The offset into name start hashing.
     /// @return hash The resulting namehash.
     function namehash(
         bytes memory name,
-        uint256 idx
+        uint256 offset
     ) internal pure returns (bytes32 hash) {
-        (hash, idx) = readLabel(name, idx);
-        if (hash == bytes32(0)) {
-            if (idx != name.length) revert DNSDecodingFailed(name); // "namehash: Junk at end of name"
-        } else {
-            bytes32 parent = namehash(name, idx);
+        (hash, offset) = readLabel(name, offset);
+        if (hash != bytes32(0)) {
+            bytes32 parent = namehash(name, offset);
             assembly {
                 mstore(0, parent)
                 mstore(32, hash)

--- a/contracts/utils/NameCoder.sol
+++ b/contracts/utils/NameCoder.sol
@@ -32,11 +32,13 @@ library NameCoder {
     ///      Error selector: `0x9a4c3e3b`
     error DNSEncodingFailed(string ens);
 
-    /// @dev Read the `size` of the label at `offset` and the offset for the next label.
+    /// @dev Read the `size` of the label at `offset`.
     ///      If `size = 0`, it must be the end of `name` (no junk at end).
     ///      Reverts `DNSDecodingFailed`.
     /// @param name The DNS-encoded name.
-    /// @param offset The offset into `name` to start reading forwards.
+    /// @param offset The offset into `name` to start reading.
+    /// @return size The size of the label in bytes.
+    /// @return nextOffset The offset into `name` of the next label.
     function nextLabel(
         bytes memory name,
         uint256 offset
@@ -58,7 +60,7 @@ library NameCoder {
     ///      Reverts `DNSDecodingFailed`.
     /// @param name The DNS-encoded name.
     /// @param offset The offset into `name` to start reading backwards.
-    /// @return prevOffset The offset of the previous label.
+    /// @return prevOffset The offset into `name` of the previous label.
     function prevLabel(
         bytes memory name,
         uint256 offset
@@ -79,6 +81,7 @@ library NameCoder {
     /// @param name The DNS-encoded name.
     /// @param offset The offset into `name` to start reading.
     /// @param parseHashed If true, supports hashed labels.
+    /// @return size The size of the label in bytes.
     /// @return labelHash The resulting labelhash.
     /// @return wasHashed If true, the label was interpreted as a hashed label.
     /// @return nextOffset The offset into `name` of the next label.
@@ -89,9 +92,13 @@ library NameCoder {
     )
         internal
         pure
-        returns (bytes32 labelHash, bool wasHashed, uint256 nextOffset)
+        returns (
+            uint256 size,
+            bytes32 labelHash,
+            bool wasHashed,
+            uint256 nextOffset
+        )
     {
-        uint256 size;
         (size, nextOffset) = nextLabel(name, offset);
         if (
             parseHashed &&
@@ -119,7 +126,7 @@ library NameCoder {
         bytes memory name,
         uint256 offset
     ) internal pure returns (bytes32 labelHash, uint256 nextOffset) {
-        (labelHash, , nextOffset) = readLabel(name, offset, true);
+        (, labelHash, , nextOffset) = readLabel(name, offset, true);
     }
 
     /// @dev Same as `BytesUtils.namehash()` but supports hashed labels.

--- a/contracts/utils/NameCoder.sol
+++ b/contracts/utils/NameCoder.sol
@@ -153,7 +153,7 @@ library NameCoder {
         bytes32 parentNode,
         bytes32 labelHash
     ) internal pure returns (bytes32 node) {
-		// ~100 gas less than: keccak256(abi.encode(parentNode, labelHash))
+        // ~100 gas less than: keccak256(abi.encode(parentNode, labelHash))
         assembly {
             mstore(0, parentNode)
             mstore(32, labelHash)

--- a/contracts/utils/NameCoder.sol
+++ b/contracts/utils/NameCoder.sol
@@ -42,7 +42,7 @@ library NameCoder {
     function nextLabel(
         bytes memory name,
         uint256 offset
-    ) internal pure returns (uint256 size, uint256 nextOffset) {
+    ) internal pure returns (uint8 size, uint256 nextOffset) {
         assembly {
             size := byte(0, mload(add(add(name, 32), offset))) // uint8(name[offset])
             nextOffset := add(offset, add(1, size)) // offset + 1 + size
@@ -81,10 +81,10 @@ library NameCoder {
     /// @param name The DNS-encoded name.
     /// @param offset The offset into `name` to start reading.
     /// @param parseHashed If true, supports hashed labels.
-    /// @return size The size of the label in bytes.
     /// @return labelHash The resulting labelhash.
-    /// @return wasHashed If true, the label was interpreted as a hashed label.
     /// @return nextOffset The offset into `name` of the next label.
+    /// @return size The size of the label in bytes.
+    /// @return wasHashed If true, the label was interpreted as a hashed label.
     function readLabel(
         bytes memory name,
         uint256 offset,
@@ -93,10 +93,10 @@ library NameCoder {
         internal
         pure
         returns (
-            uint256 size,
             bytes32 labelHash,
-            bool wasHashed,
-            uint256 nextOffset
+            uint256 nextOffset,
+            uint8 size,
+            bool wasHashed
         )
     {
         (size, nextOffset) = nextLabel(name, offset);
@@ -126,7 +126,7 @@ library NameCoder {
         bytes memory name,
         uint256 offset
     ) internal pure returns (bytes32 labelHash, uint256 nextOffset) {
-        (, labelHash, , nextOffset) = readLabel(name, offset, true);
+        (labelHash, nextOffset, , ) = readLabel(name, offset, true);
     }
 
     /// @dev Same as `BytesUtils.namehash()` but supports hashed labels.

--- a/contracts/utils/NameCoder.sol
+++ b/contracts/utils/NameCoder.sol
@@ -75,7 +75,7 @@ library NameCoder {
         }
     }
 
-    /// @dev Compute the `labelHash` of the label at `offset` and the offset for the next label.
+    /// @dev Compute the ENS labelhash of the label at `offset` and the offset for the next label.
     ///      Disallows hashed label of zero (eg. `[0..0]`) to prevent confusion with terminator.
     ///      Reverts `DNSDecodingFailed`.
     /// @param name The DNS-encoded name.
@@ -121,7 +121,7 @@ library NameCoder {
         }
     }
 
-    /// @dev Same as `BytesUtils.readLabel()` but supports hashed labels.
+    /// @dev Same as `BytesUtils.namehash()` but supports hashed labels.
     function readLabel(
         bytes memory name,
         uint256 offset
@@ -129,23 +129,35 @@ library NameCoder {
         (labelHash, nextOffset, , ) = readLabel(name, offset, true);
     }
 
-    /// @dev Same as `BytesUtils.namehash()` but supports hashed labels.
+    /// @dev Compute the ENS namehash of `name[:offset]`.
+    ///      Supports hashed labels.
     ///      Reverts `DNSDecodingFailed`.
     /// @param name The DNS-encoded name.
     /// @param offset The offset into name start hashing.
-    /// @return hash The resulting namehash.
+    /// @return hash The namehash of `name[:offset]`.
     function namehash(
         bytes memory name,
         uint256 offset
     ) internal pure returns (bytes32 hash) {
         (hash, offset) = readLabel(name, offset);
         if (hash != bytes32(0)) {
-            bytes32 parent = namehash(name, offset);
-            assembly {
-                mstore(0, parent)
-                mstore(32, hash)
-                hash := keccak256(0, 64)
-            }
+            hash = namehash(namehash(name, offset), hash);
+        }
+    }
+
+    /// @dev Compute a child namehash from a parent namehash.
+    /// @param parentNode The namehash of the parent.
+    /// @param labelHash The labelhash of the child.
+    /// @return node The namehash of the child.
+    function namehash(
+        bytes32 parentNode,
+        bytes32 labelHash
+    ) internal pure returns (bytes32 node) {
+		// ~100 gas less than: keccak256(abi.encode(parentNode, labelHash))
+        assembly {
+            mstore(0, parentNode)
+            mstore(32, labelHash)
+            node := keccak256(0, 64)
         }
     }
 
@@ -254,7 +266,7 @@ library NameCoder {
     /// @param nodeSuffix The node to match.
     /// @return matched True if `name` ends with the suffix.
     /// @return node The namehash of `name`.
-    /// @return suffixOffset The offset into `name` that namehashes to the `nodeSuffix` or 0 if no match.
+    /// @return suffixOffset The offset into `name` that namehashes to the `nodeSuffix`.
     function matchSuffix(
         bytes memory name,
         uint256 offset,
@@ -267,11 +279,7 @@ library NameCoder {
                 matched = true;
                 suffixOffset = next;
             }
-            assembly {
-                mstore(0, node)
-                mstore(32, labelHash)
-                node := keccak256(0, 64) // compute namehash()
-            }
+            node = namehash(node, labelHash);
         }
         if (node == nodeSuffix) {
             matched = true;

--- a/contracts/utils/NameCoder.sol
+++ b/contracts/utils/NameCoder.sol
@@ -33,7 +33,7 @@ library NameCoder {
     error DNSEncodingFailed(string ens);
 
     /// @dev Read the `size` of the label at `offset` and the offset for the next label.
-    ///      If `size = 0`, it must be the end of `name`.
+    ///      If `size = 0`, it must be the end of `name` (no junk at end).
     ///      Reverts `DNSDecodingFailed`.
     /// @param name The DNS-encoded name.
     /// @param offset The offset into `name` to start reading forwards.
@@ -45,7 +45,7 @@ library NameCoder {
             size := byte(0, mload(add(add(name, 32), offset))) // uint8(name[offset])
             nextOffset := add(offset, add(1, size)) // offset + 1 + size
         }
-        if (size == 0 ? nextOffset != name.length : nextOffset >= name.length) {
+        if (size > 0 ? nextOffset >= name.length : nextOffset != name.length) {
             revert DNSDecodingFailed(name);
         }
     }

--- a/contracts/utils/TestNameCoder.sol
+++ b/contracts/utils/TestNameCoder.sol
@@ -62,7 +62,16 @@ contract TestNameCoder {
         bytes memory name,
         uint256 offset,
         bytes32 nodeSuffix
-    ) external pure returns (bool matched, bytes32 node, uint256 suffixOffset) {
+    )
+        external
+        pure
+        returns (
+            bool matched,
+            bytes32 node,
+            uint256 prevOffset,
+            uint256 matchOffset
+        )
+    {
         return NameCoder.matchSuffix(name, offset, nodeSuffix);
     }
 }

--- a/contracts/utils/TestNameCoder.sol
+++ b/contracts/utils/TestNameCoder.sol
@@ -57,4 +57,12 @@ contract TestNameCoder {
     ) external pure returns (string memory ens) {
         return NameCoder.decode(dns);
     }
+
+    function matchSuffix(
+        bytes memory name,
+        uint256 offset,
+        bytes32 nodeSuffix
+    ) external pure returns (bool matched, bytes32 node, uint256 suffixOffset) {
+        return NameCoder.matchSuffix(name, offset, nodeSuffix);
+    }
 }

--- a/contracts/utils/TestNameCoder.sol
+++ b/contracts/utils/TestNameCoder.sol
@@ -4,6 +4,36 @@ pragma solidity ^0.8.0;
 import {NameCoder} from "./NameCoder.sol";
 
 contract TestNameCoder {
+    function nextLabel(
+        bytes memory name,
+        uint256 offset
+    ) external pure returns (uint256 size, uint256 nextOffset) {
+        return NameCoder.nextLabel(name, offset);
+    }
+
+    function prevLabel(
+        bytes memory name,
+        uint256 offset
+    ) external pure returns (uint256) {
+        return NameCoder.prevLabel(name, offset);
+    }
+
+    function readLabel(
+        bytes memory name,
+        uint256 offset,
+        bool parseHashed
+    )
+        external
+        pure
+        returns (bytes32 labelHash, bool wasHashed, uint256 nextOffset)
+    {
+        (labelHash, wasHashed, nextOffset) = NameCoder.readLabel(
+            name,
+            offset,
+            parseHashed
+        );
+    }
+
     function namehash(
         bytes memory name,
         uint256 offset

--- a/contracts/utils/TestNameCoder.sol
+++ b/contracts/utils/TestNameCoder.sol
@@ -7,7 +7,7 @@ contract TestNameCoder {
     function nextLabel(
         bytes memory name,
         uint256 offset
-    ) external pure returns (uint256 size, uint256 nextOffset) {
+    ) external pure returns (uint8 size, uint256 nextOffset) {
         return NameCoder.nextLabel(name, offset);
     }
 
@@ -26,13 +26,13 @@ contract TestNameCoder {
         external
         pure
         returns (
-            uint256 size,
             bytes32 labelHash,
-            bool wasHashed,
-            uint256 nextOffset
+            uint256 nextOffset,
+            uint8 size,
+            bool wasHashed
         )
     {
-        (size, labelHash, wasHashed, nextOffset) = NameCoder.readLabel(
+        (labelHash, nextOffset, size, wasHashed) = NameCoder.readLabel(
             name,
             offset,
             parseHashed

--- a/contracts/utils/TestNameCoder.sol
+++ b/contracts/utils/TestNameCoder.sol
@@ -25,9 +25,14 @@ contract TestNameCoder {
     )
         external
         pure
-        returns (bytes32 labelHash, bool wasHashed, uint256 nextOffset)
+        returns (
+            uint256 size,
+            bytes32 labelHash,
+            bool wasHashed,
+            uint256 nextOffset
+        )
     {
-        (labelHash, wasHashed, nextOffset) = NameCoder.readLabel(
+        (size, labelHash, wasHashed, nextOffset) = NameCoder.readLabel(
             name,
             offset,
             parseHashed

--- a/test/utils/TestNameCoder.ts
+++ b/test/utils/TestNameCoder.ts
@@ -61,7 +61,7 @@ describe('NameCoder', () => {
       await expect(
         F.read.nextLabel([dns, prev]),
         'nextLabel',
-      ).resolves.toStrictEqual([0n, offset])
+      ).resolves.toStrictEqual([0, offset])
     })
 
     it('offset = name.length-1 is <tld>', async () => {
@@ -79,7 +79,7 @@ describe('NameCoder', () => {
       await expect(
         F.read.readLabel([dns, prev, true]),
         'readLabel',
-      ).resolves.toStrictEqual([BigInt(v.length), keccak256(v), false, offset])
+      ).resolves.toStrictEqual([keccak256(v), offset, v.length, false])
     })
 
     it('offset = 0 reverts', async () => {
@@ -103,7 +103,7 @@ describe('NameCoder', () => {
     const v = stringToBytes(label)
     await expect(
       F.read.readLabel([dnsEncodeName(label), 0n, false]),
-    ).resolves.toStrictEqual([BigInt(v.length), keccak256(v), false, 67n])
+    ).resolves.toStrictEqual([keccak256(v), 67n, v.length, false])
   })
 
   it('invalid hashed label', async () => {

--- a/test/utils/TestNameCoder.ts
+++ b/test/utils/TestNameCoder.ts
@@ -75,10 +75,11 @@ describe('NameCoder', () => {
         F.read.prevLabel([dns, offset]),
         'prevLabel',
       ).resolves.toStrictEqual(prev)
+      const v = stringToBytes(tld)
       await expect(
         F.read.readLabel([dns, prev, true]),
         'readLabel',
-      ).resolves.toStrictEqual([keccak256(stringToBytes(tld)), false, offset])
+      ).resolves.toStrictEqual([BigInt(v.length), keccak256(v), false, offset])
     })
 
     it('offset = 0 reverts', async () => {
@@ -99,9 +100,10 @@ describe('NameCoder', () => {
   it('disable hashed label support', async () => {
     const F = await loadFixture(fixture)
     const label = `[${'0'.repeat(64)}]`
+    const v = stringToBytes(label)
     await expect(
       F.read.readLabel([dnsEncodeName(label), 0n, false]),
-    ).resolves.toStrictEqual([keccak256(stringToBytes(label)), false, 67n])
+    ).resolves.toStrictEqual([BigInt(v.length), keccak256(v), false, 67n])
   })
 
   it('invalid hashed label', async () => {

--- a/test/utils/TestNameCoder.ts
+++ b/test/utils/TestNameCoder.ts
@@ -10,12 +10,12 @@ async function fixture() {
   return hre.viem.deployContract('TestNameCoder', [])
 }
 
-function forceHashedLabel(s: string) {
-  return `[${keccak256(stringToBytes(s)).slice(2)}]`
+function forceHashedLabel(label: string) {
+  return `[${keccak256(stringToBytes(label)).slice(2)}]`
 }
 
-function fmt(s: string) {
-  return s || '<root>'
+function fmt(name: string) {
+  return name || '<root>'
 }
 
 describe('NameCoder', () => {
@@ -26,7 +26,7 @@ describe('NameCoder', () => {
       ['1x255', '1'.repeat(255)],
       ['1x300', '1'.repeat(300)],
       ['hashed("eth")', forceHashedLabel('eth')],
-      ['mixed', `1.${'1'.repeat(300)}.[${'1'.repeat(64)}].eth`],
+      ['mixed', `${'1'.repeat(300)}.${forceHashedLabel('test')}.eth`],
     ]) {
       it(fmt(title), async () => {
         const F = await loadFixture(fixture)

--- a/test/utils/TestNameCoder.ts
+++ b/test/utils/TestNameCoder.ts
@@ -1,10 +1,9 @@
 import hre from 'hardhat'
 import { loadFixture } from '@nomicfoundation/hardhat-toolbox-viem/network-helpers.js'
 import { expect } from 'chai'
-import { namehash, slice, toHex } from 'viem'
+import { namehash, toHex, size, keccak256, stringToBytes } from 'viem'
 import { dnsEncodeName } from '../fixtures/dnsEncodeName.js'
 import { dnsDecodeName } from '../fixtures/dnsDecodeName.js'
-import { getParentName } from './resolutions.js'
 
 async function fixture() {
   return hre.viem.deployContract('TestNameCoder', [])
@@ -28,18 +27,88 @@ describe('NameCoder', () => {
         await expect(F.read.decode([dns]), 'decode').resolves.toStrictEqual(
           dnsDecodeName(dns),
         )
-        let pos = 0
-        while (true) {
-          await expect(
-            F.read.namehash([dns, BigInt(pos)]),
-            `namehash: ${ens}`,
-          ).resolves.toStrictEqual(namehash(ens))
-          if (!ens) break
-          pos += 1 + parseInt(slice(dns, pos, pos + 1))
-          ens = getParentName(ens)
+        await expect(
+          F.read.namehash([dns, 0n]),
+          'namehash',
+        ).resolves.toStrictEqual(namehash(ens))
+        for (let offset = 0n; offset < size(dns); ) {
+          ;[, offset] = await F.read.nextLabel([dns, offset])
+        }
+        for (let offset = BigInt(size(dns)); offset; ) {
+          offset = await F.read.prevLabel([dns, offset])
         }
       })
     }
+  })
+
+  it('no next label', async () => {
+    const F = await loadFixture(fixture)
+    await expect(F)
+      .read('nextLabel', [dnsEncodeName(''), 1n])
+      .toBeRevertedWithCustomError('DNSDecodingFailed')
+  })
+
+  describe('prevLabel()', () => {
+    it('offset = name.length is <root>', async () => {
+      const F = await loadFixture(fixture)
+      const dns = dnsEncodeName('eth')
+      const offset = BigInt(size(dns))
+      const prev = offset - 1n
+      await expect(
+        F.read.prevLabel([dns, offset]),
+        'prevLabel',
+      ).resolves.toStrictEqual(prev)
+      await expect(
+        F.read.nextLabel([dns, prev]),
+        'nextLabel',
+      ).resolves.toStrictEqual([0n, offset])
+    })
+
+    it('offset = name.length-1 is <tld>', async () => {
+      const F = await loadFixture(fixture)
+      const namespace = 'a.b.c.'
+      const tld = 'eth'
+      const dns = dnsEncodeName(namespace + tld)
+      const offset = BigInt(size(dns) - 1)
+      const prev = BigInt(namespace.length)
+      await expect(
+        F.read.prevLabel([dns, offset]),
+        'prevLabel',
+      ).resolves.toStrictEqual(prev)
+      await expect(
+        F.read.readLabel([dns, prev, true]),
+        'readLabel',
+      ).resolves.toStrictEqual([keccak256(stringToBytes(tld)), false, offset])
+    })
+
+    it('offset = 0 reverts', async () => {
+      const F = await loadFixture(fixture)
+      await expect(F)
+        .read('prevLabel', [dnsEncodeName(''), 0n])
+        .toBeRevertedWithCustomError('DNSDecodingFailed')
+    })
+  })
+
+  it('null hashed label', async () => {
+    const F = await loadFixture(fixture)
+    await expect(F)
+      .read('readLabel', [dnsEncodeName(`[${'0'.repeat(64)}]`), 0n, true])
+      .toBeRevertedWithCustomError('DNSDecodingFailed')
+  })
+
+  it('disable hashed label support', async () => {
+    const F = await loadFixture(fixture)
+    const label = `[${'0'.repeat(64)}]`
+    await expect(
+      F.read.readLabel([dnsEncodeName(label), 0n, false]),
+    ).resolves.toStrictEqual([keccak256(stringToBytes(label)), false, 67n])
+  })
+
+  it('invalid hashed label', async () => {
+    const F = await loadFixture(fixture)
+    await expect(F)
+      .read('namehash', [dnsEncodeName(`[${'z'.repeat(64)}]`), 0n])
+      .toBeRevertedWithCustomError('DNSDecodingFailed')
   })
 
   describe('encode() failure', () => {
@@ -54,7 +123,7 @@ describe('NameCoder', () => {
   })
 
   describe('decode() failure', () => {
-    for (const dns of ['0x', '0x02', '0x0000', '0x1000'] as const) {
+    for (const dns of ['0x', '0x02', '0x0000', '0x0100'] as const) {
       it(dns, async () => {
         const F = await loadFixture(fixture)
         await expect(F)
@@ -65,19 +134,12 @@ describe('NameCoder', () => {
           .toBeRevertedWithCustomError('DNSDecodingFailed')
       })
     }
-  })
 
-  it('malicious label', async () => {
-    const F = await loadFixture(fixture)
-    await expect(F)
-      .read('decode', [toHex('\x03a.b\x00')])
-      .toBeRevertedWithCustomError('DNSDecodingFailed')
-  })
-
-  it('null hashed label', async () => {
-    const F = await loadFixture(fixture)
-    await expect(F)
-      .read('namehash', [dnsEncodeName(`[${'0'.repeat(64)}]`), 0n])
-      .toBeRevertedWithCustomError('DNSDecodingFailed')
+    it('malicious label', async () => {
+      const F = await loadFixture(fixture)
+      await expect(F)
+        .read('decode', [toHex('\x03a.b\x00')])
+        .toBeRevertedWithCustomError('DNSDecodingFailed')
+    })
   })
 })

--- a/test/utils/TestNameCoder.ts
+++ b/test/utils/TestNameCoder.ts
@@ -4,23 +4,31 @@ import { expect } from 'chai'
 import { namehash, toHex, size, keccak256, stringToBytes } from 'viem'
 import { dnsEncodeName } from '../fixtures/dnsEncodeName.js'
 import { dnsDecodeName } from '../fixtures/dnsDecodeName.js'
+import { getParentName } from './resolutions.js'
 
 async function fixture() {
   return hre.viem.deployContract('TestNameCoder', [])
 }
 
+function forceHashedLabel(s: string) {
+  return `[${keccak256(stringToBytes(s)).slice(2)}]`
+}
+
+function fmt(s: string) {
+  return s || '<root>'
+}
+
 describe('NameCoder', () => {
   describe('valid', () => {
-    for (let [title, ens] of [
-      ['empty', ''],
+    for (const [title, ens = title] of [
+      [''],
       ['a.bb.ccc.dddd.eeeee'],
       ['1x255', '1'.repeat(255)],
       ['1x300', '1'.repeat(300)],
-      [`[${'1'.repeat(64)}]`],
-      ['mixed', `${'1'.repeat(300)}.[${'1'.repeat(64)}].eth`],
+      ['hashed("eth")', forceHashedLabel('eth')],
+      ['mixed', `1.${'1'.repeat(300)}.[${'1'.repeat(64)}].eth`],
     ]) {
-      ens ??= title
-      it(title, async () => {
+      it(fmt(title), async () => {
         const F = await loadFixture(fixture)
         const dns = dnsEncodeName(ens)
         await expect(F.read.encode([ens]), 'encode').resolves.toStrictEqual(dns)
@@ -49,7 +57,22 @@ describe('NameCoder', () => {
   })
 
   describe('prevLabel()', () => {
-    it('offset = name.length is <root>', async () => {
+    it('0 reverts', async () => {
+      const F = await loadFixture(fixture)
+      await expect(F)
+        .read('prevLabel', [dnsEncodeName(''), 0n])
+        .toBeRevertedWithCustomError('DNSDecodingFailed')
+    })
+
+    it('name.length+1 reverts', async () => {
+      const F = await loadFixture(fixture)
+      const dns = dnsEncodeName('')
+      await expect(F)
+        .read('prevLabel', [dns, BigInt(dns.length + 1)])
+        .toBeRevertedWithCustomError('DNSDecodingFailed')
+    })
+
+    it('name.length is <root>', async () => {
       const F = await loadFixture(fixture)
       const dns = dnsEncodeName('eth')
       const offset = BigInt(size(dns))
@@ -64,7 +87,7 @@ describe('NameCoder', () => {
       ).resolves.toStrictEqual([0, offset])
     })
 
-    it('offset = name.length-1 is <tld>', async () => {
+    it('name.length-1 is <tld>', async () => {
       const F = await loadFixture(fixture)
       const namespace = 'a.b.c.'
       const tld = 'eth'
@@ -80,13 +103,6 @@ describe('NameCoder', () => {
         F.read.readLabel([dns, prev, true]),
         'readLabel',
       ).resolves.toStrictEqual([keccak256(v), offset, v.length, false])
-    })
-
-    it('offset = 0 reverts', async () => {
-      const F = await loadFixture(fixture)
-      await expect(F)
-        .read('prevLabel', [dnsEncodeName(''), 0n])
-        .toBeRevertedWithCustomError('DNSDecodingFailed')
     })
   })
 
@@ -143,5 +159,63 @@ describe('NameCoder', () => {
         .read('decode', [toHex('\x03a.b\x00')])
         .toBeRevertedWithCustomError('DNSDecodingFailed')
     })
+  })
+
+  describe('matchSuffix()', () => {
+    function testNoMatch(name: string, suffix: string) {
+      it(`no match: ${fmt(name)} / ${fmt(suffix)}`, async () => {
+        const F = await loadFixture(fixture)
+        await expect(
+          F.read.matchSuffix([dnsEncodeName(name), 0n, namehash(suffix)]),
+        ).resolves.toStrictEqual([false, namehash(name), 0n])
+      })
+    }
+
+    function testMatch(
+      name: string,
+      suffix = name,
+      nameTitle = name,
+      suffixTitle = suffix,
+    ) {
+      it(`match: ${fmt(nameTitle)} / ${fmt(suffixTitle)}`, async () => {
+        const F = await loadFixture(fixture)
+        const nodeSuffix = namehash(suffix)
+        let temp = name
+        while (namehash(temp) !== nodeSuffix) {
+          if (!temp) throw new Error('expected match')
+          temp = getParentName(temp)
+        }
+        const offset = BigInt(
+          size(dnsEncodeName(name)) - size(dnsEncodeName(temp)),
+        )
+        await expect(
+          F.read.matchSuffix([dnsEncodeName(name), 0n, namehash(suffix)]),
+        ).resolves.toStrictEqual([true, namehash(name), offset])
+      })
+    }
+
+    testNoMatch('test.eth', 'com')
+    testNoMatch('a', 'b')
+    testNoMatch('a', 'a.b')
+    testNoMatch('a', 'b.a')
+
+    testMatch('')
+    testMatch('eth')
+    testMatch('a.b.c')
+
+    testMatch('test.eth', 'eth')
+    testMatch('a.b.c.com', 'com')
+    testMatch('test.xyz', 'xyz')
+
+    testMatch('a.b.c.d', 'b.c.d')
+    testMatch('a.b.c.d', 'c.d')
+    testMatch('a.b.c.d', 'd')
+    testMatch('a.b.c.d', '')
+
+    testMatch('1'.repeat(300), undefined, '1^300', '1^300')
+    testMatch('2'.repeat(300), forceHashedLabel('2'.repeat(300)), '2^300')
+    testMatch('3.eth', forceHashedLabel('eth'))
+    testMatch(`4.${forceHashedLabel('eth')}`, 'eth')
+    testMatch(`5.${forceHashedLabel('test')}.eth`, 'test.eth')
   })
 })

--- a/test/utils/TestNameCoder.ts
+++ b/test/utils/TestNameCoder.ts
@@ -167,7 +167,7 @@ describe('NameCoder', () => {
         const F = await loadFixture(fixture)
         await expect(
           F.read.matchSuffix([dnsEncodeName(name), 0n, namehash(suffix)]),
-        ).resolves.toStrictEqual([false, namehash(name), 0n])
+        ).resolves.toStrictEqual([false, namehash(name), 0n, 0n])
       })
     }
 
@@ -180,17 +180,21 @@ describe('NameCoder', () => {
       it(`match: ${fmt(nameTitle)} / ${fmt(suffixTitle)}`, async () => {
         const F = await loadFixture(fixture)
         const nodeSuffix = namehash(suffix)
-        let temp = name
-        while (namehash(temp) !== nodeSuffix) {
-          if (!temp) throw new Error('expected match')
-          temp = getParentName(temp)
+        let prev = name
+        let match = name
+        while (namehash(match) !== nodeSuffix) {
+          if (!match) throw new Error('expected match')
+          prev = match
+          match = getParentName(match)
         }
-        const offset = BigInt(
-          size(dnsEncodeName(name)) - size(dnsEncodeName(temp)),
-        )
         await expect(
           F.read.matchSuffix([dnsEncodeName(name), 0n, namehash(suffix)]),
-        ).resolves.toStrictEqual([true, namehash(name), offset])
+        ).resolves.toStrictEqual([
+          true,
+          namehash(name),
+          BigInt(size(dnsEncodeName(name)) - size(dnsEncodeName(prev))),
+          BigInt(size(dnsEncodeName(name)) - size(dnsEncodeName(match))),
+        ])
       })
     }
 
@@ -217,5 +221,28 @@ describe('NameCoder', () => {
     testMatch('3.eth', forceHashedLabel('eth'))
     testMatch(`4.${forceHashedLabel('eth')}`, 'eth')
     testMatch(`5.${forceHashedLabel('test')}.eth`, 'test.eth')
+
+    describe('nonzero offset', () => {
+      it('no match', async () => {
+        const F = await loadFixture(fixture)
+        await expect(
+          F.read.matchSuffix([dnsEncodeName('a.b.c.eth'), 4n, namehash('xyz')]),
+        ).resolves.toStrictEqual([false, namehash('c.eth'), 0n, 0n])
+      })
+
+      it('exact exact', async () => {
+        const F = await loadFixture(fixture)
+        await expect(
+          F.read.matchSuffix([dnsEncodeName('a.b.c.eth'), 6n, namehash('eth')]),
+        ).resolves.toStrictEqual([true, namehash('eth'), 6n, 6n])
+      })
+
+      it('match', async () => {
+        const F = await loadFixture(fixture)
+        await expect(
+          F.read.matchSuffix([dnsEncodeName('a.b.c.eth'), 2n, namehash('eth')]),
+        ).resolves.toStrictEqual([true, namehash('b.c.eth'), 4n, 6n])
+      })
+    })
   })
 })


### PR DESCRIPTION
- added [nextLabel()](https://github.com/ensdomains/ens-contracts/blob/fix/namecoder-iter/contracts/utils/NameCoder.sol) and `prevLabel()`
- added `namehash(bytes32, bytes32) returns (bytes32)`
- added `readLabel()` w/optional hashed label support
- added `matchSuffix()` from `namechain/`
- moved "junk at end" revert from `namehash()` to `nextLabel()`
- added [more tests](https://github.com/ensdomains/ens-contracts/blob/fix/namecoder-iter/test/utils/TestNameCoder.ts)
- changed `RegistryUtils.findResolver()` to use `NameCoder.namehash()`