### PR TITLE
Fix unchecked arithmetic overflow in BulkRenewal.rentPrice

### DIFF
--- a/contracts/ethregistrar/BulkRenewal.sol
+++ b/contracts/ethregistrar/BulkRenewal.sol
@@ -44,8 +44,8 @@ contract BulkRenewal is IBulkRenewal {
             );
             unchecked {
                 ++i;
-                total += (price.base + price.premium);
             }
+            total += (price.base + price.premium);
         }
     }
 

--- a/test/ethregistrar/TestBulkRenewal.test.ts
+++ b/test/ethregistrar/TestBulkRenewal.test.ts
@@ -100,7 +100,7 @@ async function fixture() {
     ])
   }
 
-  return { ensRegistry, baseRegistrar, bulkRenewal }
+  return { ensRegistry, baseRegistrar, bulkRenewal, dummyOracle }
 }
 const loadFixture = async () => connection.networkHelpers.loadFixture(fixture)
 
@@ -139,5 +139,25 @@ describe('BulkRenewal', () => {
     await expect(
       publicClient.getBalance({ address: bulkRenewal.address }),
     ).resolves.toEqual(0n)
+  })
+
+  it('should revert rather than silently wrap when the total overflows uint256', async () => {
+    const { bulkRenewal, dummyOracle } = await loadFixture()
+
+    // The price is sourced from the registrar's oracle, which is not fully
+    // under the contract's control. If it reports an inflated ETH price, a
+    // large duration makes each name's rent price exceed 2**255 wei, so the
+    // sum of just two names overflows uint256. rentPrice must revert with an
+    // arithmetic-overflow panic (0x11) instead of silently wrapping.
+    //
+    // With ethPrice = 1 wei and price5Letter = 1, StablePriceOracle returns
+    // base = price5Letter * duration * 1e8 / 1 = duration * 1e8 for a 5+
+    // char name. duration just above 2**255 / 1e8 yields base > 2**255.
+    await dummyOracle.write.set([1n])
+
+    const duration = (2n ** 255n) / 100000000n + 1n
+    await expect(
+      bulkRenewal.read.rentPrice([['test1', 'test2'], duration]),
+    ).toBeRevertedWithPanic(0x11n)
   })
 })


### PR DESCRIPTION
Fixes #399

## Problem

`BulkRenewal.rentPrice` accumulates each name's price inside an `unchecked` block:

```solidity
unchecked {
    ++i;
    total += (price.base + price.premium);
}
```

The per-name price comes from the registrar's price oracle, which is not fully under the contract's control. If the oracle reports an inflated price (e.g. a manipulated `DummyOracle`/`StablePriceOracle` ETH price), the `unchecked` accumulation can overflow `uint256`. Because `rentPrice` is a `view` function, nothing on-chain catches the wrap - callers simply receive a silently wrong total.

## Fix

The `++i` counter cannot realistically overflow (it is bounded by `names.length`), so it stays in `unchecked`. The total accumulation moves out to checked arithmetic, so an overflow now reverts with an arithmetic-overflow panic (`0x11`) instead of wrapping:

```solidity
unchecked {
    ++i;
}
total += (price.base + price.premium);
```

The gas cost of these two additions is negligible for a view function, and the extra safety is cheap.

## Verification

Added a regression test in `test/ethregistrar/TestBulkRenewal.test.ts` that inflates the oracle-reported ETH price (`DummyOracle.set(1)`) and passes a duration just above `2**255 / 1e8`, so each 5+ char name prices above `2**255` wei and the sum of two names overflows `uint256`. The test asserts `rentPrice` reverts with panic `0x11`.

- Before the fix: the test fails - the call silently wraps and returns a value.
- After the fix: the test passes - the call reverts with panic `0x11`.

Full suite (`bun run test`) continues to pass. Note: `contracts/ethregistrar/StaticBulkRenewal.sol` carries the same unchecked accumulation in its `rentPrice`; happy to extend the same fix there if desired, but I kept this PR scoped to the contract named in the issue.