### PR TITLE
Fix typos in comments and docs (combined)

### DIFF
--- a/contracts/resolvers/Multicallable.sol
+++ b/contracts/resolvers/Multicallable.sol
@@ -28,7 +28,7 @@ abstract contract Multicallable is IMulticallable, ERC165 {
     }
 
     // This function provides an extra security check when called
-    // from priviledged contracts (such as EthRegistrarController)
+    // from privileged contracts (such as EthRegistrarController)
     // that can set records on behalf of the node owners
     function multicallWithNodeCheck(
         bytes32 nodehash,

--- a/contracts/wrapper/ERC1155Fuse.sol
+++ b/contracts/wrapper/ERC1155Fuse.sol
@@ -7,7 +7,7 @@ import "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
 import "@openzeppelin/contracts/token/ERC1155/extensions/IERC1155MetadataURI.sol";
 import "@openzeppelin/contracts/utils/Address.sol";
 
-/* This contract is a variation on ERC1155 with the additions of _setData, getData and _beforeTransfer and ownerOf. _setData and getData allows the use of the other 96 bits next to the address of the owner for extra data. We use this to store 'fuses' that control permissions that can be burnt. 32 bits are used for the fuses themselves and 64 bits are used for the expiry of the name. When a name has expired, its fuses will be be set back to 0 */
+/* This contract is a variation on ERC1155 with the additions of _setData, getData and _beforeTransfer and ownerOf. _setData and getData allows the use of the other 96 bits next to the address of the owner for extra data. We use this to store 'fuses' that control permissions that can be burnt. 32 bits are used for the fuses themselves and 64 bits are used for the expiry of the name. When a name has expired, its fuses will be set back to 0 */
 
 abstract contract ERC1155Fuse is ERC165, IERC1155, IERC1155MetadataURI {
     using Address for address;

--- a/contracts/wrapper/NameWrapper.sol
+++ b/contracts/wrapper/NameWrapper.sol
@@ -692,7 +692,7 @@ contract NameWrapper is
     }
 
     /// @notice Check whether a name can call setSubnodeOwner/setSubnodeRecord
-    /// @dev Checks both CANNOT_CREATE_SUBDOMAIN and PARENT_CANNOT_CONTROL and whether not they have been burnt
+    /// @dev Checks both CANNOT_CREATE_SUBDOMAIN and PARENT_CANNOT_CONTROL and whether they have been burnt
     ///      and checks whether the owner of the subdomain is 0x0 for creating or already exists for
     ///      replacing a subdomain. If either conditions are true, then it is possible to call
     ///      setSubnodeOwner

--- a/contracts/wrapper/README.md
+++ b/contracts/wrapper/README.md
@@ -329,7 +329,7 @@ The expiry can only be extended, not reduced. And the max expiry is automaticall
 **Start State**: Wrapped
 **End State**: Emancipated | Locked
 
-`setChildFuses()` can only be called the parent owner of a name. It can burn both user-controlled and parent-controlled fuses.
+`setChildFuses()` can only be called by the parent owner of a name. It can burn both user-controlled and parent-controlled fuses.
 
 If the name is Emancipated or Locked, this function may be called to extend the expiry, but cannot burn any further fuses.
 


### PR DESCRIPTION
- Fix 'priviledged' -> 'privileged' in Multicallable.sol
- Fix missing 'by' in wrapper README.md
- Fix 'will be be' -> 'will be' in ERC1155Fuse.sol
- Fix 'whether not' -> 'whether' in NameWrapper.sol