### PR TITLE
Add RegistrarSecurityController and RootSecurityController for security council access

### DIFF
--- a/contracts/ethregistrar/RegistrarSecurityController.sol
+++ b/contracts/ethregistrar/RegistrarSecurityController.sol
@@ -1,123 +1,52 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.4;
 
-import "./BaseRegistrarImplementation.sol";
-import "@openzeppelin/contracts/access/Ownable.sol";
+import {BaseRegistrarImplementation} from "./BaseRegistrarImplementation.sol";
+import {Controllable} from "../root/Controllable.sol";
+import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
-/**
- * @title RegistrarSecurityController
- * @notice Break-glass controller for the base registrar.
- * @dev Acts as a pass-through for the base registrar, but with the ability for
- *      security controllers to disable registrar controllers.
- */
-contract RegistrarSecurityController is Ownable {
-    bytes4 private constant INTERFACE_META_ID =
-        bytes4(keccak256("supportsInterface(bytes4)"));
+/// @title RegistrarSecurityController
+/// @notice Break-glass controller for the base registrar.
+/// @dev Acts as a pass-through for the base registrar, but with the ability for
+///      security controllers to disable registrar controllers.
+contract RegistrarSecurityController is Controllable, ERC165 {
 
-    /**
-     * @notice Emitted when a security controller is added.
-     * @param controller The security controller address.
-     */
-    event ControllerAdded(address indexed controller);
-    /**
-     * @notice Emitted when a security controller is removed.
-     * @param controller The security controller address.
-     */
-    event ControllerRemoved(address indexed controller);
-
-    /**
-     * @notice Security controllers authorized to disable registrar controllers.
-     * @dev These addresses can call `disableRegistrarController`.
-     */
-    mapping(address => bool) public controllers;
-
-    /**
-     * @notice The registrar this controller manages.
-     */
+    /// @notice The registrar this controller manages.
     BaseRegistrarImplementation public registrar;
 
-    /**
-     * @dev Restricts actions to security controllers.
-     */
-    modifier onlyController() {
-        require(controllers[msg.sender]);
-        _;
-    }
-
-    /**
-     * @param _registrar The base registrar to manage.
-     */
+    /// @param _registrar The base registrar to manage.
     constructor(BaseRegistrarImplementation _registrar) {
         registrar = _registrar;
     }
 
-    /**
-     * @notice Authorizes a security controller.
-     * @param controller The security controller address.
-     */
-    function addController(address controller) external onlyOwner {
-        controllers[controller] = true;
-        emit ControllerAdded(controller);
-    }
-
-    /**
-     * @notice Revokes a security controller.
-     * @param controller The security controller address.
-     */
-    function removeController(address controller) external onlyOwner {
-        controllers[controller] = false;
-        emit ControllerRemoved(controller);
-    }
-
-    /**
-     * @notice Grants registrar controller permissions.
-     * @param controller The registrar controller to add.
-     */
+    /// @notice Grants registrar controller permissions.
+    /// @param controller The registrar controller to add.
     function addRegistrarController(address controller) external onlyOwner {
         registrar.addController(controller);
     }
 
-    /**
-     * @notice Revokes registrar controller permissions.
-     * @param controller The registrar controller to remove.
-     */
+    /// @notice Revokes registrar controller permissions.
+    /// @param controller The registrar controller to remove.
     function removeRegistrarController(address controller) external onlyOwner {
         registrar.removeController(controller);
     }
 
-    /**
-     * @notice Sets the registrar's resolver for the base node.
-     * @param resolver The resolver address to set.
-     */
+    /// @notice Sets the registrar's resolver for the base node.
+    /// @param resolver The resolver address to set.
     function setRegistrarResolver(address resolver) external onlyOwner {
         registrar.setResolver(resolver);
     }
 
-    /**
-     * @notice Transfers ownership of the registrar.
-     * @param newOwner The new owner for the registrar.
-     */
+    /// @notice Transfers ownership of the registrar.
+    /// @param newOwner The new owner for the registrar.
     function transferRegistrarOwnership(address newOwner) public virtual onlyOwner {
         registrar.transferOwnership(newOwner);
     }
 
-    /**
-     * @notice Removes a registrar controller in emergencies.
-     * @dev Callable only by security controllers.
-     * @param controller The registrar controller to remove.
-     */
+    /// @notice Removes a registrar controller in emergencies.
+    /// @dev Callable only by security controllers.
+    /// @param controller The registrar controller to remove.
     function disableRegistrarController(address controller) external onlyController {
         registrar.removeController(controller);
-    }
-
-    /**
-     * @notice ERC165 support for this controller.
-     * @param interfaceID The interface identifier to check.
-     * @return True if the interface is supported.
-     */
-    function supportsInterface(
-        bytes4 interfaceID
-    ) external pure returns (bool) {
-        return interfaceID == INTERFACE_META_ID;
     }
 }

--- a/contracts/ethregistrar/RegistrarSecurityController.sol
+++ b/contracts/ethregistrar/RegistrarSecurityController.sol
@@ -1,0 +1,64 @@
+pragma solidity ^0.8.4;
+
+import "./BaseRegistrarImplementation.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+contract RegistrarSecurityController is Ownable {
+    bytes4 private constant INTERFACE_META_ID =
+        bytes4(keccak256("supportsInterface(bytes4)"));
+
+    event ControllerAdded(address indexed controller);
+    event ControllerRemoved(address indexed controller);
+
+    // A map of addresses that are authorised to call `disableRegistrarController`.
+    mapping(address => bool) public controllers;
+
+    BaseRegistrarImplementation public registrar;
+
+    modifier onlyController() {
+        require(controllers[msg.sender]);
+        _;
+    }
+
+    constructor(BaseRegistrarImplementation _registrar) {
+        registrar = _registrar;
+    }
+
+    // Authorises a controller, who can register and renew domains.
+    function addController(address controller) external onlyOwner {
+        controllers[controller] = true;
+        emit ControllerAdded(controller);
+    }
+
+    // Revoke controller permission for an address.
+    function removeController(address controller) external onlyOwner {
+        controllers[controller] = false;
+        emit ControllerRemoved(controller);
+    }
+
+    function addRegistrarController(address controller) external onlyOwner {
+        registrar.addController(controller);
+    }
+
+    function removeRegistrarController(address controller) external onlyOwner {
+        registrar.removeController(controller);
+    }
+
+    function setRegistrarResolver(address resolver) external onlyOwner {
+        registrar.setResolver(resolver);
+    }
+
+    function transferRegistrarOwnership(address newOwner) public virtual onlyOwner {
+        registrar.transferOwnership(newOwner);
+    }
+
+    function disableRegistrarController(address controller) external onlyController {
+        registrar.removeController(controller);
+    }
+
+    function supportsInterface(
+        bytes4 interfaceID
+    ) external pure returns (bool) {
+        return interfaceID == INTERFACE_META_ID;
+    }
+}

