### PR TITLE
Fix `NameCoder.nextLabel()`

### DIFF
--- a/contracts/utils/NameCoder.sol
+++ b/contracts/utils/NameCoder.sol
@@ -60,11 +60,10 @@ library NameCoder {
                 revert DNSDecodingFailed(name);
             }
             size = uint8(name[offset]);
-            ++offset;
-            if ((size == 0) != (offset == name.length)) {
+            nextOffset = offset + 1 + size;
+            if (size > 0 ? nextOffset >= name.length : nextOffset != name.length) {
                 revert DNSDecodingFailed(name);
             }
-            nextOffset = offset + size;
         }
     }
 

--- a/test/utils/TestNameCoder.test.ts
+++ b/test/utils/TestNameCoder.test.ts
@@ -141,13 +141,26 @@ describe('NameCoder', () => {
   })
 
   describe('decode() failure', () => {
-    for (const dns of ['0x', '0x02', '0x0000', '0x0100'] as const) {
+    for (const dns of [
+      '0x',
+      '0x0000',
+      '0x0100',
+      '0x02',
+      '0x0200',
+      '0x020000',
+    ] as const) {
       it(dns, async () => {
         const F = await loadFixture()
         await expect(F.read.decode([dns])).toBeRevertedWithCustomError(
           'DNSDecodingFailed',
         )
         await expect(F.read.namehash([dns, 0n])).toBeRevertedWithCustomError(
+          'DNSDecodingFailed',
+        )
+        await expect(F.read.nextLabel([dns, 0n])).toBeRevertedWithCustomError(
+          'DNSDecodingFailed',
+        )
+        await expect(F.read.firstLabel([dns])).toBeRevertedWithCustomError(
           'DNSDecodingFailed',
         )
       })
@@ -222,11 +235,6 @@ describe('NameCoder', () => {
       await expect(
         F.read.firstLabel([dnsEncodeName('')]),
       ).toBeRevertedWithCustomError('LabelIsEmpty')
-    })
-
-    it(`invalid encoding does not revert`, async () => {
-      const F = await loadFixture()
-      await expect(F.read.firstLabel(['0x0161'])).resolves.toEqual('a')
     })
   })
 


### PR DESCRIPTION
- restored logic before https://github.com/ensdomains/ens-contracts/pull/489 
- added missing tests