### PR TITLE
Fix NatSpec comment: improve setUpgradeContract documentation

### DIFF
--- a/contracts/wrapper/NameWrapper.sol
+++ b/contracts/wrapper/NameWrapper.sol
@@ -196,7 +196,7 @@ contract NameWrapper is
     }
 
     /**
-     * @notice Set the address of the upgradeContract of the contract. only admin can do this
+     * @notice Set the address of the upgradeContract. Only admin can do this.
      * @dev The default value of upgradeContract is the 0 address. Use the 0 address at any time
      * to make the contract not upgradable.
      * @param _upgradeAddress address of an upgraded contract


### PR DESCRIPTION
## Summary
- Fixed NatSpec comment in `contracts/wrapper/NameWrapper.sol`:
  - Removed redundant phrasing: "of the contract. only" -> ". Only"
  - Capitalized "Only" at the start of a new sentence
  - Original: "Set the address of the upgradeContract of the contract. only admin can do this"
  - Fixed: "Set the address of the upgradeContract. Only admin can do this."

## Test plan
- No functional changes, documentation fix only