### PR TITLE
Add OwnedResolver authorization tests

### DIFF
--- a/test/resolvers/TestOwnedResolver.test.ts
+++ b/test/resolvers/TestOwnedResolver.test.ts
@@ -1,0 +1,113 @@
+import hre from 'hardhat'
+import {
+  getAddress,
+  keccak256,
+  namehash,
+  stringToHex,
+  type Address,
+} from 'viem'
+
+import { getAccounts } from '../fixtures/utils.js'
+
+const targetNode = namehash('eth')
+const textKey = 'url'
+const textValue = 'https://ens.domains'
+
+const connection = await hre.network.connect()
+const accounts = await getAccounts(connection)
+
+async function fixture() {
+  const ownedResolver = await connection.viem.deployContract(
+    'OwnedResolver',
+    [],
+  )
+
+  return { ownedResolver, accounts }
+}
+
+const loadFixture = async () => connection.networkHelpers.loadFixture(fixture)
+
+describe('OwnedResolver', () => {
+  it('permits the owner to change records', async () => {
+    const { ownedResolver } = await loadFixture()
+
+    const setAddr = ownedResolver.write.setAddr([
+      targetNode,
+      accounts[1].address,
+    ])
+
+    await expect(setAddr).toEmitEvent('AddressChanged').withArgs({
+      node: targetNode,
+      coinType: 60n,
+      newAddress: accounts[1].address,
+    })
+
+    await expect(setAddr)
+      .toEmitEvent('AddrChanged')
+      .withArgs({
+        node: targetNode,
+        a: getAddress(accounts[1].address),
+      })
+
+    await expect(
+      ownedResolver.read.addr([targetNode]) as Promise<Address>,
+    ).resolves.toEqualAddress(accounts[1].address)
+
+    await expect(ownedResolver.write.setText([targetNode, textKey, textValue]))
+      .toEmitEvent('TextChanged')
+      .withArgs({
+        node: targetNode,
+        indexedKey: keccak256(stringToHex(textKey)),
+        key: textKey,
+        value: textValue,
+      })
+
+    await expect(
+      ownedResolver.read.text([targetNode, textKey]),
+    ).resolves.toEqual(textValue)
+  })
+
+  it('forbids non-owners from changing records', async () => {
+    const { ownedResolver } = await loadFixture()
+
+    await ownedResolver.write.setAddr([targetNode, accounts[1].address])
+    await ownedResolver.write.setText([targetNode, textKey, textValue])
+
+    await expect(
+      ownedResolver.write.setAddr([targetNode, accounts[2].address], {
+        account: accounts[2],
+      }),
+    ).toBeRevertedWithoutReason()
+
+    await expect(
+      ownedResolver.write.setText(
+        [targetNode, textKey, 'https://example.com'],
+        {
+          account: accounts[2],
+        },
+      ),
+    ).toBeRevertedWithoutReason()
+
+    await expect(
+      ownedResolver.read.addr([targetNode]) as Promise<Address>,
+    ).resolves.toEqualAddress(accounts[1].address)
+
+    await expect(
+      ownedResolver.read.text([targetNode, textKey]),
+    ).resolves.toEqual(textValue)
+  })
+
+  it('forbids non-owners from clearing records', async () => {
+    const { ownedResolver } = await loadFixture()
+
+    await ownedResolver.write.setAddr([targetNode, accounts[1].address])
+
+    await expect(
+      ownedResolver.write.clearRecords([targetNode], { account: accounts[2] }),
+    ).toBeRevertedWithoutReason()
+
+    await expect(
+      ownedResolver.read.addr([targetNode]) as Promise<Address>,
+    ).resolves.toEqualAddress(accounts[1].address)
+  })
+})


### PR DESCRIPTION
﻿## Summary
- add `OwnedResolver` tests covering owner-managed record updates
- assert non-owners cannot overwrite address/text records or clear records
- verify records remain unchanged after unauthorized attempts

Closes #243

## Tests
- `bun run compile`
- `bun x prettier --check test/resolvers/TestOwnedResolver.test.ts`
- `NODE_OPTIONS="--disable-warning=ExperimentalWarning" bun x vitest run test/resolvers/TestOwnedResolver.test.ts`

Note: `bun run lint` timed out locally after 5 minutes while running `hardhat check`; the targeted formatter, compile, and test checks above passed.
