### PR TITLE
Add `BasicExtendedDNSResolver`

### DIFF
--- a/contracts/resolvers/profiles/BasicExtendedDNSResolver.sol
+++ b/contracts/resolvers/profiles/BasicExtendedDNSResolver.sol
@@ -11,19 +11,20 @@ import {HexUtils} from "../../utils/HexUtils.sol";
 import {COIN_TYPE_ETH} from "../../utils/ENSIP19.sol";
 
 /// @notice An IExtendedDNSResolver that parses a single address from DNS TXT records and implements IAddrResolver.
-/// 
+///
 /// DNS TXT record format: `ENS1 dnsname.ens.eth <address>`
 /// (where "dnsname.ens.eth" resolves to this contract.)
 ///
 /// Supported record formats:
-/// * `addr(bytes32)`
-/// * `addr(bytes32, coinType)` where `coinType = 60`
+/// * `addr(bytes32 node)`
+/// * `addr(bytes32 node, uint256 coinType)`
+/// 
+/// `name` and `node` are ignored.
 ///
 contract BasicExtendedDNSResolver is ERC165, IExtendedDNSResolver {
-
     /// @dev Error selector: `0x7b1c461b`
     error UnsupportedResolverProfile(bytes4 selector);
-    
+
     /// @dev Error selector: `0xc9e47ee5`
     error InvalidAddressFormat();
 
@@ -31,7 +32,9 @@ contract BasicExtendedDNSResolver is ERC165, IExtendedDNSResolver {
     function supportsInterface(
         bytes4 interfaceId
     ) public view virtual override returns (bool) {
-        return interfaceId == type(IExtendedDNSResolver).interfaceId || super.supportsInterface(interfaceId);
+        return
+            interfaceId == type(IExtendedDNSResolver).interfaceId ||
+            super.supportsInterface(interfaceId);
     }
 
     /// @inheritdoc IExtendedDNSResolver

--- a/contracts/resolvers/profiles/BasicExtendedDNSResolver.sol
+++ b/contracts/resolvers/profiles/BasicExtendedDNSResolver.sol
@@ -31,7 +31,7 @@ contract BasicExtendedDNSResolver is ERC165, IExtendedDNSResolver {
     function supportsInterface(
         bytes4 interfaceId
     ) public view virtual override returns (bool) {
-        return interfaceId == type(IExtendedDNSResolver).interfaceId;
+        return interfaceId == type(IExtendedDNSResolver).interfaceId || super.supportsInterface(interfaceId);
     }
 
     /// @inheritdoc IExtendedDNSResolver

--- a/contracts/resolvers/profiles/BasicExtendedDNSResolver.sol
+++ b/contracts/resolvers/profiles/BasicExtendedDNSResolver.sol
@@ -15,10 +15,10 @@ import {COIN_TYPE_ETH} from "../../utils/ENSIP19.sol";
 /// DNS TXT record format: `ENS1 dnsname.ens.eth <address>`
 /// (where "dnsname.ens.eth" resolves to this contract.)
 ///
-/// Supported record formats:
-/// * `addr(bytes32 node)`
-/// * `addr(bytes32 node, uint256 coinType)`
-/// 
+/// Supported resolver profiles:
+/// * `IAddrResolver`
+/// * `IAddressResolver` but returns null for every coin type except 60.
+///
 /// `name` and `node` are ignored.
 ///
 contract BasicExtendedDNSResolver is ERC165, IExtendedDNSResolver {

--- a/contracts/resolvers/profiles/BasicExtendedDNSResolver.sol
+++ b/contracts/resolvers/profiles/BasicExtendedDNSResolver.sol
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.4;
+
+import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
+import {
+    IExtendedDNSResolver
+} from "../../resolvers/profiles/IExtendedDNSResolver.sol";
+import {IAddressResolver} from "../../resolvers/profiles/IAddressResolver.sol";
+import {IAddrResolver} from "../../resolvers/profiles/IAddrResolver.sol";
+import {HexUtils} from "../../utils/HexUtils.sol";
+import {COIN_TYPE_ETH} from "../../utils/ENSIP19.sol";
+
+/// @notice An IExtendedDNSResolver that parses a single address from DNS TXT records and implements IAddrResolver.
+/// 
+/// DNS TXT record format: `ENS1 dnsname.ens.eth <address>`
+/// (where "dnsname.ens.eth" resolves to this contract.)
+///
+/// Supported record formats:
+/// * `addr(bytes32)`
+/// * `addr(bytes32, coinType)` where `coinType = 60`
+///
+contract BasicExtendedDNSResolver is ERC165, IExtendedDNSResolver {
+
+    /// @dev Error selector: `0x7b1c461b`
+    error UnsupportedResolverProfile(bytes4 selector);
+    
+    /// @dev Error selector: `0xc9e47ee5`
+    error InvalidAddressFormat();
+
+    /// @inheritdoc ERC165
+    function supportsInterface(
+        bytes4 interfaceId
+    ) public view virtual override returns (bool) {
+        return interfaceId == type(IExtendedDNSResolver).interfaceId;
+    }
+
+    /// @inheritdoc IExtendedDNSResolver
+    function resolve(
+        bytes calldata /* name */,
+        bytes calldata data,
+        bytes calldata context
+    ) external pure override returns (bytes memory) {
+        bytes4 selector = bytes4(data);
+        if (selector == IAddrResolver.addr.selector) {
+            return abi.encode(_parseAddressFromContext(context));
+        } else if (selector == IAddressResolver.addr.selector) {
+            (, uint256 coinType) = abi.decode(data[4:], (bytes32, uint256));
+            return
+                abi.encode(
+                    coinType == COIN_TYPE_ETH
+                        ? abi.encodePacked(_parseAddressFromContext(context))
+                        : bytes("")
+                );
+        } else {
+            revert UnsupportedResolverProfile(selector);
+        }
+    }
+
+    /// @dev Parse `"0x{address}"` into `address`.
+    function _parseAddressFromContext(
+        bytes calldata context
+    ) internal pure returns (address) {
+        if (bytes2(context) == "0x") {
+            (address addr, bool ok) = HexUtils.hexToAddress(
+                context,
+                2,
+                context.length
+            );
+            if (ok) return addr;
+        }
+        revert InvalidAddressFormat();
+    }
+}

--- a/test/resolvers/TestBasicExtendedDNSResolver.test.ts
+++ b/test/resolvers/TestBasicExtendedDNSResolver.test.ts
@@ -6,27 +6,29 @@ import {
   parseAbi,
   stringToHex,
 } from 'viem'
+import { shouldSupportInterfaces } from '@ensdomains/hardhat-chai-matchers-viem/behaviour'
 
 import { dnsEncodeName } from '../fixtures/dnsEncodeName.js'
 import { COIN_TYPE_ETH } from '../fixtures/ensip19.js'
 
-const testAddress = '0x8000000000000000000000000000000000000001' as const
+const testAddress = '0x8000000000000000000000000000000000000001'
 const testName = dnsEncodeName('ignored1')
 const testNode = namehash('ignored2')
 
 const connection = await hre.network.connect()
 
-async function fixture() {
-  const resolver = await connection.viem.deployContract(
-    'BasicExtendedDNSResolver',
-    [],
-  )
-  return resolver
+function fixture() {
+  return connection.viem.deployContract('BasicExtendedDNSResolver', [])
 }
 const loadFixture = async () => connection.networkHelpers.loadFixture(fixture)
 
 describe('BasicExtendedDNSResolver', () => {
-  it(`addr()`, async () => {
+  shouldSupportInterfaces({
+    contract: () => loadFixture(),
+    interfaces: ['IExtendedDNSResolver'],
+  })
+
+  it('addr()', async () => {
     const F = await loadFixture()
     const answer = await F.read.resolve([
       testName,
@@ -41,7 +43,7 @@ describe('BasicExtendedDNSResolver', () => {
     )
   })
 
-  it(`addr(60)`, async () => {
+  it('addr(60)', async () => {
     const F = await loadFixture()
     const answer = await F.read.resolve([
       testName,
@@ -56,7 +58,7 @@ describe('BasicExtendedDNSResolver', () => {
     )
   })
 
-  it(`addr(<not 60>)`, async () => {
+  it('addr(<not 60>)', async () => {
     const F = await loadFixture()
     const answer = await F.read.resolve([
       testName,
@@ -78,7 +80,7 @@ describe('BasicExtendedDNSResolver', () => {
     await expect(
       F.read.resolve([
         dnsEncodeName(name),
-        selector,
+        selector, // unknown profile
         stringToHex(`${testAddress}`),
       ]),
     )
@@ -95,7 +97,7 @@ describe('BasicExtendedDNSResolver', () => {
           abi: parseAbi(['function addr(bytes32) returns (address)']),
           args: [testNode],
         }),
-        stringToHex('0x1234'),
+        stringToHex('0x1234'), // not 42 bytes
       ]),
     ).toBeRevertedWithCustomError('InvalidAddressFormat')
   })

--- a/test/resolvers/TestBasicExtendedDNSResolver.test.ts
+++ b/test/resolvers/TestBasicExtendedDNSResolver.test.ts
@@ -1,0 +1,102 @@
+import hre from 'hardhat'
+import {
+  encodeAbiParameters,
+  encodeFunctionData,
+  namehash,
+  parseAbi,
+  stringToHex,
+} from 'viem'
+
+import { dnsEncodeName } from '../fixtures/dnsEncodeName.js'
+import { COIN_TYPE_ETH } from '../fixtures/ensip19.js'
+
+const testAddress = '0x8000000000000000000000000000000000000001' as const
+const testName = dnsEncodeName('ignored1')
+const testNode = namehash('ignored2')
+
+const connection = await hre.network.connect()
+
+async function fixture() {
+  const resolver = await connection.viem.deployContract(
+    'BasicExtendedDNSResolver',
+    [],
+  )
+  return resolver
+}
+const loadFixture = async () => connection.networkHelpers.loadFixture(fixture)
+
+describe('BasicExtendedDNSResolver', () => {
+  it(`addr()`, async () => {
+    const F = await loadFixture()
+    const answer = await F.read.resolve([
+      testName,
+      encodeFunctionData({
+        abi: parseAbi(['function addr(bytes32) returns (address)']),
+        args: [testNode],
+      }),
+      stringToHex(`${testAddress}`),
+    ])
+    expect(answer).toStrictEqual(
+      encodeAbiParameters([{ type: 'address' }], [testAddress]),
+    )
+  })
+
+  it(`addr(60)`, async () => {
+    const F = await loadFixture()
+    const answer = await F.read.resolve([
+      testName,
+      encodeFunctionData({
+        abi: parseAbi(['function addr(bytes32, uint256) returns (bytes)']),
+        args: [testNode, COIN_TYPE_ETH],
+      }),
+      stringToHex(`${testAddress}`),
+    ])
+    expect(answer).toStrictEqual(
+      encodeAbiParameters([{ type: 'bytes' }], [testAddress]),
+    )
+  })
+
+  it(`addr(<not 60>)`, async () => {
+    const F = await loadFixture()
+    const answer = await F.read.resolve([
+      testName,
+      encodeFunctionData({
+        abi: parseAbi(['function addr(bytes32, uint256) returns (bytes)']),
+        args: [testNode, 1n],
+      }),
+      stringToHex(`${testAddress}`),
+    ])
+    expect(answer).toStrictEqual(
+      encodeAbiParameters([{ type: 'bytes' }], ['0x']),
+    )
+  })
+
+  it('UnsupportedResolverProfile', async () => {
+    const F = await loadFixture()
+    const name = 'any.eth'
+    const selector = '0x12345678'
+    await expect(
+      F.read.resolve([
+        dnsEncodeName(name),
+        selector,
+        stringToHex(`${testAddress}`),
+      ]),
+    )
+      .toBeRevertedWithCustomError('UnsupportedResolverProfile')
+      .withArgs([selector])
+  })
+
+  it('InvalidAddressFormat', async () => {
+    const F = await loadFixture()
+    await expect(
+      F.read.resolve([
+        dnsEncodeName('ignored1'),
+        encodeFunctionData({
+          abi: parseAbi(['function addr(bytes32) returns (address)']),
+          args: [testNode],
+        }),
+        stringToHex('0x1234'),
+      ]),
+    ).toBeRevertedWithCustomError('InvalidAddressFormat')
+  })
+})


### PR DESCRIPTION
* current `dnsname.ens.eth` is [`0x238A8F792dFA6033814B18618aD4100654aeef01`](https://etherscan.io/address/0x238A8F792dFA6033814B18618aD4100654aeef01#code) and incorrectly handles `addr(coinType)`.
* current `ExtendedDNSResolver` uses the new record format: `a[60]=...`

---

- added [BasicExtendedDNSResolver.sol](https://github.com/ensdomains/ens-contracts/blob/feat/basic-extended-dns/contracts/resolvers/profiles/BasicExtendedDNSResolver.sol)
- added [TestBasicExtendedDNSResolver.test.ts](https://github.com/ensdomains/ens-contracts/blob/feat/basic-extended-dns/test/resolvers/TestBasicExtendedDNSResolver.test.ts)