### PR TITLE
Add `IExtendedDNSResolver` to `ResolverCaller`

### DIFF
--- a/contracts/universalResolver/ResolverCaller.sol
+++ b/contracts/universalResolver/ResolverCaller.sol
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.17;
 
-import {ERC165Checker} from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
+import {
+    ERC165Checker
+} from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
 
 import {CCIPBatcher} from "../ccipRead/CCIPBatcher.sol";
 import {BytesUtils} from "../utils/BytesUtils.sol";
@@ -10,6 +12,9 @@ import {ResolverFeatures} from "../resolvers/ResolverFeatures.sol";
 
 // resolver profiles
 import {IExtendedResolver} from "../resolvers/profiles/IExtendedResolver.sol";
+import {
+    IExtendedDNSResolver
+} from "../resolvers/profiles/IExtendedDNSResolver.sol";
 import {IMulticallable} from "../resolvers/IMulticallable.sol";
 
 abstract contract ResolverCaller is CCIPBatcher {
@@ -20,38 +25,46 @@ abstract contract ResolverCaller is CCIPBatcher {
 
     /// @notice Perform forward resolution.
     ///
-    /// If ENSIP-22 is supported, performs a direct call.
     /// Call this function with `ccipRead()` to intercept the response.
+    /// Supports extended (`IExtendedDNSResolver` and `IExtendedResolver`) and immediate resolvers.
     ///
-    /// 1. if `IExtendedResolver`, `resolver.resolve(name, calldata)`.
-    /// 2. otherwise, `resolver.staticall(calldata)`.
-    ///
-    /// - If (1), the calldata is not `multicall()`, and the resolver supports features,
+    /// - If extended, the calldata is not `multicall()`, and the resolver supports ENSIP-22 features,
     ///   the call is performed directly without the batch gateway.
-    /// - If (1), the calldata is `multicall()`, and the resolver supports `RESOLVE_MULTICALL` feature,
+    /// - If extended, the calldata is `multicall()`, and the resolver supports `eth.ens.resolver.extended.multicall` feature,
     ///   the call is performed directly without the batch gateway.
     /// - Otherwise, the call is performed with the batch gateway.
-    ///   If the calldata is `multicall()`, it is disassembled, called separately, and reassembled.
+    ///   The batch gateway is only invoked if any call reverts `OffchainLookup`.
+    ///   If the calldata is `multicall()` it is disassembled, called separately, and reassembled.
     ///
     /// @dev Reverts `UnreachableName` if resolver is not a contract.
     /// @param resolver The resolver to call.
     /// @param name The DNS-encoded ENS name.
     /// @param data The calldata for the resolution.
+    /// @param hasContext True if `IExtendedDNSResolver` should be considered.
+    /// @param context The context for `IExtendedDNSResolver`.
     /// @param batchGateways The batch gateway URLs.
     function callResolver(
         address resolver,
         bytes memory name,
         bytes memory data,
+        bool hasContext,
+        bytes memory context,
         string[] memory batchGateways
     ) public view returns (bytes memory) {
         if (resolver.code.length == 0) {
             revert UnreachableName(name);
         }
         bool multi = bytes4(data) == IMulticallable.multicall.selector;
-        bool extended = ERC165Checker.supportsERC165InterfaceUnchecked(
-            resolver,
-            type(IExtendedResolver).interfaceId
-        );
+        bool extendedDNS = hasContext &&
+            ERC165Checker.supportsERC165InterfaceUnchecked(
+                resolver,
+                type(IExtendedDNSResolver).interfaceId
+            );
+        bool extended = extendedDNS ||
+            ERC165Checker.supportsERC165InterfaceUnchecked(
+                resolver,
+                type(IExtendedResolver).interfaceId
+            );
         if (
             ERC165Checker.supportsERC165InterfaceUnchecked(
                 resolver,
@@ -67,7 +80,7 @@ abstract contract ResolverCaller is CCIPBatcher {
                 // resolve() has the same return signature as callResolver()
                 ccipRead(
                     resolver,
-                    abi.encodeCall(IExtendedResolver.resolve, (name, data))
+                    _makeExtendedCall(extendedDNS, name, data, context)
                 );
             } else {
                 ccipRead(
@@ -91,9 +104,11 @@ abstract contract ResolverCaller is CCIPBatcher {
         }
         if (extended) {
             for (uint256 i; i < calls.length; ++i) {
-                calls[i] = abi.encodeCall(
-                    IExtendedResolver.resolve,
-                    (name, calls[i])
+                calls[i] = _makeExtendedCall(
+                    extendedDNS,
+                    name,
+                    calls[i],
+                    context
                 );
             }
         }
@@ -151,5 +166,21 @@ abstract contract ResolverCaller is CCIPBatcher {
             }
             return v;
         }
+    }
+
+    /// @dev Create extended resolver calldata.
+    function _makeExtendedCall(
+        bool extendedDNS,
+        bytes memory name,
+        bytes memory call,
+        bytes memory context
+    ) internal pure returns (bytes memory) {
+        return
+            extendedDNS
+                ? abi.encodeCall(
+                    IExtendedDNSResolver.resolve,
+                    (name, call, context)
+                )
+                : abi.encodeCall(IExtendedResolver.resolve, (name, call));
     }
 }

--- a/contracts/universalResolver/mocks/DummyShapeshiftResolver.sol
+++ b/contracts/universalResolver/mocks/DummyShapeshiftResolver.sol
@@ -73,10 +73,12 @@ contract DummyShapeshiftResolver is
         }
     }
 
-    function setOld() external {
-        isERC165 = false;
-        isExtended = false;
-        isExtendedDNS = false;
+    function setOld(bool x) external {
+        isERC165 = !x;
+        if (x) {
+            isExtended = false;
+            isExtendedDNS = false;
+        }
     }
 
     function setExtended(bool x) external {
@@ -140,7 +142,7 @@ contract DummyShapeshiftResolver is
     function resolve(
         bytes memory,
         bytes memory call
-    ) public view returns (bytes memory) {
+    ) external view returns (bytes memory) {
         if (!isExtended) {
             assembly {
                 return(0, 0)

--- a/contracts/universalResolver/mocks/DummyShapeshiftResolver.sol
+++ b/contracts/universalResolver/mocks/DummyShapeshiftResolver.sol
@@ -3,7 +3,12 @@ pragma solidity ^0.8.0;
 
 import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import {IERC7996} from "../../utils/IERC7996.sol";
-import {IExtendedResolver} from "../../resolvers/profiles/IExtendedResolver.sol";
+import {
+    IExtendedResolver
+} from "../../resolvers/profiles/IExtendedResolver.sol";
+import {
+    IExtendedDNSResolver
+} from "../../resolvers/profiles/IExtendedDNSResolver.sol";
 import {IMulticallable} from "../../resolvers/IMulticallable.sol";
 import {OffchainLookup} from "../../ccipRead/EIP3668.sol";
 import {BytesUtils} from "../../utils/BytesUtils.sol";
@@ -11,7 +16,12 @@ import {BytesUtils} from "../../utils/BytesUtils.sol";
 /// @dev This resolver can perform all resolver permutations.
 ///      When this contract triggers OffchainLookup(), it uses a data-url, so no server is required.
 ///      The actual response is set using `setResponse()`.
-contract DummyShapeshiftResolver is IExtendedResolver, IERC165, IERC7996 {
+contract DummyShapeshiftResolver is
+    IExtendedResolver,
+    IExtendedDNSResolver,
+    IERC165,
+    IERC7996
+{
     // https://github.com/ensdomains/ensips/pull/18
     error UnsupportedResolverProfile(bytes4 call);
 
@@ -21,6 +31,7 @@ contract DummyShapeshiftResolver is IExtendedResolver, IERC165, IERC7996 {
     uint256 public featureCount;
     bool public isERC165 = true; // default
     bool public isExtended;
+    bool public isExtendedDNS;
     bool public isOffchain;
     bool public revertUnsupported;
     bool public revertEmpty;
@@ -65,11 +76,17 @@ contract DummyShapeshiftResolver is IExtendedResolver, IERC165, IERC7996 {
     function setOld() external {
         isERC165 = false;
         isExtended = false;
+        isExtendedDNS = false;
     }
 
     function setExtended(bool x) external {
-        isERC165 = true;
         isExtended = x;
+        if (x) isERC165 = true;
+    }
+
+    function setExtendedDNS(bool x) external {
+        isExtendedDNS = x;
+        if (x) isERC165 = true;
     }
 
     function setOffchain(bool x) external {
@@ -86,7 +103,7 @@ contract DummyShapeshiftResolver is IExtendedResolver, IERC165, IERC7996 {
 
     fallback() external {
         if (msg.data.length < 4) return;
-        if (isExtended) return;
+        if (isExtended || isExtendedDNS) return;
         bytes memory v = getResponse(msg.data);
         if (v.length == 0) {
             if (revertEmpty) {
@@ -111,7 +128,8 @@ contract DummyShapeshiftResolver is IExtendedResolver, IERC165, IERC7996 {
         }
         return
             type(IERC165).interfaceId == x ||
-            (type(IExtendedResolver).interfaceId == x && isExtended) ||
+            (isExtended && type(IExtendedResolver).interfaceId == x) ||
+            (isExtendedDNS && type(IExtendedDNSResolver).interfaceId == x) ||
             (type(IERC7996).interfaceId == x && featureCount > 0);
     }
 
@@ -122,7 +140,31 @@ contract DummyShapeshiftResolver is IExtendedResolver, IERC165, IERC7996 {
     function resolve(
         bytes memory,
         bytes memory call
+    ) public view returns (bytes memory) {
+        if (!isExtended) {
+            assembly {
+                return(0, 0)
+            }
+        }
+        bytes memory v = getResponse(call);
+        if (v.length == 0 && revertUnsupported) {
+            revert UnsupportedResolverProfile(bytes4(call));
+        }
+        if (isOffchain) _revertOffchain(v);
+        _revertIfError(v);
+        return v;
+    }
+
+    function resolve(
+        bytes memory,
+        bytes memory call,
+        bytes memory
     ) external view returns (bytes memory) {
+        if (!isExtendedDNS) {
+            assembly {
+                return(0, 0)
+            }
+        }
         bytes memory v = getResponse(call);
         if (v.length == 0 && revertUnsupported) {
             revert UnsupportedResolverProfile(bytes4(call));
@@ -149,7 +191,7 @@ contract DummyShapeshiftResolver is IExtendedResolver, IERC165, IERC7996 {
         bytes memory v
     ) external view returns (bytes memory) {
         _revertIfError(v);
-        if (isExtended) return v;
+        if (isExtended || isExtendedDNS) return v;
         assembly {
             return(add(v, 32), mload(v))
         }

--- a/test/reverseResolver/TestETHReverseResolver.ts
+++ b/test/reverseResolver/TestETHReverseResolver.ts
@@ -87,7 +87,7 @@ const sources = {
         name: getReverseName(account.address),
         primary: { value: name },
       })
-      await F.shapeshift.write.setOld()
+      await F.shapeshift.write.setOld([true])
       await F.shapeshift.write.setResponse([res.call, res.answer])
       await F.claimV1(account.address)
     },

--- a/test/universalResolver/TestResolverCaller.test.ts
+++ b/test/universalResolver/TestResolverCaller.test.ts
@@ -35,7 +35,7 @@ describe('ResolverCaller', () => {
     for (const offchain of [false, true]) {
       for (const type of ['extended', 'extendedDNS', 'immediate', 'old'] as const) {
         for (const feature of [false, true]) {
-          if (type === 'old' && (multi || offchain || feature)) continue;
+          if (type === 'old' && (offchain || feature)) continue;
           let title = `${offchain ? 'offchain' : 'onchain'} ${type}`
           if (multi) title += ' w/multicall'
           if (feature) title += ' w/feature'

--- a/test/universalResolver/TestResolverCaller.test.ts
+++ b/test/universalResolver/TestResolverCaller.test.ts
@@ -33,8 +33,9 @@ async function fixture() {
 describe('ResolverCaller', () => {
   for (const multi of [false, true]) {
     for (const offchain of [false, true]) {
-      for (const type of ['extended', 'extendedDNS', 'immediate'] as const) {
+      for (const type of ['extended', 'extendedDNS', 'immediate', 'old'] as const) {
         for (const feature of [false, true]) {
+          if (type === 'old' && (multi || offchain || feature)) continue;
           let title = `${offchain ? 'offchain' : 'onchain'} ${type}`
           if (multi) title += ' w/multicall'
           if (feature) title += ' w/feature'
@@ -50,6 +51,7 @@ describe('ResolverCaller', () => {
               ],
               texts: [{ key: 'url', value: 'https://ens.domains' }],
             }
+            await F.ssResolver.write.setOld([type === 'old'])
             await F.ssResolver.write.setExtended([type === 'extended'])
             await F.ssResolver.write.setExtendedDNS([type === 'extendedDNS'])
             await F.ssResolver.write.setOffchain([offchain])
@@ -69,7 +71,7 @@ describe('ResolverCaller', () => {
               dnsEncodeName(kp.name),
               bundle.call,
               type === 'extendedDNS',
-              '0x1234',
+              '0x1234', // context
               ['x-batch-gateway:true'],
             ])
             bundle.expect(answer)

--- a/test/universalResolver/TestResolverCaller.test.ts
+++ b/test/universalResolver/TestResolverCaller.test.ts
@@ -33,11 +33,9 @@ async function fixture() {
 describe('ResolverCaller', () => {
   for (const multi of [false, true]) {
     for (const offchain of [false, true]) {
-      for (const extended of [false, true]) {
+      for (const type of ['extended', 'extendedDNS', 'immediate'] as const) {
         for (const feature of [false, true]) {
-          let title = `${offchain ? 'offchain' : 'onchain'} ${
-            extended ? 'extended' : 'immediate'
-          }`
+          let title = `${offchain ? 'offchain' : 'onchain'} ${type}`
           if (multi) title += ' w/multicall'
           if (feature) title += ' w/feature'
           it(title, async () => {
@@ -52,7 +50,8 @@ describe('ResolverCaller', () => {
               ],
               texts: [{ key: 'url', value: 'https://ens.domains' }],
             }
-            await F.ssResolver.write.setExtended([extended])
+            await F.ssResolver.write.setExtended([type === 'extended'])
+            await F.ssResolver.write.setExtendedDNS([type === 'extendedDNS'])
             await F.ssResolver.write.setOffchain([offchain])
             await F.ssResolver.write.setDeriveMulticall([multi])
             await F.ssResolver.write.setFeature([
@@ -69,6 +68,8 @@ describe('ResolverCaller', () => {
               F.ssResolver.address,
               dnsEncodeName(kp.name),
               bundle.call,
+              type === 'extendedDNS',
+              '0x1234',
               ['x-batch-gateway:true'],
             ])
             bundle.expect(answer)


### PR DESCRIPTION
- added `IExtendedDNSResolver` support to `ResolverCaller`
- updated  `DummyShapeshiftResolver`
     * added `setExtendedDNS()`
     * changed `setOld()` to `setOld(bool)`
- updated tests
     * call `IExtendedDNSResolver` resolver
     * call old resolver

---

This reduces the need for a custom `ResolverCaller` implementation in `DNSTLDResolver` (which is just `ResolverCaller` + `IExtendedDNSResolver`).

A future refactor could probably merge `AbstractUniversalResolver` and `ResolverCaller` into one, which means there's a single implementation for calling all resolver types used by all core resolver contracts (UR has different errors and the return type includes the resolver address.)