### PR TITLE
Make `IDNSGateway` Importable

### DIFF
--- a/contracts/dnsregistrar/OffchainDNSResolver.sol
+++ b/contracts/dnsregistrar/OffchainDNSResolver.sol
@@ -1,34 +1,22 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.4;
 
+import {Address} from "@openzeppelin/contracts/utils/Address.sol";
+import {ERC165, IERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
+
 import "../../contracts/resolvers/profiles/IAddrResolver.sol";
 import "../../contracts/resolvers/profiles/IExtendedResolver.sol";
 import "../../contracts/resolvers/profiles/IExtendedDNSResolver.sol";
-import "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import "../dnssec-oracle/DNSSEC.sol";
 import "../dnssec-oracle/RRUtils.sol";
 import "../registry/ENSRegistry.sol";
 import "../utils/HexUtils.sol";
 import "../utils/BytesUtils.sol";
-
-import {Address} from "@openzeppelin/contracts/utils/Address.sol";
+import {IDNSGateway} from "../dnssec-oracle/IDNSGateway.sol";
+import {OffchainLookup} from "../ccipRead/EIP3668.sol";
 import {LowLevelCallUtils} from "../utils/LowLevelCallUtils.sol";
 
 error InvalidOperation();
-error OffchainLookup(
-    address sender,
-    string[] urls,
-    bytes callData,
-    bytes4 callbackFunction,
-    bytes extraData
-);
-
-interface IDNSGateway {
-    function resolve(
-        bytes memory name,
-        uint16 qtype
-    ) external returns (DNSSEC.RRSetWithSignature[] memory);
-}
 
 uint16 constant CLASS_INET = 1;
 uint16 constant TYPE_TXT = 16;

--- a/contracts/dnssec-oracle/IDNSGateway.sol
+++ b/contracts/dnssec-oracle/IDNSGateway.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {DNSSEC} from "./DNSSEC.sol";
+
+/// @notice Interface for the offchain DNSSEC oracle gateway.
+/// @dev Interface selector: `0x31b137b9`
+interface IDNSGateway {
+    /// @param name The DNS-encoded name.
+    /// @param qtype The DNS record query type.
+    /// @return The list of verifiable DNS resource records.
+    function resolve(
+        bytes memory name,
+        uint16 qtype
+    ) external returns (DNSSEC.RRSetWithSignature[] memory);
+}

--- a/contracts/dnssec-oracle/IDNSGateway.sol
+++ b/contracts/dnssec-oracle/IDNSGateway.sol
@@ -4,11 +4,13 @@ pragma solidity ^0.8.0;
 import {DNSSEC} from "./DNSSEC.sol";
 
 /// @notice Interface for the offchain DNSSEC oracle gateway.
+///         https://docs.ens.domains/ensip/17#dnssec-gateway-api
 /// @dev Interface selector: `0x31b137b9`
 interface IDNSGateway {
+    /// @dev Fetch verifiable DNSSEC resource records of a specific type for a name.
     /// @param name The DNS-encoded name.
-    /// @param qtype The DNS record query type.
-    /// @return The list of verifiable DNS resource records.
+    /// @param qtype The DNS record query type according to RFC-1034.
+    /// @return The list of verifiable DNS resource records according to RFC-4035.
     function resolve(
         bytes memory name,
         uint16 qtype


### PR DESCRIPTION
- moved  `IDNSGateway` to [IDNSGateway.sol](https://github.com/ensdomains/ens-contracts/blob/fix/dns-gateway-import/contracts/dnssec-oracle/IDNSGateway.sol)
- adjusted [OffchainDNSResolver.sol](https://github.com/ensdomains/ens-contracts/blob/fix/dns-gateway-import/contracts/dnsregistrar/OffchainDNSResolver.sol) imports