--- a/contracts/ethregistrar/RegistrarSecurityController.sol
+++ b/contracts/ethregistrar/RegistrarSecurityController.sol
@@ -1,61 +1,120 @@
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.4;
 
 import "./BaseRegistrarImplementation.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 
+/**
+ * @title RegistrarSecurityController
+ * @notice Break-glass controller for the base registrar.
+ * @dev Acts as a pass-through for the base registrar, but with the ability for
+ *      security controllers to disable registrar controllers.
+ */
 contract RegistrarSecurityController is Ownable {
     bytes4 private constant INTERFACE_META_ID =
         bytes4(keccak256("supportsInterface(bytes4)"));
 
+    /**
+     * @notice Emitted when a security controller is added.
+     * @param controller The security controller address.
+     */
     event ControllerAdded(address indexed controller);
+    /**
+     * @notice Emitted when a security controller is removed.
+     * @param controller The security controller address.
+     */
     event ControllerRemoved(address indexed controller);
 
-    // A map of addresses that are authorised to call `disableRegistrarController`.
+    /**
+     * @notice Security controllers authorized to disable registrar controllers.
+     * @dev These addresses can call `disableRegistrarController`.
+     */
     mapping(address => bool) public controllers;
 
+    /**
+     * @notice The registrar this controller manages.
+     */
     BaseRegistrarImplementation public registrar;
 
+    /**
+     * @dev Restricts actions to security controllers.
+     */
     modifier onlyController() {
         require(controllers[msg.sender]);
         _;
     }
 
+    /**
+     * @param _registrar The base registrar to manage.
+     */
     constructor(BaseRegistrarImplementation _registrar) {
         registrar = _registrar;
     }
 
-    // Authorises a controller, who can register and renew domains.
+    /**
+     * @notice Authorizes a security controller.
+     * @param controller The security controller address.
+     */
     function addController(address controller) external onlyOwner {
         controllers[controller] = true;
         emit ControllerAdded(controller);
     }
 
-    // Revoke controller permission for an address.
+    /**
+     * @notice Revokes a security controller.
+     * @param controller The security controller address.
+     */
     function removeController(address controller) external onlyOwner {
         controllers[controller] = false;
         emit ControllerRemoved(controller);
     }
 
+    /**
+     * @notice Grants registrar controller permissions.
+     * @param controller The registrar controller to add.
+     */
     function addRegistrarController(address controller) external onlyOwner {
         registrar.addController(controller);
     }
 
+    /**
+     * @notice Revokes registrar controller permissions.
+     * @param controller The registrar controller to remove.
+     */
     function removeRegistrarController(address controller) external onlyOwner {
         registrar.removeController(controller);
     }
 
+    /**
+     * @notice Sets the registrar's resolver for the base node.
+     * @param resolver The resolver address to set.
+     */
     function setRegistrarResolver(address resolver) external onlyOwner {
         registrar.setResolver(resolver);
     }
 
+    /**
+     * @notice Transfers ownership of the registrar.
+     * @param newOwner The new owner for the registrar.
+     */
     function transferRegistrarOwnership(address newOwner) public virtual onlyOwner {
         registrar.transferOwnership(newOwner);
     }
 
+    /**
+     * @notice Removes a registrar controller in emergencies.
+     * @dev Callable only by security controllers.
+     * @param controller The registrar controller to remove.
+     */
     function disableRegistrarController(address controller) external onlyController {
         registrar.removeController(controller);
     }
 
+    /**
+     * @notice ERC165 support for this controller.
+     * @param interfaceID The interface identifier to check.
+     * @return True if the interface is supported.
+     */
     function supportsInterface(
         bytes4 interfaceID
     ) external pure returns (bool) {

--- a/contracts/root/RootSecurityController.sol
+++ b/contracts/root/RootSecurityController.sol
@@ -1,0 +1,30 @@
+pragma solidity ^0.8.4;
+
+import "./Root.sol";
+import "../registry/ENS.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+contract RootSecurityController is Ownable {
+    bytes32 private constant ROOT_NODE = bytes32(0);
+    bytes4 private constant INTERFACE_META_ID =
+        bytes4(keccak256("supportsInterface(bytes4)"));
+
+    Root public root;
+    ENS public ens;
+
+    constructor(Root _root) {
+        root = _root;
+        ens = _root.ens();
+    }
+
+    function disableTLD(bytes32 label) external onlyOwner {
+        root.setSubnodeOwner(label, address(this));
+        ens.setResolver(keccak256(abi.encodePacked(ROOT_NODE, label)), address(0));
+    }
+
+    function supportsInterface(
+        bytes4 interfaceID
+    ) external pure returns (bool) {
+        return interfaceID == INTERFACE_META_ID;
+    }
+}

--- a/contracts/root/RootSecurityController.sol
+++ b/contracts/root/RootSecurityController.sol
@@ -1,55 +1,33 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.4;
 
-import "./Root.sol";
-import "../registry/ENS.sol";
-import "@openzeppelin/contracts/access/Ownable.sol";
+import {Root} from "./Root.sol";
+import {ENS} from "../registry/ENS.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
-/**
- * @title RootSecurityController
- * @notice Break-glass controller for ENS root operations.
- * @dev Ownable contract that can disable a TLD and clear its resolver in
- *      emergencies.
- */
-contract RootSecurityController is Ownable {
+/// @title RootSecurityController
+/// @notice Break-glass controller for ENS root operations.
+/// @dev Ownable contract that can disable a TLD and clear its resolver in
+///      emergencies.
+contract RootSecurityController is Ownable, ERC165 {
     bytes32 private constant ROOT_NODE = bytes32(0);
-    bytes4 private constant INTERFACE_META_ID =
-        bytes4(keccak256("supportsInterface(bytes4)"));
 
-    /**
-     * @notice The root contract.
-     */
+    /// @notice The root contract.
     Root public root;
-    /**
-     * @notice The ENS registry.
-     */
+    /// @notice The ENS registry.
     ENS public ens;
 
-    /**
-     * @param _root The root contract to manage.
-     */
+    /// @param _root The root contract to manage.
     constructor(Root _root) {
         root = _root;
         ens = _root.ens();
     }
 
-    /**
-     * @notice Takes ownership of a TLD and clears its resolver.
-     * @param label The labelhash of the TLD to disable.
-     */
+    /// @notice Takes ownership of a TLD and clears its resolver.
+    /// @param label The labelhash of the TLD to disable.
     function disableTLD(bytes32 label) external onlyOwner {
         root.setSubnodeOwner(label, address(this));
         ens.setResolver(keccak256(abi.encodePacked(ROOT_NODE, label)), address(0));
-    }
-
-    /**
-     * @notice ERC165 support for this controller.
-     * @param interfaceID The interface identifier to check.
-     * @return True if the interface is supported.
-     */
-    function supportsInterface(
-        bytes4 interfaceID
-    ) external pure returns (bool) {
-        return interfaceID == INTERFACE_META_ID;
     }
 }

--- a/contracts/root/RootSecurityController.sol
+++ b/contracts/root/RootSecurityController.sol
@@ -1,27 +1,52 @@
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.4;
 
 import "./Root.sol";
 import "../registry/ENS.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 
+/**
+ * @title RootSecurityController
+ * @notice Break-glass controller for ENS root operations.
+ * @dev Ownable contract that can disable a TLD and clear its resolver in
+ *      emergencies.
+ */
 contract RootSecurityController is Ownable {
     bytes32 private constant ROOT_NODE = bytes32(0);
     bytes4 private constant INTERFACE_META_ID =
         bytes4(keccak256("supportsInterface(bytes4)"));
 
+    /**
+     * @notice The root contract.
+     */
     Root public root;
+    /**
+     * @notice The ENS registry.
+     */
     ENS public ens;
 
+    /**
+     * @param _root The root contract to manage.
+     */
     constructor(Root _root) {
         root = _root;
         ens = _root.ens();
     }
 
+    /**
+     * @notice Takes ownership of a TLD and clears its resolver.
+     * @param label The labelhash of the TLD to disable.
+     */
     function disableTLD(bytes32 label) external onlyOwner {
         root.setSubnodeOwner(label, address(this));
         ens.setResolver(keccak256(abi.encodePacked(ROOT_NODE, label)), address(0));
     }
 
+    /**
+     * @notice ERC165 support for this controller.
+     * @param interfaceID The interface identifier to check.
+     * @return True if the interface is supported.
+     */
     function supportsInterface(
         bytes4 interfaceID
     ) external pure returns (bool) {

--- a/test/ethregistrar/TestRegistrarSecurityController.test.ts
+++ b/test/ethregistrar/TestRegistrarSecurityController.test.ts
@@ -1,0 +1,253 @@
+import hre from 'hardhat'
+import { labelhash, namehash, zeroHash } from 'viem'
+
+import { getAccounts } from '../fixtures/utils.js'
+
+const connection = await hre.network.connect()
+const accounts = await getAccounts(connection)
+
+async function fixture() {
+  const ensRegistry = await connection.viem.deployContract('ENSRegistry', [])
+  const baseRegistrar = await connection.viem.deployContract(
+    'BaseRegistrarImplementation',
+    [ensRegistry.address, namehash('eth')],
+  )
+  const registrarSecurityController = await connection.viem.deployContract(
+    'RegistrarSecurityController',
+    [baseRegistrar.address],
+  )
+
+  await ensRegistry.write.setSubnodeOwner([
+    zeroHash,
+    labelhash('eth'),
+    baseRegistrar.address,
+  ])
+  await baseRegistrar.write.transferOwnership([
+    registrarSecurityController.address,
+  ])
+
+  return {
+    ensRegistry,
+    baseRegistrar,
+    registrarSecurityController,
+  }
+}
+const loadFixture = async () => connection.networkHelpers.loadFixture(fixture)
+
+describe('RegistrarSecurityController', () => {
+  it('initializes registrar reference', async () => {
+    const { baseRegistrar, registrarSecurityController } = await loadFixture()
+    await expect(
+      registrarSecurityController.read.registrar(),
+    ).resolves.toEqualAddress(baseRegistrar.address)
+  })
+
+  describe('disableRegistrarController', () => {
+    it('should remove controller access', async () => {
+      const { baseRegistrar, registrarSecurityController } =
+        await loadFixture()
+      const controller = accounts[1].address
+      const securityController = accounts[2]
+
+      await registrarSecurityController.write.addRegistrarController([
+        controller,
+      ])
+      await registrarSecurityController.write.addController([
+        securityController.address,
+      ])
+
+      await expect(
+        baseRegistrar.read.controllers([controller]),
+      ).resolves.toEqual(true)
+
+      await registrarSecurityController.write.disableRegistrarController(
+        [controller],
+        { account: securityController },
+      )
+
+      await expect(
+        baseRegistrar.read.controllers([controller]),
+      ).resolves.toEqual(false)
+    })
+
+    it('should revert when called by non-controller', async () => {
+      const { registrarSecurityController } = await loadFixture()
+      await expect(
+        registrarSecurityController.write.disableRegistrarController(
+          [accounts[1].address],
+          { account: accounts[1] },
+        ),
+      ).toBeRevertedWithoutReason()
+    })
+  })
+
+  describe('addController', () => {
+    it('should add controller access', async () => {
+      const { registrarSecurityController } = await loadFixture()
+      const controller = accounts[1].address
+
+      await registrarSecurityController.write.addController([controller])
+
+      await expect(
+        registrarSecurityController.read.controllers([controller]),
+      ).resolves.toEqual(true)
+    })
+
+    it('should revert when called by non-owner', async () => {
+      const { registrarSecurityController } = await loadFixture()
+      await expect(
+        registrarSecurityController.write.addController(
+          [accounts[1].address],
+          { account: accounts[1] },
+        ),
+      ).toBeRevertedWithString('Ownable: caller is not the owner')
+    })
+  })
+
+  describe('removeController', () => {
+    it('should remove controller access', async () => {
+      const { registrarSecurityController } = await loadFixture()
+      const controller = accounts[1].address
+
+      await registrarSecurityController.write.addController([controller])
+
+      await expect(
+        registrarSecurityController.read.controllers([controller]),
+      ).resolves.toEqual(true)
+
+      await registrarSecurityController.write.removeController([controller])
+
+      await expect(
+        registrarSecurityController.read.controllers([controller]),
+      ).resolves.toEqual(false)
+    })
+
+    it('should revert when called by non-owner', async () => {
+      const { registrarSecurityController } = await loadFixture()
+      await expect(
+        registrarSecurityController.write.removeController(
+          [accounts[1].address],
+          { account: accounts[1] },
+        ),
+      ).toBeRevertedWithString('Ownable: caller is not the owner')
+    })
+  })
+
+  describe('setRegistrarResolver', () => {
+    it('should set the resolver for the base node', async () => {
+      const { ensRegistry, registrarSecurityController } = await loadFixture()
+      const resolver = accounts[1].address
+
+      await registrarSecurityController.write.setRegistrarResolver([resolver])
+
+      await expect(
+        ensRegistry.read.resolver([namehash('eth')]),
+      ).resolves.toEqualAddress(resolver)
+    })
+
+    it('should revert when called by non-owner', async () => {
+      const { registrarSecurityController } = await loadFixture()
+      await expect(
+        registrarSecurityController.write.setRegistrarResolver(
+          [accounts[1].address],
+          { account: accounts[1] },
+        ),
+      ).toBeRevertedWithString('Ownable: caller is not the owner')
+    })
+  })
+
+  describe('addRegistrarController', () => {
+    it('should add registrar controller access', async () => {
+      const { baseRegistrar, registrarSecurityController } = await loadFixture()
+      const controller = accounts[1].address
+
+      await registrarSecurityController.write.addRegistrarController([
+        controller,
+      ])
+
+      await expect(
+        baseRegistrar.read.controllers([controller]),
+      ).resolves.toEqual(true)
+    })
+
+    it('should revert when called by non-owner', async () => {
+      const { registrarSecurityController } = await loadFixture()
+      await expect(
+        registrarSecurityController.write.addRegistrarController(
+          [accounts[1].address],
+          { account: accounts[1] },
+        ),
+      ).toBeRevertedWithString('Ownable: caller is not the owner')
+    })
+  })
+
+  describe('removeRegistrarController', () => {
+    it('should remove registrar controller access', async () => {
+      const { baseRegistrar, registrarSecurityController } = await loadFixture()
+      const controller = accounts[1].address
+
+      await registrarSecurityController.write.addRegistrarController([
+        controller,
+      ])
+      await registrarSecurityController.write.removeRegistrarController([
+        controller,
+      ])
+
+      await expect(
+        baseRegistrar.read.controllers([controller]),
+      ).resolves.toEqual(false)
+    })
+
+    it('should revert when called by non-owner', async () => {
+      const { registrarSecurityController } = await loadFixture()
+      await expect(
+        registrarSecurityController.write.removeRegistrarController(
+          [accounts[1].address],
+          { account: accounts[1] },
+        ),
+      ).toBeRevertedWithString('Ownable: caller is not the owner')
+    })
+  })
+
+  describe('transferRegistrarOwnership', () => {
+    it('should transfer registrar ownership', async () => {
+      const { baseRegistrar, registrarSecurityController } = await loadFixture()
+      const newOwner = accounts[1].address
+      await registrarSecurityController.write.transferRegistrarOwnership([
+        newOwner,
+      ])
+
+      await expect(baseRegistrar.read.owner()).resolves.toEqualAddress(newOwner)
+    })
+
+    it('should revert when called by non-owner', async () => {
+      const { registrarSecurityController } = await loadFixture()
+      await expect(
+        registrarSecurityController.write.transferRegistrarOwnership(
+          [accounts[1].address],
+          {
+            account: accounts[1],
+          },
+        ),
+      ).toBeRevertedWithString('Ownable: caller is not the owner')
+    })
+  })
+
+  describe('supportsInterface', () => {
+    it('should support ERC165', async () => {
+      const { registrarSecurityController } = await loadFixture()
+
+      await expect(
+        registrarSecurityController.read.supportsInterface(['0x01ffc9a7']),
+      ).resolves.toEqual(true)
+    })
+
+    it('should return false for unknown interface', async () => {
+      const { registrarSecurityController } = await loadFixture()
+
+      await expect(
+        registrarSecurityController.read.supportsInterface(['0xffffffff']),
+      ).resolves.toEqual(false)
+    })
+  })
+})

--- a/test/ethregistrar/TestRegistrarSecurityController.test.ts
+++ b/test/ethregistrar/TestRegistrarSecurityController.test.ts
@@ -1,3 +1,4 @@
+import { shouldSupportInterfaces } from '@ensdomains/hardhat-chai-matchers-viem/behaviour'
 import hre from 'hardhat'
 import { labelhash, namehash, zeroHash } from 'viem'
 
@@ -35,6 +36,11 @@ async function fixture() {
 const loadFixture = async () => connection.networkHelpers.loadFixture(fixture)
 
 describe('RegistrarSecurityController', () => {
+  shouldSupportInterfaces({
+    contract: () => loadFixture().then((F) => F.registrarSecurityController),
+    interfaces: ['IERC165'],
+  })
+
   it('initializes registrar reference', async () => {
     const { baseRegistrar, registrarSecurityController } = await loadFixture()
     await expect(
@@ -52,8 +58,9 @@ describe('RegistrarSecurityController', () => {
       await registrarSecurityController.write.addRegistrarController([
         controller,
       ])
-      await registrarSecurityController.write.addController([
+      await registrarSecurityController.write.setController([
         securityController.address,
+        true,
       ])
 
       await expect(
@@ -77,59 +84,7 @@ describe('RegistrarSecurityController', () => {
           [accounts[1].address],
           { account: accounts[1] },
         ),
-      ).toBeRevertedWithoutReason()
-    })
-  })
-
-  describe('addController', () => {
-    it('should add controller access', async () => {
-      const { registrarSecurityController } = await loadFixture()
-      const controller = accounts[1].address
-
-      await registrarSecurityController.write.addController([controller])
-
-      await expect(
-        registrarSecurityController.read.controllers([controller]),
-      ).resolves.toEqual(true)
-    })
-
-    it('should revert when called by non-owner', async () => {
-      const { registrarSecurityController } = await loadFixture()
-      await expect(
-        registrarSecurityController.write.addController(
-          [accounts[1].address],
-          { account: accounts[1] },
-        ),
-      ).toBeRevertedWithString('Ownable: caller is not the owner')
-    })
-  })
-
-  describe('removeController', () => {
-    it('should remove controller access', async () => {
-      const { registrarSecurityController } = await loadFixture()
-      const controller = accounts[1].address
-
-      await registrarSecurityController.write.addController([controller])
-
-      await expect(
-        registrarSecurityController.read.controllers([controller]),
-      ).resolves.toEqual(true)
-
-      await registrarSecurityController.write.removeController([controller])
-
-      await expect(
-        registrarSecurityController.read.controllers([controller]),
-      ).resolves.toEqual(false)
-    })
-
-    it('should revert when called by non-owner', async () => {
-      const { registrarSecurityController } = await loadFixture()
-      await expect(
-        registrarSecurityController.write.removeController(
-          [accounts[1].address],
-          { account: accounts[1] },
-        ),
-      ).toBeRevertedWithString('Ownable: caller is not the owner')
+      ).toBeRevertedWithString('Controllable: Caller is not a controller')
     })
   })
 
@@ -233,21 +188,4 @@ describe('RegistrarSecurityController', () => {
     })
   })
 
-  describe('supportsInterface', () => {
-    it('should support ERC165', async () => {
-      const { registrarSecurityController } = await loadFixture()
-
-      await expect(
-        registrarSecurityController.read.supportsInterface(['0x01ffc9a7']),
-      ).resolves.toEqual(true)
-    })
-
-    it('should return false for unknown interface', async () => {
-      const { registrarSecurityController } = await loadFixture()
-
-      await expect(
-        registrarSecurityController.read.supportsInterface(['0xffffffff']),
-      ).resolves.toEqual(false)
-    })
-  })
 })

--- a/test/root/TestRootSecurityController.test.ts
+++ b/test/root/TestRootSecurityController.test.ts
@@ -1,0 +1,86 @@
+import hre from 'hardhat'
+import { labelhash, namehash, zeroAddress, zeroHash } from 'viem'
+
+import { getAccounts } from '../fixtures/utils.js'
+
+const connection = await hre.network.connect()
+const accounts = await getAccounts(connection)
+
+async function fixture() {
+  const ensRegistry = await connection.viem.deployContract('ENSRegistry', [])
+  const root = await connection.viem.deployContract('Root', [
+    ensRegistry.address,
+  ])
+  const rootSecurityController = await connection.viem.deployContract(
+    'RootSecurityController',
+    [root.address],
+  )
+
+  await ensRegistry.write.setOwner([zeroHash, root.address])
+  await root.write.setController([accounts[0].address, true])
+  await root.write.setController([rootSecurityController.address, true])
+
+  return { ensRegistry, root, rootSecurityController, accounts }
+}
+const loadFixture = async () => connection.networkHelpers.loadFixture(fixture)
+
+describe('RootSecurityController', () => {
+  it('initializes root and ens references', async () => {
+    const { ensRegistry, root, rootSecurityController } = await loadFixture()
+
+    await expect(rootSecurityController.read.root()).resolves.toEqualAddress(
+      root.address,
+    )
+    await expect(rootSecurityController.read.ens()).resolves.toEqualAddress(
+      ensRegistry.address,
+    )
+  })
+
+  describe('disableTLD', () => {
+    it('should take ownership and clear resolver', async () => {
+      const { ensRegistry, root, rootSecurityController } = await loadFixture()
+      const label = labelhash('eth')
+      const node = namehash('eth')
+
+      await root.write.setSubnodeOwner([label, accounts[0].address])
+      await ensRegistry.write.setResolver([node, accounts[1].address])
+
+      await rootSecurityController.write.disableTLD([label])
+
+      await expect(ensRegistry.read.owner([node])).resolves.toEqualAddress(
+        rootSecurityController.address,
+      )
+      await expect(ensRegistry.read.resolver([node])).resolves.toEqualAddress(
+        zeroAddress,
+      )
+    })
+
+    it('should revert when called by non-owner', async () => {
+      const { rootSecurityController } = await loadFixture()
+
+      await expect(
+        rootSecurityController.write.disableTLD([labelhash('eth')], {
+          account: accounts[1],
+        }),
+      ).toBeRevertedWithString('Ownable: caller is not the owner')
+    })
+  })
+
+  describe('supportsInterface', () => {
+    it('should support ERC165', async () => {
+      const { rootSecurityController } = await loadFixture()
+
+      await expect(
+        rootSecurityController.read.supportsInterface(['0x01ffc9a7']),
+      ).resolves.toEqual(true)
+    })
+
+    it('should return false for unknown interface', async () => {
+      const { rootSecurityController } = await loadFixture()
+
+      await expect(
+        rootSecurityController.read.supportsInterface(['0xffffffff']),
+      ).resolves.toEqual(false)
+    })
+  })
+})

--- a/test/root/TestRootSecurityController.test.ts
+++ b/test/root/TestRootSecurityController.test.ts
@@ -1,3 +1,4 @@
+import { shouldSupportInterfaces } from '@ensdomains/hardhat-chai-matchers-viem/behaviour'
 import hre from 'hardhat'
 import { labelhash, namehash, zeroAddress, zeroHash } from 'viem'
 
@@ -25,6 +26,11 @@ async function fixture() {
 const loadFixture = async () => connection.networkHelpers.loadFixture(fixture)
 
 describe('RootSecurityController', () => {
+  shouldSupportInterfaces({
+    contract: () => loadFixture().then((F) => F.rootSecurityController),
+    interfaces: ['IERC165'],
+  })
+
   it('initializes root and ens references', async () => {
     const { ensRegistry, root, rootSecurityController } = await loadFixture()
 
@@ -66,21 +72,4 @@ describe('RootSecurityController', () => {
     })
   })
 
-  describe('supportsInterface', () => {
-    it('should support ERC165', async () => {
-      const { rootSecurityController } = await loadFixture()
-
-      await expect(
-        rootSecurityController.read.supportsInterface(['0x01ffc9a7']),
-      ).resolves.toEqual(true)
-    })
-
-    it('should return false for unknown interface', async () => {
-      const { rootSecurityController } = await loadFixture()
-
-      await expect(
-        rootSecurityController.read.supportsInterface(['0xffffffff']),
-      ).resolves.toEqual(false)
-    })
-  })
 })


### PR DESCRIPTION
These contracts facilitate the security council immediately disabling a vulnerable registrar controller or TLD in case of compromise, so the DAO can act to fix and reinstate the vulnerable code later.