### PR TITLE
Stale

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -30,3 +30,4 @@ jobs:
           only-pr: true
           days-before-issue-stale: -1
           days-before-issue-close: -1
+          operations-per-run: 200

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,7 +1,6 @@
 name: Close stale PRs
 
 on:
-  push: # TEMPORARY: remove after testing
   schedule:
     - cron: '0 0 * * *' # daily at midnight UTC
   workflow_dispatch: # allow manual trigger

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,6 +1,7 @@
 name: Close stale PRs
 
 on:
+  push: # TEMPORARY: remove after testing
   schedule:
     - cron: '0 0 * * *' # daily at midnight UTC
   workflow_dispatch: # allow manual trigger

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,31 @@
+name: Close stale PRs
+
+on:
+  schedule:
+    - cron: '0 0 * * *' # daily at midnight UTC
+  workflow_dispatch: # allow manual trigger
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-stale: 365
+          days-before-close: 30
+          stale-pr-message: >
+            This pull request has been automatically marked as stale because it
+            has not had recent activity. It will be closed in 30 days if no
+            further activity occurs. Thank you for your contributions.
+          close-pr-message: >
+            This pull request was closed because it has been stale for 30 days
+            with no activity.
+          stale-pr-label: 'stale'
+          exempt-pr-labels: 'pinned,keep-open'
+          only-pr: true
+          days-before-issue-stale: -1
+          days-before-issue-close: -1


### PR DESCRIPTION
This job will mark any PRs older than 1 year as "stale" and then remove after 30 days if no update