### PR TITLE
Fix typo: 'whether not' -> 'whether' in NameWrapper.sol

### DIFF
--- a/contracts/wrapper/NameWrapper.sol
+++ b/contracts/wrapper/NameWrapper.sol
@@ -771,7 +771,7 @@ contract NameWrapper is
 
     /**
      * @notice Check whether a name can call setSubnodeOwner/setSubnodeRecord
-     * @dev Checks both CANNOT_CREATE_SUBDOMAIN and PARENT_CANNOT_CONTROL and whether not they have been burnt
+     * @dev Checks both CANNOT_CREATE_SUBDOMAIN and PARENT_CANNOT_CONTROL and whether they have been burnt
      *      and checks whether the owner of the subdomain is 0x0 for creating or already exists for
      *      replacing a subdomain. If either conditions are true, then it is possible to call
      *      setSubnodeOwner


### PR DESCRIPTION
## Summary
- Fixed typo in NatSpec comment in `contracts/wrapper/NameWrapper.sol`: "whether not" -> "whether"

## Test plan
- No functional changes, documentation fix only