### PR TITLE
Remove `ICompositeResolver.requiresOffchain()`

### DIFF
--- a/contracts/resolvers/profiles/ICompositeResolver.sol
+++ b/contracts/resolvers/profiles/ICompositeResolver.sol
@@ -4,7 +4,7 @@ pragma solidity >=0.8.4;
 import {IExtendedResolver} from "./IExtendedResolver.sol";
 
 /// @notice A resolver that calls other resolvers.
-/// @dev Interface selector: `0xc7e45d73`
+/// @dev Interface selector: `0xeea330f9`
 interface ICompositeResolver is IExtendedResolver {
     /// @notice Fetch the underlying resolver for `name`.
     ///         Callers should enable EIP-3668.
@@ -19,11 +19,4 @@ interface ICompositeResolver is IExtendedResolver {
     function getResolver(
         bytes memory name
     ) external view returns (address resolver, bool offchain);
-
-    /// @notice Determine if resolving `name` requires offchain data.
-    ///
-    /// @param name The DNS-encoded name.
-    ///
-    /// @return `true` if requires offchain data.
-    function requiresOffchain(bytes calldata name) external view returns (bool);
 }


### PR DESCRIPTION
This was designed for Namechain where heavy CCIP-Read was expected as part of resolver resolution.  With ENSv2, this is no longer the case.  Since this hasn't been standardized yet or used in the wild, I think it is safe to remove.

This function was a convenience around checking to see if the function would revert.  The client can always perform this behavior by disabling CCIP-Read handling, calling the function, and seeing if it reverts `OffchainLookup`.