### PR TITLE
Handle non-contract DNS resolver records

### DIFF
--- a/contracts/dnsregistrar/OffchainDNSResolver.sol
+++ b/contracts/dnsregistrar/OffchainDNSResolver.sol
@@ -109,8 +109,12 @@ contract OffchainDNSResolver is IExtendedResolver, IERC165 {
 
             // If we found a valid record, try to resolve it
             if (dnsresolver != address(0)) {
+                if (!dnsresolver.isContract()) {
+                    continue;
+                }
                 if (
-                    IERC165(dnsresolver).supportsInterface(
+                    supportsInterface(
+                        dnsresolver,
                         IExtendedDNSResolver.resolve.selector
                     )
                 ) {
@@ -125,7 +129,8 @@ contract OffchainDNSResolver is IExtendedResolver, IERC165 {
                             )
                         );
                 } else if (
-                    IERC165(dnsresolver).supportsInterface(
+                    supportsInterface(
+                        dnsresolver,
                         IExtendedResolver.resolve.selector
                     )
                 ) {
@@ -207,6 +212,16 @@ contract OffchainDNSResolver is IExtendedResolver, IERC165 {
             }
         }
         return resolveName(nameOrAddress, idx, lastIdx);
+    }
+
+    function supportsInterface(
+        address resolver,
+        bytes4 interfaceId
+    ) internal view returns (bool) {
+        (bool ok, bytes memory ret) = resolver.staticcall(
+            abi.encodeCall(IERC165.supportsInterface, (interfaceId))
+        );
+        return ok && ret.length >= 32 && abi.decode(ret, (bool));
     }
 
     function resolveName(

--- a/test/dnsregistrar/TestOffchainDNSResolver.test.ts
+++ b/test/dnsregistrar/TestOffchainDNSResolver.test.ts
@@ -314,6 +314,25 @@ describe('OffchainDNSResolver', () => {
     ).toBeRevertedWithCustomError('CouldNotResolve')
   })
 
+  it('rejects TXT records that point to non-contract resolver addresses', async () => {
+    const { doDnsResolveCallback, publicResolverAbi } = await loadFixture()
+
+    const name = 'test.test'
+    const calldata = encodeFunctionData({
+      abi: publicResolverAbi,
+      functionName: 'addr',
+      args: [namehash(name)],
+    })
+
+    await expect(
+      doDnsResolveCallback({
+        name,
+        texts: [`ENS1 ${accounts[1].address}`],
+        calldata,
+      }),
+    ).toBeRevertedWithCustomError('CouldNotResolve')
+  })
+
   it('handles calls to resolveCallback() where the valid TXT record is not the first', async () => {
     const { ownedResolver, doDnsResolveCallback, publicResolverAbi } =
       await loadFixture()
@@ -333,6 +352,32 @@ describe('OffchainDNSResolver', () => {
       doDnsResolveCallback({
         name,
         texts: ['foo', `ENS1 ${ownedResolver.address}`],
+        calldata,
+      }),
+    ).resolves.toEqual(
+      encodeAbiParameters([{ type: 'address' }], [testAddress]),
+    )
+  })
+
+  it('skips non-contract resolver addresses and uses the next valid TXT record', async () => {
+    const { ownedResolver, doDnsResolveCallback, publicResolverAbi } =
+      await loadFixture()
+
+    const name = 'test.test'
+    const testAddress = '0xfefeFEFeFEFEFEFEFeFefefefefeFEfEfefefEfe'
+
+    await ownedResolver.write.setAddr([namehash(name), testAddress])
+
+    const calldata = encodeFunctionData({
+      abi: publicResolverAbi,
+      functionName: 'addr',
+      args: [namehash(name)],
+    })
+
+    await expect(
+      doDnsResolveCallback({
+        name,
+        texts: [`ENS1 ${accounts[1].address}`, `ENS1 ${ownedResolver.address}`],
         calldata,
       }),
     ).resolves.toEqual(


### PR DESCRIPTION
## Summary
- skip ENS-DNS TXT resolver records that point at addresses without contract code
- query ERC-165 support with a non-reverting staticcall before falling back to legacy resolver calls
- add regression coverage for non-contract resolver records, including using the next valid TXT record

Closes #221.

## Tests
- `npx bun run compile`
- `npx bun x vitest run test/dnsregistrar/TestOffchainDNSResolver.test.ts`
- `npx bun x prettier --check contracts/dnsregistrar/OffchainDNSResolver.sol test/dnsregistrar/TestOffchainDNSResolver.test.ts`
- `git diff --check`

Note: `npx bun run lint` did not complete within 5 minutes in my local Windows environment; the targeted checks above pass.